### PR TITLE
Update climate.py

### DIFF
--- a/custom_components/versatile_thermostat/climate.py
+++ b/custom_components/versatile_thermostat/climate.py
@@ -966,7 +966,7 @@ class VersatileThermostat(ClimateEntity, RestoreEntity):
             # else OFF
             one_idle = False
             for under in self._underlyings:
-                if action := under.hvac_action not in [HVACAction.IDLE, HVACAction.OFF]:
+                if (action := under.hvac_action) not in [HVACAction.IDLE, HVACAction.OFF]:
                     return action
                 if under.hvac_action == HVACAction.IDLE:
                     one_idle = True


### PR DESCRIPTION
without these parenthesis the `action` and therefore returned `hvac_action` seems to be `True` instead of i.e. `heating` (did not see that when using an underlying homekit devices climate device, but when the underlying was a generic thermostat)