### PR TITLE
switch from HEAT to COOL mode

### DIFF
--- a/custom_components/versatile_thermostat/base_thermostat.py
+++ b/custom_components/versatile_thermostat/base_thermostat.py
@@ -338,7 +338,7 @@ class BaseThermostat(ClimateEntity, RestoreEntity):
         self._presence_on = self._presence_sensor_entity_id is not None
 
         if self._ac_mode:
-            self._hvac_list = [HVACMode.COOL, HVACMode.OFF]
+            self._hvac_list = [HVACMode.HEAT, HVACMode.COOL, HVACMode.OFF]
         else:
             self._hvac_list = [HVACMode.HEAT, HVACMode.OFF]
 

--- a/tests/test_switch_ac.py
+++ b/tests/test_switch_ac.py
@@ -56,7 +56,7 @@ async def test_over_switch_ac_full_start(hass: HomeAssistant, skip_hass_states_i
         assert entity.ac_mode is True
         assert entity.hvac_action is HVACAction.OFF
         assert entity.hvac_mode is HVACMode.OFF
-        assert entity.hvac_modes == [HVACMode.COOL, HVACMode.OFF]
+        assert entity.hvac_modes == [HVACMode.HEAT, HVACMode.COOL, HVACMode.OFF]
         assert entity.target_temperature == entity.max_temp
         assert entity.preset_modes == [
             PRESET_NONE,
@@ -138,3 +138,15 @@ async def test_over_switch_ac_full_start(hass: HomeAssistant, skip_hass_states_i
             assert entity.hvac_mode is HVACMode.COOL
             assert (entity.hvac_action is HVACAction.OFF or entity.hvac_action is HVACAction.IDLE)
             assert entity.target_temperature == 27 # eco_ac_away
+
+        await entity.async_set_hvac_mode(HVACMode.HEAT)
+        assert entity.hvac_mode is HVACMode.HEAT
+
+        await entity.async_set_preset_mode(PRESET_COMFORT)
+        assert entity.preset_mode is PRESET_COMFORT
+        assert entity.target_temperature == 26
+
+        # switch to Eco
+        await entity.async_set_preset_mode(PRESET_ECO)
+        assert entity.preset_mode is PRESET_ECO
+        assert entity.target_temperature == 27


### PR DESCRIPTION
Hello Collin, 

I need the capability to switch from HEAT to COOL mode, does it make sense for you?

I have an aermec unit which can generate both cooling and heating, it is managed by ZBMINI-L2 ZigBee, if the thermostat is configured in AC mode I would like support both.

unit test updated as well! 