### PR TITLE
fix #185 switching from HEAT to COOL or viceversa

### DIFF
--- a/custom_components/versatile_thermostat/base_thermostat.py
+++ b/custom_components/versatile_thermostat/base_thermostat.py
@@ -1170,10 +1170,10 @@ class BaseThermostat(ClimateEntity, RestoreEntity):
             return self._power_temp
         else:
             # Select _ac presets if in COOL Mode (or over_switch with _ac_mode)
-            if self._ac_mode and (
-                self._hvac_mode == HVACMode.COOL or not self.is_over_climate
-            ):
+            if self._ac_mode and self._hvac_mode == HVACMode.COOL:
                 preset_mode = preset_mode + PRESET_AC_SUFFIX
+
+            _LOGGER.info("%s - find preset temp: %s", self, preset_mode)
 
             if self._presence_on is False or self._presence_state in [
                 STATE_ON,

--- a/tests/test_switch_ac.py
+++ b/tests/test_switch_ac.py
@@ -123,7 +123,7 @@ async def test_over_switch_ac_full_start(hass: HomeAssistant, skip_hass_states_i
 
             assert entity.hvac_mode is HVACMode.OFF
             assert entity.hvac_action is HVACAction.OFF
-            assert entity.target_temperature == 27 # eco_ac_away
+            assert entity.target_temperature == 16 # eco_ac_away
 
         # Close a window
         with patch(
@@ -142,11 +142,18 @@ async def test_over_switch_ac_full_start(hass: HomeAssistant, skip_hass_states_i
         await entity.async_set_hvac_mode(HVACMode.HEAT)
         assert entity.hvac_mode is HVACMode.HEAT
 
+        # switch to comfort
         await entity.async_set_preset_mode(PRESET_COMFORT)
         assert entity.preset_mode is PRESET_COMFORT
-        assert entity.target_temperature == 26
+        assert entity.target_temperature == 17
 
         # switch to Eco
         await entity.async_set_preset_mode(PRESET_ECO)
         assert entity.preset_mode is PRESET_ECO
-        assert entity.target_temperature == 27
+        assert entity.target_temperature == 16
+
+        # switch to boost
+        await entity.async_set_preset_mode(PRESET_BOOST)
+        assert entity.preset_mode is PRESET_BOOST
+        assert entity.target_temperature == 18
+


### PR DESCRIPTION
on my end I have those 2 condition always true 

self._ac_mode ==> true
not self.is_over_climate ==> true

so the find_preset_temp was always selecting the eco_ac on cool and heat mode