### PR TITLE
Change log level of “Window auto event is ignored” log message

### DIFF
--- a/custom_components/versatile_thermostat/base_thermostat.py
+++ b/custom_components/versatile_thermostat/base_thermostat.py
@@ -1859,7 +1859,7 @@ class BaseThermostat(ClimateEntity, RestoreEntity):
         )
 
         if self.window_bypass_state or not self.is_window_auto_enabled:
-            _LOGGER.info(
+            _LOGGER.debug(
                 "%s - Window auto event is ignored because bypass is ON or window auto detection is disabled",
                 self,
             )


### PR DESCRIPTION
Since updating to a recent version of Versatile Thermostat (I think v5.2.1 or later), my Home Assistant logs are flooded with the following info log messages (printed every 30 seconds), _even when the “Use window detection” checkbox is **unticked** in the configuration:_

```
2024-01-19 14:41:36.655 INFO (MainThread) [custom_components.versatile_thermostat.base_thermostat] ... - Window auto event is ignored because bypass is ON or window auto detection is disabled
2024-01-19 14:42:06.693 INFO (MainThread) [custom_components.versatile_thermostat.base_thermostat] ... - Window auto event is ignored because bypass is ON or window auto detection is disabled
2024-01-19 14:42:36.613 INFO (MainThread) [custom_components.versatile_thermostat.base_thermostat] ... - Window auto event is ignored because bypass is ON or window auto detection is disabled
2024-01-19 14:43:06.631 INFO (MainThread) [custom_components.versatile_thermostat.base_thermostat] ... - Window auto event is ignored because bypass is ON or window auto detection is disabled
...
```

I reckon that this log message is not needed when the window detection feature is not enabled by the user (my case). Interestingly, I also observed that if the “Use window detection” checkbox was ***ticked,*** the message above was not printed (or at least it was not printed every 30 seconds).

This PR proposes a fix to this issue.