### PR TITLE
Only modify _last_regulation_change if new regulation is sent to thermostats

### DIFF
--- a/custom_components/versatile_thermostat/thermostat_climate.py
+++ b/custom_components/versatile_thermostat/thermostat_climate.py
@@ -162,7 +162,6 @@ class ThermostatOverClimate(BaseThermostat):
             self._regulated_target_temp = self.target_temperature
 
         _LOGGER.info("%s - regulation calculation will be done", self)
-        self._last_regulation_change = now
 
         new_regulated_temp = round_to_nearest(
             self._regulation_algo.calculate_regulated_temperature(
@@ -188,6 +187,7 @@ class ThermostatOverClimate(BaseThermostat):
             new_regulated_temp,
         )
 
+        self._last_regulation_change = now
         for under in self._underlyings:
             await under.set_temperature(
                 self.regulated_target_temp, self._attr_max_temp, self._attr_min_temp


### PR DESCRIPTION
This MR fixes and issue where `_last_regulation_change` is set to `now` even though the new temperature setting is never sent to the thermostats, because `abs(dtemp) < self._auto_regulation_dtemp`