### PR TITLE
Add more type hints in the thermostat classes and selected files

### DIFF
--- a/custom_components/versatile_thermostat/select.py
+++ b/custom_components/versatile_thermostat/select.py
@@ -14,8 +14,10 @@ from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.entity_component import EntityComponent
 
-
-from custom_components.versatile_thermostat.base_thermostat import BaseThermostat
+from custom_components.versatile_thermostat.base_thermostat import (
+    BaseThermostat,
+    ConfigData,
+)
 from .const import (
     DOMAIN,
     DEVICE_MANUFACTURER,
@@ -57,7 +59,9 @@ async def async_setup_entry(
 class CentralModeSelect(SelectEntity, RestoreEntity):
     """Representation of the central mode choice"""
 
-    def __init__(self, hass: HomeAssistant, unique_id, name, entry_infos) -> None:
+    def __init__(
+        self, hass: HomeAssistant, unique_id: str, name: str, entry_infos: ConfigData
+    ):
         """Initialize the energy sensor"""
         self._config_id = unique_id
         self._device_name = entry_infos.get(CONF_NAME)
@@ -67,7 +71,7 @@ class CentralModeSelect(SelectEntity, RestoreEntity):
         self._attr_current_option = CENTRAL_MODE_AUTO
 
     @property
-    def icon(self) -> str | None:
+    def icon(self) -> str:
         return "mdi:form-select"
 
     @property
@@ -116,7 +120,7 @@ class CentralModeSelect(SelectEntity, RestoreEntity):
             self._attr_current_option = option
             await self.notify_central_mode_change(old_central_mode=old_option)
 
-    async def notify_central_mode_change(self, old_central_mode=None):
+    async def notify_central_mode_change(self, old_central_mode: str | None = None):
         """Notify all VTherm that the central_mode have change"""
         # Update all VTherm states
         component: EntityComponent[ClimateEntity] = self.hass.data[CLIMATE_DOMAIN]
@@ -130,5 +134,5 @@ class CentralModeSelect(SelectEntity, RestoreEntity):
                     self._attr_current_option, old_central_mode
                 )
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"VersatileThermostat-{self.name}"

--- a/custom_components/versatile_thermostat/thermostat_switch.py
+++ b/custom_components/versatile_thermostat/thermostat_switch.py
@@ -3,7 +3,11 @@
 """ A climate over switch classe """
 import logging
 from homeassistant.core import callback
-from homeassistant.helpers.event import async_track_state_change_event
+from homeassistant.helpers.event import (
+    async_track_state_change_event,
+    EventStateChangedData,
+)
+from homeassistant.helpers.typing import EventType as HASSEventType
 from homeassistant.components.climate import HVACMode
 
 from .const import (
@@ -15,7 +19,7 @@ from .const import (
     overrides,
 )
 
-from .base_thermostat import BaseThermostat
+from .base_thermostat import BaseThermostat, ConfigData
 from .underlyings import UnderlyingSwitch
 from .prop_algorithm import PropAlgorithm
 
@@ -51,7 +55,7 @@ class ThermostatOverSwitch(BaseThermostat):
     # def __init__(self, hass: HomeAssistant, unique_id, name, config_entry) -> None:
     #    """Initialize the thermostat over switch."""
     #    super().__init__(hass, unique_id, name, config_entry)
-    _is_inversed: bool = None
+    _is_inversed: bool | None = None
 
     @property
     def is_over_switch(self) -> bool:
@@ -72,7 +76,7 @@ class ThermostatOverSwitch(BaseThermostat):
             return None
 
     @overrides
-    def post_init(self, config_entry):
+    def post_init(self, config_entry: ConfigData):
         """Initialize the Thermostat"""
 
         super().post_init(config_entry)
@@ -200,7 +204,7 @@ class ThermostatOverSwitch(BaseThermostat):
         )
 
     @callback
-    def _async_switch_changed(self, event):
+    def _async_switch_changed(self, event: HASSEventType[EventStateChangedData]):
         """Handle heater switch state changes."""
         new_state = event.data.get("new_state")
         old_state = event.data.get("old_state")

--- a/custom_components/versatile_thermostat/thermostat_valve.py
+++ b/custom_components/versatile_thermostat/thermostat_valve.py
@@ -6,11 +6,13 @@ from datetime import timedelta, datetime
 from homeassistant.helpers.event import (
     async_track_state_change_event,
     async_track_time_interval,
+    EventStateChangedData,
 )
+from homeassistant.helpers.typing import EventType as HASSEventType
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.components.climate import HVACMode
 
-from .base_thermostat import BaseThermostat
+from .base_thermostat import BaseThermostat, ConfigData
 from .prop_algorithm import PropAlgorithm
 
 from .const import (
@@ -55,12 +57,14 @@ class ThermostatOverValve(BaseThermostat):
         )
     )
 
-    def __init__(self, hass: HomeAssistant, unique_id, name, config_entry) -> None:
+    def __init__(
+        self, hass: HomeAssistant, unique_id: str, name: str, config_entry: ConfigData
+    ):
         """Initialize the thermostat over switch."""
         self._valve_open_percent: int = 0
-        self._last_calculation_timestamp: datetime = None
-        self._auto_regulation_dpercent: float = None
-        self._auto_regulation_period_min: int = None
+        self._last_calculation_timestamp: datetime | None = None
+        self._auto_regulation_dpercent: float | None = None
+        self._auto_regulation_period_min: int | None = None
 
         # Call to super must be done after initialization because it calls post_init at the end
         super().__init__(hass, unique_id, name, config_entry)
@@ -79,7 +83,7 @@ class ThermostatOverValve(BaseThermostat):
             return self._valve_open_percent
 
     @overrides
-    def post_init(self, config_entry):
+    def post_init(self, config_entry: ConfigData):
         """Initialize the Thermostat"""
 
         super().post_init(config_entry)
@@ -144,7 +148,7 @@ class ThermostatOverValve(BaseThermostat):
         )
 
     @callback
-    async def _async_valve_changed(self, event):
+    async def _async_valve_changed(self, event: HASSEventType[EventStateChangedData]):
         """Handle unerdlying valve state changes.
         This method just log the change. It changes nothing to avoid loops.
         """


### PR DESCRIPTION
This PR adds more type hints to selected files, mainly the thermostats classes. It started with wanting to know the type of the `config_entry` and `entry_infos` variables in the code, as I wondered if it was an object that had the same `get(key[, default])` method signature as the standard `dict` class. I found that yes, it does. Then I thought, _“Why don’t I add the type hint then?”_ From there it snowballed a bit and became this PR, but I think I am stopping here (I am not planning further PRs related to typing).

I don’t see type hints as just “hints for the developer that are ignored by the Python interpreter”, I see them as enabling the use of type checking tools such as `pyright` that help to avoid and catch bugs. Running `pyright` in the dev container (installed with `pip install pyright`) reported an _increase_ from 379 to 412 errors before and after this PR respectively. The increased number errors is a good thing in the sense that the additional errors were simply being masked by the lack of type information. Pyright does not report an error if anything is assigned to a variable of type `Unknown` or `Any`, whereas it is an error to assign, say, a `str` value to a variable of type `float | None` for example.

Just glancing over the errors reported by pyright, I found at least one that points to code that cannot be right:

```
thermostat_climate.py:785:26 - error: Cannot access member "hvac_modes" for type "type[super]”
```

It is a line that reads `super.hvac_modes` instead of `super().hvac_modes`.

However, to confirm, this PR does **not** make any changes to functionality, nor fixes any issues. It just adds type hints. All tests pass with `pytest` and the code was formatted with `black` in the dev container.
