### PR TITLE
README*.md: Replace absolute image URLs with relative URLs

### DIFF
--- a/README-fr.md
+++ b/README-fr.md
@@ -4,9 +4,9 @@
 [![hacs][hacs_badge]][hacs]
 [![BuyMeCoffee][buymecoffeebadge]][buymecoffee]
 
-![Tip](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/icon.png?raw=true)
+![Tip](images/icon.png)
 
-> ![Tip](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/tips.png?raw=true) Cette intégration de thermostat vise à simplifier considérablement vos automatisations autour de la gestion du chauffage. Parce que tous les événements autour du chauffage classiques sont gérés nativement par le thermostat (personne à la maison ?, activité détectée dans une pièce ?, fenêtre ouverte ?, délestage de courant ?), vous n'avez pas à vous encombrer de scripts et d'automatismes compliqués pour gérer vos climats. ;-).
+> ![Tip](images/tips.png) Cette intégration de thermostat vise à simplifier considérablement vos automatisations autour de la gestion du chauffage. Parce que tous les événements autour du chauffage classiques sont gérés nativement par le thermostat (personne à la maison ?, activité détectée dans une pièce ?, fenêtre ouverte ?, délestage de courant ?), vous n'avez pas à vous encombrer de scripts et d'automatismes compliqués pour gérer vos climats. ;-).
 
 - [Changements majeurs dans la version 5.0](#changements-majeurs-dans-la-version-50)
 - [Merci pour la bière buymecoffee](#merci-pour-la-bière-buymecoffee)
@@ -83,7 +83,7 @@
 Ce composant personnalisé pour Home Assistant est une mise à niveau et est une réécriture complète du composant "Awesome thermostat" (voir [Github](https://github.com/dadge/awesome_thermostat)) avec l'ajout de fonctionnalités.
 
 
-> ![Nouveau](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/new-icon.png?raw=true) _*Nouveautés*_
+> ![Nouveau](images/new-icon.png) _*Nouveautés*_
 > * **Release 5.4** : Ajout du pas de température [#311](https://github.com/jmcollin78/versatile_thermostat/issues/311). Ajout de seuils de régulation pour les `over_valve` pour éviter de trop vider la batterie des TRV [#338](https://github.com/jmcollin78/versatile_thermostat/issues/338)
 > * **Release 5.3** : Ajout d'une fonction de pilotage d'une chaudière centrale [#234](https://github.com/jmcollin78/versatile_thermostat/issues/234) - plus d'infos ici: [Le contrôle d'une chaudière centrale](#le-contrôle-dune-chaudière-centrale). Ajout de la possibilité de désactiver le mode sécurité pour le thermomètre extérieur [#343](https://github.com/jmcollin78/versatile_thermostat/issues/343)
 > * **Release 5.2** : Ajout d'un `central_mode` permettant de piloter tous les VTherms de façon centralisée [#158](https://github.com/jmcollin78/versatile_thermostat/issues/158).
@@ -111,7 +111,7 @@ Ce composant personnalisé pour Home Assistant est une mise à niveau et est une
 </details>
 
 # Changements majeurs dans la version 5.0
-![Nouveau](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/new-icon.png?raw=true)
+![Nouveau](images/new-icon.png)
 
 Vous pouvez maintenant définir une configuration centrale qui va vous permettre de mettre en commun sur tous vos VTherms (ou seulement une partie), certains attributs. Pour utiliser cette possibilité, vous devez :
 1. Créer un VTherm de type "Configuration Centrale",
@@ -194,7 +194,7 @@ Ce composant nommé __Versatile thermostat__ gère les cas d'utilisation suivant
 
 -- VTherm = Versatile Thermostat dans la suite de ce document --
 
-> ![Astuce](/images/tips.png?raw=true) _*Notes*_
+> ![Astuce](images/tips.png) _*Notes*_
 >
 > Trois façons de configurer les VTherms sont disponibles :
 > 1. Chaque Versatile Thermostat est entièrement configurée de manière indépendante. Choisissez cette option si vous ne souhaitez avoir aucune configuration ou gestion centrale.
@@ -205,7 +205,7 @@ Ce composant nommé __Versatile thermostat__ gère les cas d'utilisation suivant
 ## Création d'un nouveau Versatile Thermostat
 Cliquez sur le bouton Ajouter une intégration dans la page d'intégration
 
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/add-an-integration.png?raw=true)
+![image](images/add-an-integration.png)
 
 La configuration peut être modifiée via la même interface. Sélectionnez simplement le thermostat à modifier, appuyez sur "Configurer" et vous pourrez modifier certains paramètres ou la configuration.
 
@@ -213,9 +213,9 @@ Suivez ensuite les étapes de configuration comme suit :
 
 ## Choix des attributs de base
 
-![image](/images/config-main0.png?raw=true)
+![image](images/config-main0.png)
 
-![image](/images/config-main.png?raw=true)
+![image](images/config-main.png)
 
 Donnez les principaux attributs obligatoires :
 1. un nom (sera le nom de l'intégration et aussi le nom de l'entité climate)
@@ -228,14 +228,14 @@ Donnez les principaux attributs obligatoires :
 9. la possibilité de controler le thermostat de façon centralisée. Cf [controle centralisé](#le-contrôle-centralisé),
 10. la liste des fonctionnalités qui seront utilisées pour ce thermostat. En fonction de vos choix, les écrans de configuration suivants s'afficheront ou pas.
 
-> ![Astuce](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/tips.png?raw=true) _*Notes*_
+> ![Astuce](images/tips.png) _*Notes*_
 >  1. avec les types ```over_switch``` et ```over_valve```, les calculs sont effectués à chaque cycle. Donc en cas de changement de conditions, il faudra attendre le prochain cycle pour voir un changement. Pour cette raison, le cycle ne doit pas être trop long. **5 min est une bonne valeur**,
 >  2. si le cycle est trop court, le radiateur ne pourra jamais atteindre la température cible. Pour le radiateur à accumulation par exemple il sera sollicité inutilement.
 
 ## Sélectionnez des entités pilotées
 En fonction de votre choix sur le type de thermostat, vous devrez choisir une ou plusieurs entités de type `switch`, `climate` ou `number`. Seules les entités compatibles avec le type sont présentées.
 
-> ![Astuce](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/tips.png?raw=true) _*Comment choisir le type*_
+> ![Astuce](images/tips.png) _*Comment choisir le type*_
 > Le choix du type est important. Même si il toujours possible de le modifier ensuite via l'IHM de configuration, il est préférable de se poser les quelques questions suivantes :
 > 1. **quel type d'équipement je vais piloter ?** Dans l'ordre voici ce qu'il faut faire :
 >    1. si vous avez une vanne thermostatique (TRV) commandable dans Home Assistant via une entité de type ```number``` (par exemple une _Shelly TRV_), choisissez le type `over_valve`. C'est le type le plus direct et qui assure la meilleure régulation,
@@ -244,18 +244,18 @@ En fonction de votre choix sur le type de thermostat, vous devrez choisir une ou
 > 2. **quelle type de régulation je veux ?** Si l'équipement piloté possède son propre mécanisme de régulation (clim, certaine vanne TRV) et que cette régulation fonctionne bien, optez pour un ```over_climate```
 
 ### Pour un thermostat de type ```thermostat_over_switch```
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/config-linked-entity.png?raw=true)
+![image](images/config-linked-entity.png)
 L'algorithme à utiliser est aujourd'hui limité à TPI est disponible. Voir [algorithme](#algorithme).
 Si plusieurs entités de type sont configurées, la thermostat décale les activations afin de minimiser le nombre de switch actif à un instant t. Ca permet une meilleure répartition de la puissance puisque chaque radiateur va s'allumer à son tour.
 Exemple de déclenchement synchronisé :
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/multi-switch-activation.png?raw=true)
+![image](images/multi-switch-activation.png)
 
 Il est possible de choisir un thermostat over switch qui commande une climatisation en cochant la case "AC Mode". Dans ce cas, seul le mode refroidissement sera visible.
 
 Si votre équipement est commandé par un fil pilote avec un diode, vous aurez certainement besoin de cocher la case "Inverser la case". Elle permet de mettre le switch à On lorsqu'on doit étiendre l'équipement et à Off lorsqu'on doit l'allumer.
 
 ### Pour un thermostat de type ```thermostat_over_climate```:
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/config-linked-entity2.png?raw=true)
+![image](images/config-linked-entity2.png)
 
 Il est possible de choisir un thermostat over climate qui commande une climatisation réversible en cochant la case "AC Mode". Dans ce cas, selon l'équipement commandé vous aurez accès au chauffage et/ou au réfroidissement.
 
@@ -278,7 +278,7 @@ La fonction d'auto-régulation se paramètre avec :
 
 Ces trois paramètres permettent de moduler la régulation et éviter de multiplier les envois de régulation. Certains équipements comme les TRV, les chaudières n'aiment pas qu'on change la consigne de température trop souvent.
 
-> ![Astuce](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/tips.png?raw=true) _*Conseil de mise en place*_
+> ![Astuce](images/tips.png) _*Conseil de mise en place*_
 > 1. Ne démarrez pas tout de suite l'auto-régulation. Regardez comment se passe la régulation naturelle de votre équipement. Si vous constatez que la température de consigne n'est pas atteinte ou qu'elle met trop de temps à être atteinte, démarrez la régulation,
 > 2. D'abord commencez par une légère auto-régulation et gardez les deux paramètres avec leur valeurs par défaut. Attendez quelques jours et vérifiez si la situation s'est améliorée,
 > 3. Si ce n'est pas suffisant, passez en auto-régulation Medium, attendez une stabilisation,
@@ -375,7 +375,7 @@ Si votre équipement ne comprend pas le mode Turbo, le mode Forte` sera utilisé
 Une fois l'écart de température redevenu faible, la ventilation se mettra dans un mode "normal" qui dépend de votre équipement à savoir (dans l'ordre) : `Silence (mute)`, `Auto (auto)`, `Faible (low)`. La première valeur qui est possible pour votre équipement sera choisie.
 
 ### Pour un thermostat de type ```thermostat_over_valve```:
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/config-linked-entity3.png?raw=true)
+![image](images/config-linked-entity3.png)
 Vous pouvez choisir jusqu'à entité du domaine ```number``` ou ```ìnput_number``` qui vont commander les vannes.
 L'algorithme à utiliser est aujourd'hui limité à TPI est disponible. Voir [algorithme](#algorithme).
 
@@ -385,7 +385,7 @@ Il est possible de choisir un thermostat over valve qui commande une climatisati
 
 Si vous avez choisi un thermostat de type ```over_switch``` ou  ```over_valve``` vous arriverez sur cette page :
 
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/config-tpi.png?raw=true)
+![image](images/config-tpi.png)
 
 Vous devez donner :
 1. le coefficient coef_int de l'algorithme TPI,
@@ -397,7 +397,7 @@ Pour plus d'informations sur l'algorithme TPI et son réglage, veuillez vous ré
 ## Configurer la température préréglée
 Cliquez sur 'Valider' sur la page précédente et vous y arriverez :
 
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/config-presets.png?raw=true)
+![image](images/config-presets.png)
 
 Le mode préréglé (preset) vous permet de préconfigurer la température ciblée. Utilisé en conjonction avec Scheduler (voir [scheduler](#even-better-with-scheduler-component) vous aurez un moyen puissant et simple d'optimiser la température par rapport à la consommation électrique de votre maison. Les préréglages gérés sont les suivants :
  - **Eco** : l'appareil est en mode d'économie d'énergie
@@ -408,7 +408,7 @@ Le mode préréglé (preset) vous permet de préconfigurer la température cibl�
 
 **Aucun** est toujours ajouté dans la liste des modes, car c'est un moyen de ne pas utiliser les preset mais une **température manuelle** à la place.
 
-> ![Astuce](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/tips.png?raw=true) _*Notes*_
+> ![Astuce](images/tips.png) _*Notes*_
 >  1. En modifiant manuellement la température cible, réglez le préréglage sur Aucun (pas de préréglage). De cette façon, vous pouvez toujours définir une température cible même si aucun préréglage n'est disponible.
 >  2. Le préréglage standard ``Away`` est un préréglage caché qui n'est pas directement sélectionnable. Versatile Thermostat utilise la gestion de présence ou la gestion de mouvement pour régler automatiquement et dynamiquement la température cible en fonction d'une présence dans le logement ou d'une activité dans la pièce. Voir [gestion de la présence](#configure-the-presence-management).
 >  3. Si vous utilisez la gestion du délestage, vous verrez un préréglage caché nommé ``power``. Le préréglage de l'élément chauffant est réglé sur « puissance » lorsque des conditions de surpuissance sont rencontrées et que le délestage est actif pour cet élément chauffant. Voir [gestion de l'alimentation](#configure-the-power-management).
@@ -423,7 +423,7 @@ La détecttion des ouvertures peut se faire de 2 manières:
 
 ### Le mode capteur
 En mode capteur, vous devez renseigner les informations suivantes:
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/config-window-sensor.png?raw=true)
+![image](images/config-window-sensor.png)
 
 1. un identifiant d'entité d'un **capteur de fenêtre/porte**. Cela devrait être un binary_sensor ou un input_boolean. L'état de l'entité doit être 'on' lorsque la fenêtre est ouverte ou 'off' lorsqu'elle est fermée
 2. un **délai en secondes** avant tout changement. Cela permet d'ouvrir rapidement une fenêtre sans arrêter le chauffage.
@@ -431,7 +431,7 @@ En mode capteur, vous devez renseigner les informations suivantes:
 
 ### Le mode auto
 En mode auto, la configuration est la suivante:
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/config-window-auto.png?raw=true)
+![image](images/config-window-auto.png)
 
 1. un seuil de détection en degré par minute. Lorsque la température chute au delà de ce seuil, le thermostat s'éteindra. Plus cette valeur est faible et plus la détection sera rapide (en contre-partie d'un risque de faux positif),
 2. un seuil de fin de détection en degré par minute. Lorsque la chute de température repassera au-dessus cette valeur, le thermostat se remettra dans le mode précédent (mode et preset),
@@ -443,14 +443,14 @@ Pour régler les seuils il est conseillé de commencer avec les valeurs de réf�
 - durée max : 60 min.
 
 Un nouveau capteur "slope" a été ajouté pour tous les thermostats. Il donne la pente de la courbe de température en °C/min (ou °K/min). Cette pente est lissée et filtrée pour éviter les valeurs abérrantes des thermomètres qui viendraient pertuber la mesure.
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/temperature-slope.png?raw=true)
+![image](images/temperature-slope.png)
 
 Pour bien régler il est conseillé d'affocher sur un même graphique historique la courbe de température et la pente de la courbe (le "slope") :
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/window-auto-tuning.png?raw=true)
+![image](images/window-auto-tuning.png)
 
 Et c'est tout ! votre thermostat s'éteindra lorsque les fenêtres seront ouvertes et se rallumera lorsqu'il sera fermé.
 
-> ![Astuce](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/tips.png?raw=true) _*Notes*_
+> ![Astuce](images/tips.png) _*Notes*_
 >  1. Si vous souhaitez utiliser **plusieurs capteurs de porte/fenêtre** pour automatiser votre thermostat, créez simplement un groupe avec le comportement habituel (https://www.home-assistant.io/integrations/binary_sensor.group/)
 >  2. Si vous n'avez pas de capteur de fenêtre/porte dans votre chambre, laissez simplement l'identifiant de l'entité du capteur vide,
 >  3. **Un seul mode est permis**. On ne peut pas configurer un thermostat avec un capteur et une détection automatique. Les 2 modes risquant de se contredire, il n'est pas possible d'avoir les 2 modes en même temps,
@@ -459,7 +459,7 @@ Et c'est tout ! votre thermostat s'éteindra lorsque les fenêtres seront ouvert
 ## Configurer le mode d'activité ou la détection de mouvement
 Si vous avez choisi la fonctionnalité ```Avec détection de mouvement```, cliquez sur 'Valider' sur la page précédente et vous y arriverez :
 
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/config-motion.png?raw=true)
+![image](images/config-motion.png)
 
 Nous allons maintenant voir comment configurer le nouveau mode Activité.
 Ce dont nous avons besoin:
@@ -479,21 +479,21 @@ Alors imaginons que nous voulions avoir le comportement suivant :
 
 Pour que cela fonctionne, le thermostat doit être en mode préréglé « Activité ».
 
-> ![Astuce](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/tips.png?raw=true) _*Notes*_
+> ![Astuce](images/tips.png) _*Notes*_
     1. Sachez que comme pour les autres modes prédéfinis, ``Activity`` ne sera proposé que s'il est correctement configuré. En d'autres termes, les 4 clés de configuration doivent être définies si vous souhaitez voir l'activité dans l'interface de l'assistant domestique
 
 ## Configurer la gestion de la puissance
 
 Si vous avez choisi la fonctionnalité ```Avec détection de la puissance```, cliquez sur 'Valider' sur la page précédente et vous arriverez ici :
 
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/config-power.png?raw=true)
+![image](images/config-power.png)
 
 Cette fonction vous permet de réguler la consommation électrique de vos radiateurs. Connue sous le nom de délestage, cette fonction vous permet de limiter la consommation électrique de votre appareil de chauffage si des conditions de surpuissance sont détectées. Donnez un **capteur à la consommation électrique actuelle de votre maison**, un **capteur à la puissance max** qu'il ne faut pas dépasser, la **consommation électrique totale des équipements du VTherm** (en étape 1 de la configuration) et l'algorithme ne démarrera pas un radiateur si la puissance maximale sera dépassée après le démarrage du radiateur.
 
 Notez que toutes les valeurs de puissance doivent avoir les mêmes unités (kW ou W par exemple).
 Cela vous permet de modifier la puissance maximale au fil du temps à l'aide d'un planificateur ou de ce que vous voulez.
 
-> ![Astuce](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/tips.png?raw=true) _*Notes*_
+> ![Astuce](images/tips.png) _*Notes*_
 > 1. En cas de délestage, le radiateur est réglé sur le préréglage nommé ```power```. Il s'agit d'un préréglage caché, vous ne pouvez pas le sélectionner manuellement.
 > 2. Je l'utilise pour éviter de dépasser la limite de mon contrat d'électricité lorsqu'un véhicule électrique est en charge. Cela crée une sorte d'autorégulation.
 > 3. Gardez toujours une marge, car la puissance max peut être brièvement dépassée en attendant le calcul du prochain cycle typiquement ou par des équipements non régulés.
@@ -504,7 +504,7 @@ Cela vous permet de modifier la puissance maximale au fil du temps à l'aide d'u
 Si sélectionnée en première page, cette fonction vous permet de modifier dynamiquement la température de tous les préréglages du thermostat configurés lorsque personne n'est à la maison ou lorsque quelqu'un rentre à la maison. Pour cela, vous devez configurer la température qui sera utilisée pour chaque préréglage lorsque la présence est désactivée. Lorsque le capteur de présence s'éteint, ces températures seront utilisées. Lorsqu'il se rallume, la température "normale" configurée pour le préréglage est utilisée. Voir [gestion des préréglages](#configure-the-preset-temperature).
 Pour configurer la présence remplissez ce formulaire :
 
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/config-presence.png?raw=true)
+![image](images/config-presence.png)
 
 Pour cela, vous devez configurer :
 1. Un **capteur d'occupation** dont l'état doit être 'on' ou 'home' si quelqu'un est présent ou 'off' ou 'not_home' sinon,
@@ -516,7 +516,7 @@ Si le mode AC est utilisé, vous pourrez aussi configurer les températures lors
 
 ATTENTION : les groupes de personnes ne fonctionnent pas en tant que capteur de présence. Ils ne sont pas reconnus comme un capteur de présence. Vous devez utiliser, un template comme décrit ici [Utilisation d'un groupe de personnes comme capteur de présence](#utilisation-dun-groupe-de-personnes-comme-capteur-de-présence).
 
-> ![Astuce](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/tips.png?raw=true) _*Notes*_
+> ![Astuce](images/tips.png) _*Notes*_
 > 1. le changement de température est immédiat et se répercute sur le volet avant. Le calcul prendra en compte la nouvelle température cible au prochain calcul du cycle,
 > 2. vous pouvez utiliser le capteur direct person.xxxx ou un groupe de capteurs de Home Assistant. Le capteur de présence gère les états ``on`` ou ``home`` comme présents et les états ``off`` ou ``not_home`` comme absents.
 
@@ -524,7 +524,7 @@ ATTENTION : les groupes de personnes ne fonctionnent pas en tant que capteur de 
 Ces paramètres permettent d'affiner le réglage du thermostat.
 Le formulaire de configuration avancée est le suivant :
 
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/config-advanced.png?raw=true)
+![image](images/config-advanced.png)
 
 Le premier délai (minimal_activation_delay_sec) en secondes est le délai minimum acceptable pour allumer le chauffage. Lorsque le calcul donne un délai de mise sous tension inférieur à cette valeur, le chauffage reste éteint.
 
@@ -546,7 +546,7 @@ Par défaut, le thermomètre extérieur peut déclencher une mise en sécurité 
 
 Voir [exemple de réglages](#examples-tuning) pour avoir des exemples de réglage communs
 
-> ![Astuce](/images/tips.png?raw=true) _*Notes*_
+> ![Astuce](images/tips.png) _*Notes*_
 > 1. Lorsque le capteur de température viendra à la vie et renverra les températures, le préréglage sera restauré à sa valeur précédente,
 > 2. Attention, deux températures sont nécessaires : la température interne et la température externe et chacune doit donner la température, sinon le thermostat sera en préréglage "security",
 > 3. Un service est disponible qui permet de régler les 3 paramètres de sécurité. Ca peut servir à adapter la fonction de sécurité à votre usage,
@@ -566,7 +566,7 @@ Cette entité se présente sous la forme d'une liste de choix qui contient les c
 Il est donc possible de contrôler tous les VTherms (que ceux que l'on désigne explicitement) avec un seul contrôle.
 Exemple de rendu :
 
-![central_mode](/images/central_mode.png?raw=true)
+![central_mode](images/central_mode.png)
 
 ## Le contrôle d'une chaudière centrale
 Depuis la release 5.3, vous avez la possibilité de contrôler une chaudière centralisée. A partir du moment où il est possible de déclencher ou stopper cette chaudière depuis Home Assistant, alors Versatile Thermostat va pouvoir la commander directement.
@@ -584,16 +584,16 @@ Le principe mis en place est globalement le suivant :
 Vous avez donc en permanence, les informations qui permettent de piloter et régler le déclenchement de la chaudière.
 
 Toutes ces entités sont rattachés au service de configuration centrale :
-![Les entités pilotant la chaudière](/images/entitites-central-boiler.png?raw=true)
+![Les entités pilotant la chaudière](images/entitites-central-boiler.png)
 
 ### Configuration
 Pour configurer cette fonction, vous devez avoir une configuration centralisée (cf. [Configuration](#configuration)) et cochez la case 'Ajouter une chuadière centrale' :
 
-![Ajout d'une chaudière centrale](/images/config-central-boiler-1.png?raw=true)
+![Ajout d'une chaudière centrale](images/config-central-boiler-1.png)
 
 Sur la page suivante vous pouvez donner la configuration des services à appeler lors de l'allumage / extinction de la chaudière :
 
-![Ajout d'une chaudière centrale](/images/config-central-boiler-2.png?raw=true)
+![Ajout d'une chaudière centrale](images/config-central-boiler-2.png)
 
 Les services se configurent comme indiqués dans la page :
 1. le format général est `entity_id/service_id[/attribut:valeur]` (où `/attribut:valeur` est facultatif),
@@ -616,11 +616,11 @@ Exemple:
 
 Sous "Outils de développement / Service" :
 
-![Configuration du service](/images/dev-tools-turnon-boiler-1.png?raw=true)
+![Configuration du service](images/dev-tools-turnon-boiler-1.png)
 
 En mode yaml :
 
-![Configuration du service](/images/dev-tools-turnon-boiler-2.png?raw=true)
+![Configuration du service](images/dev-tools-turnon-boiler-2.png)
 
 Le service à configurer est alors le suivant: `climate.empty_thermostast/climate.set_hvac_mode/hvac_mode:heat` (notez la suppression du blanc dans `hvac_mode:heat`)
 
@@ -665,7 +665,7 @@ context:
 
 ### Avertissement
 
-> ![Astuce](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/tips.png?raw=true) _*Notes*_
+> ![Astuce](images/tips.png) _*Notes*_
 > Le contrôle par du logiciel ou du matériel de type domotique d'une chaudière centrale peut induire des risques pour son bon fonctionnement. Assurez-vous avant d'utiliser ces fonctions, que votre chaudière possède bien des fonctions de sécurité et que celles-ci fonctionnent. Allumer une chaudière si tous les robinets sont fermés peut générer de la sur-pression par exemple.
 
 ## Synthèse des paramètres
@@ -816,7 +816,7 @@ Voir quelques situations à [examples](#some-results).
 
 Avec le thermostat sont disponibles des capteurs qui permettent de visualiser les alertes et l'état interne du thermostat. Ils sont disponibles dans les entités de l'appareil associé au thermostat :
 
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/thermostat-sensors.png?raw=true)
+![image](images/thermostat-sensors.png)
 
 Dans l'ordre, il y a :
 1. l'entité principale climate de commande du thermostat,
@@ -849,7 +849,7 @@ frontend:
 ```
 et choisissez le thème ```versatile_thermostat_theme``` dans la configuration du panel. Vous obtiendrez quelque-chose qui va ressembler à ça :
 
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/colored-thermostat-sensors.png?raw=true)
+![image](images/colored-thermostat-sensors.png)
 
 # Services
 
@@ -895,7 +895,7 @@ target:
     entity_id: climate.my_thermostat
 ```
 
-> ![Astuce](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/tips.png?raw=true) _*Notes*_
+> ![Astuce](images/tips.png) _*Notes*_
     - après un redémarrage, les préréglages sont réinitialisés à la température configurée. Si vous souhaitez que votre changement soit permanent, vous devez modifier le préréglage de la température dans la configuration de l'intégration.
 
 ## Modifier les paramètres de sécurité
@@ -950,7 +950,7 @@ Vous pouvez très facilement capter ses évènements dans une automatisation par
 # Attributs personnalisés
 
 Pour régler l'algorithme, vous avez accès à tout le contexte vu et calculé par le thermostat via des attributs dédiés. Vous pouvez voir (et utiliser) ces attributs dans l'IHM "Outils de développement / états" de HA. Entrez votre thermostat et vous verrez quelque chose comme ceci :
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/dev-tools-climate.png?raw=true)
+![image](images/dev-tools-climate.png)
 
 Les attributs personnalisés sont les suivants :
 
@@ -1001,23 +1001,23 @@ Les attributs personnalisés sont les suivants :
 # Quelques résultats
 
 **Convergence de la température vers la cible configurée par preset:**
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/results-1.png?raw=true)
+![image](images/results-1.png)
 
 [Cycle de marche/arrêt calculé par l'intégration :](https://)
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/results-2.png?raw=true)
+![image](images/results-2.png)
 
 **Coef_int trop élevé (oscillations autour de la cible)**
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/results-3.png?raw=true)
+![image](images/results-3.png)
 
 **Évolution du calcul de l'algorithme**
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/results-4.png?raw=true)
+![image](images/results-4.png)
 Voir le code de ce composant [[ci-dessous](#even-better-with-apex-chart-to-tune-your-thermostat)]
 
 **Thermostat finement réglé**
 Merci [impuR_Shozz](https://forum.hacf.fr/u/impur_shozz/summary) !
 On peut voir une stabilité autour de la température cible (consigne) et lorsqu'à cible le on_percent (puissance) est proche de 0,3 ce qui semble une très bonne valeur.
 
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/results-fine-tuned.png?raw=true)
+![image](images/results-fine-tuned.png)
 
 Enjoy !
 
@@ -1056,7 +1056,7 @@ J'espère que cet exemple vous aidera, n'hésitez pas à me faire part de vos re
 
 ## Encore bien mieux avec la custom:simple-thermostat front integration
 Le ``custom:simple-thermostat`` [ici](https://github.com/nervetattoo/simple-thermostat) est une excellente intégration qui permet une certaine personnalisation qui s'adapte bien à ce thermostat.
-Vous pouvez avoir quelque chose comme ça très facilement ![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/simple-thermostat.png?raw=true)
+Vous pouvez avoir quelque chose comme ça très facilement ![image](images/simple-thermostat.png)
 Exemple de configuration :
 
 ```
@@ -1099,7 +1099,7 @@ Vous pouvez personnaliser ce composant à l'aide du composant HACS card-mod pour
               }
               {% endif %}
 ```
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/custom-css-thermostat.png?raw=true)
+![image](images/custom-css-thermostat.png)
 
 ## Toujours mieux avec Plotly pour régler votre thermostat
 Vous pouvez obtenir une courbe comme celle présentée dans [some results](#some-results) avec une sorte de configuration de graphique Plotly uniquement en utilisant les attributs personnalisés du thermostat décrits [ici](#custom-attributes) :
@@ -1172,7 +1172,7 @@ Remplacez les valeurs entre [[ ]] par les votres.
 
 Exemple de courbes obtenues avec Plotly :
 
-![image](/images/plotly-curves.png?raw=true)
+![image](images/plotly-curves.png)
 
 ## Et toujours de mieux en mieux avec l'AappDaemon NOTIFIER pour notifier les évènements
 Cette automatisation utilise l'excellente App Daemon nommée NOTIFIER développée par Horizon Domotique que vous trouverez en démonstration [ici](https://www.youtube.com/watch?v=chJylIK0ASo&ab_channel=HorizonDomotique) et le code est [ici](https://github.com/jlpouffier/home-assistant-config/blob/master/appdaemon/apps/notifier.py). Elle permet de notifier les utilisateurs du logement lorsqu'un des évènements touchant à la sécurité survient sur un des Versatile Thermostats.
@@ -1366,11 +1366,11 @@ Tous ces paramètres se règlent dans la dernière page de la configuration du V
 Le premier symptôme est une température anormalement basse avec un temps de chauffe faible à chaque cycle et régulier.
 Exemple:
 
-[security mode](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/security-mode-symptome1.png?raw=true)
+[security mode](images/security-mode-symptome1.png)
 
 Si vous avez installé la carte [Versatile Thermostat UI Card](https://github.com/jmcollin78/versatile-thermostat-ui-card), le VTherm en question aura cette forme là :
 
-[security mode UI Card](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/security-mode-symptome2.png?raw=true)
+[security mode UI Card](images/security-mode-symptome2.png)
 
 Vous pouvez aussi vérifier dans les attributs du VTherm les dates de réception des différentes dates. **Les attributs sont disponibles dans les Outils de développement / Etats**.
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 [![hacs][hacs_badge]][hacs]
 [![BuyMeCoffee][buymecoffeebadge]][buymecoffee]
 
-![Tip](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/icon.png?raw=true)
+![Tip](images/icon.png)
 
-> ![Tip](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/tips.png?raw=true) This thermostat integration aims to drastically simplify your automations around climate management. Because all classical events in climate are natively handled by the thermostat (nobody at home ?, activity detected in a room ?, window open ?, power shedding ?), you don't have to build over complicated scripts and automations to manage your climates ;-).
+> ![Tip](images/tips.png) This thermostat integration aims to drastically simplify your automations around climate management. Because all classical events in climate are natively handled by the thermostat (nobody at home ?, activity detected in a room ?, window open ?, power shedding ?), you don't have to build over complicated scripts and automations to manage your climates ;-).
 
 - [Major changes in version 5.0](#major-changes-in-version-50)
 - [Thanks for the beer buymecoffee](#thanks-for-the-beer-buymecoffee)
@@ -83,7 +83,7 @@
 
 This custom component for Home Assistant is an upgrade and is a complete rewrite of the component "Awesome thermostat" (see [Github](https://github.com/dadge/awesome_thermostat)) with addition of features.
 
->![New](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/new-icon.png?raw=true) _*News*_
+>![New](images/new-icon.png) _*News*_
 > * **Release 5.4**: Added a temperature step [#311](https://github.com/jmcollin78/versatile_thermostat/issues/311). Added some regulation thresholdfor `over_valve` VTherm in order to avoid drowing the battery of TRV devices [#338](https://github.com/jmcollin78/versatile_thermostat/issues/338).
 > * **Release 5.3**: Added a central boiler control function [#234](https://github.com/jmcollin78/versatile_thermostat/issues/234) - more information here: [Controlling a central boiler](#controlling-a-central-boiler). Added the ability to disable security mode for outdoor thermometer [#343](https://github.com/jmcollin78/versatile_thermostat/issues/343)
 > * **Release 5.2**: Added a `central_mode` allowing all VTherms to be controlled centrally [#158](https://github.com/jmcollin78/versatile_thermostat/issues/158).
@@ -111,7 +111,7 @@ This custom component for Home Assistant is an upgrade and is a complete rewrite
 </details>
 
 # Major changes in version 5.0
-![New](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/new-icon.png?raw=true)
+![New](images/new-icon.png)
 
 You can now define a central configuration which will allow you to share certain attributes on all your VTherms (or only part of them). To use this possibility, you must:
 1. Create a VTherm of type “Central Configuration”,
@@ -194,7 +194,7 @@ This component named __Versatile thermostat__ manage the following use cases :
 
 -- VTherm = Versatile Thermostat in the remainder of this document --
 
-> ![Tip](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/tips.png?raw=true) _*Notes*_
+> ![Tip](images/tips.png) _*Notes*_
 >
 > Three ways to configure VTherms are available:
 > 1. Each Versatile Thermostat is completely independently configured. Choose this option if you do not want to have any central configuration or management.
@@ -204,7 +204,7 @@ This component named __Versatile thermostat__ manage the following use cases :
 
 ## Creation of a new Versatile Thermostat
 Click on Add integration button in the integration page
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/add-an-integration.png?raw=true)
+![image](images/add-an-integration.png)
 
 The configuration can be change through the same interface. Simply select the thermostat to change, hit "Configure" and you will be able to change some parameters or configuration.
 
@@ -212,9 +212,9 @@ Then follow the configurations steps as follow:
 
 ## Minimal configuration update
 
-![image](/images/config-main0.png?raw=true)
+![image](images/config-main0.png)
 
-![image](/images/config-main.png?raw=true)
+![image](images/config-main.png)
 
 Give the main mandatory attributes:
 1. a name (will be the name of the integration and also the name of the climate entity)
@@ -227,14 +227,14 @@ Give the main mandatory attributes:
 9. the possibility of controlling the thermostat centrally. Cf [centralized control](#centralized-control),
 10. the list of features that will be used for this thermostat. Depending on your choices, the following configuration screens will appear or not.
 
-> ![Tip](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/tips.png?raw=true) _*Notes*_
+> ![Tip](images/tips.png) _*Notes*_
 > 1. With the ```thermostat_over_switch``` type, calculation are done at each cycle. So in case of conditions change, you will have to wait for the next cycle to see a change. For this reason, the cycle should not be too long. **5 min is a good value**,
 > 2. if the cycle is too short, the heater could never reach the target temperature. For the storage radiator for example it will be used unnecessarily.
 
 ## Select the driven entity
 Depending on your choice of thermostat type, you will need to choose one or more `switch`, `climate` or `number` type entities. Only entities compatible with the type are presented.
 
-> ![Tip](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/tips.png?raw=true) _*How to choose the type*_
+> ![Tip](images/tips.png) _*How to choose the type*_
 > The choice of type is important. Even if it is always possible to modify it afterwards via the configuration HMI, it is preferable to ask yourself the following few questions:
 > 1. **what type of equipment am I going to pilot?** In order, here is what to do:
 >    1. if you have a thermostatic valve (TRV) that can be controlled in Home Assistant via a ```number``` type entity (for example a _Shelly TRV_), choose the `over_valve` type. It is the most direct type and which ensures the best regulation,
@@ -244,18 +244,18 @@ Depending on your choice of thermostat type, you will need to choose one or more
 It is possible to choose an over switch thermostat which controls air conditioning by checking the "AC Mode" box. In this case, only the cooling mode will be visible.
 
 ### For a ```thermostat_over_switch``` type thermostat
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/config-linked-entity.png?raw=true)
+![image](images/config-linked-entity.png)
 The algorithm to use is currently limited to TPI is available. See [algorithm](#algorithm).
 If several type entities are configured, the thermostat shifts the activations in order to minimize the number of switches active at a time t. This allows for better power distribution since each radiator will turn on in turn.
 Example of synchronized triggering:
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/multi-switch-activation.png?raw=true)
+![image](images/multi-switch-activation.png)
 
 It is possible to choose an over switch thermostat which controls air conditioning by checking the "AC Mode" box. In this case, only the cooling mode will be visible.
 
 If your equipment is controlled by a pilot wire with a diode, you will certainly need to check the "Invert Check" box. It allows you to set the switch to On when you need to turn the equipment off and to Off when you need to turn it on.
 
 ### For a thermostat of type ```thermostat_over_climate```:
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/config-linked-entity2.png?raw=true)
+![image](images/config-linked-entity2.png)
 
 It is possible to choose an over climate thermostat which controls reversible air conditioning by checking the “AC Mode” box. In this case, depending on the equipment ordered, you will have access to heating and/or cooling.
 
@@ -278,7 +278,7 @@ The self-regulation function is configured with:
 
 These three parameters make it possible to modulate the regulation and avoid multiplying the regulation sendings. Some equipment such as TRVs and boilers do not like the temperature setpoint to be changed too often.
 
-> ![Tip](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/tips.png?raw=true) _*Implementation tip*_
+> ![Tip](images/tips.png) _*Implementation tip*_
 > 1. Do not start self-regulation straight away. Watch how the natural regulation of your equipment works. If you notice that the set temperature is not reached or that it is taking too long to be reached, start the regulation,
 > 2. First start with a slight self-regulation and keep both parameters at their default values. Wait a few days and check if the situation has improved,
 > 3. If this is not sufficient, switch to Medium self-regulation, wait for stabilization,
@@ -372,7 +372,7 @@ If your equipment does not include Turbo mode, Forte` mode will be used as a rep
 Once the temperature difference becomes low again, the ventilation will go into a "normal" mode which depends on your equipment, namely (in order): `Silence (mute)`, `Auto (auto)`, `Low (low)`. The first value that is possible for your equipment will be chosen.
 
 ### For a thermostat of type ```thermostat_over_valve```:
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/config-linked-entity3.png?raw=true)
+![image](images/config-linked-entity3.png)
 You can choose up to domain entity ```number``` or ```ìnput_number``` which will control the valves.
 The algorithm to use is currently limited to TPI is available. See [algorithm](#algorithm).
 
@@ -380,13 +380,13 @@ It is possible to choose an over valve thermostat which controls air conditionin
 
 ## Configure the TPI algorithm coefficients
 click on 'Validate' on the previous page, and if you choose a  ```over_switch``` or ```over_valve``` thermostat and you will get there:
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/config-tpi.png?raw=true)
+![image](images/config-tpi.png)
 
 For more informations on the TPI algorithm and tuned please refer to [algorithm](#algorithm).
 
 ## Configure the preset temperature
 Click on 'Validate' on the previous page and you will get there:
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/config-presets.png?raw=true)
+![image](images/config-presets.png)
 
 The preset mode allows you to pre-configurate targeted temperature. Used in conjonction with Scheduler (see [scheduler](#even-better-with-scheduler-component) you will have a powerfull and simple way to optimize the temperature vs electrical consumption of your hous. Preset handled are the following :
  - **Eco** : device is running an energy-saving mode
@@ -397,7 +397,7 @@ The preset mode allows you to pre-configurate targeted temperature. Used in conj
 
 **None** is always added in the list of modes, as it is a way to not use the presets modes but a **manual temperature** instead.
 
-> ![Tip](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/tips.png?raw=true) _*Notes*_
+> ![Tip](images/tips.png) _*Notes*_
 >  1. Changing manually the target temperature, set the preset to None (no preset). This way you can always set a target temperature even if no preset are available.
 >  2. standard ``Away`` preset is a hidden preset which is not directly selectable. Versatile Thermostat uses the presence management or movement management to set automatically and dynamically the target temperature depending on a presence in the home or an activity in the room. See [presence management](#configure-the-presence-management).
 >  3. if you uses the power shedding management, you will see a hidden preset named ``power``. The heater preset is set to ``power`` when overpowering conditions are encountered and shedding is active for this heater. See [power management](#configure-the-power-management).
@@ -412,14 +412,14 @@ The detection of openings can be done in 2 ways:
 
 ### The sensor mode
 In sensor mode, you must fill in the following information:
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/config-window-sensor.png?raw=true)
+![image](images/config-window-sensor.png)
 
 1. an entity ID of a **window/door sensor**. It should be a binary_sensor or an input_boolean. The state of the entity must be 'on' when the window is open or 'off' when it is closed
 2. a **delay in seconds** before any change. This allows a window to be opened quickly without stopping the heating.
 
 ### Auto mode
 In auto mode, the configuration is as follows:
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/config-window-auto.png?raw=true)
+![image](images/config-window-auto.png)
 
 1. a detection threshold in degrees per minute. When the temperature drops below this threshold, the thermostat will turn off. The lower this value, the faster the detection will be (in return for a risk of false positives),
 2. an end of detection threshold in degrees per minute. When the temperature drop goes above this value, the thermostat will go back to the previous mode (mode and preset),
@@ -431,14 +431,14 @@ To set the thresholds it is advisable to start with the reference values ​​a
 - maximum duration: 60 min.
 
 A new "slope" sensor has been added for all thermostats. It gives the slope of the temperature curve in °C/min (or °K/min). This slope is smoothed and filtered to avoid aberrant values ​​from the thermometers which would interfere with the measurement.
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/temperature-slope.png?raw=true)
+![image](images/temperature-slope.png)
 
 To properly adjust it is advisable to display on the same historical graph the temperature curve and the slope of the curve (the "slope"):
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/window-auto-tuning.png?raw=true)
+![image](images/window-auto-tuning.png)
 
 And that's all ! your thermostat will turn off when the windows are open and turn back on when closed.
 
-> ![Tip](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/tips.png?raw=true) _*Notes*_
+> ![Tip](images/tips.png) _*Notes*_
 > 1. If you want to use **multiple door/window sensors** to automate your thermostat, just create a group with the usual behavior (https://www.home-assistant.io/integrations/binary_sensor.group/)
 > 2. If you don't have a window/door sensor in your room, just leave the sensor entity id blank,
 > 3. **Only one mode is allowed**. You cannot configure a thermostat with a sensor and automatic detection. The 2 modes may contradict each other, it is not possible to have the 2 modes at the same time,
@@ -446,7 +446,7 @@ And that's all ! your thermostat will turn off when the windows are open and tur
 
 ## Configure the activity mode or motion detection
 If you choose the ```Motion management``` feature, lick on 'Validate' on the previous page and you will get there:
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/config-motion.png?raw=true)
+![image](images/config-motion.png)
 
 We will now see how to configure the new Activity mode.
 What we need:
@@ -465,13 +465,13 @@ What we need:
 
 For this to work, the climate thermostat should be in ``Activity`` preset mode.
 
-> ![Tip](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/tips.png?raw=true)  _*Notes*_
+> ![Tip](images/tips.png)  _*Notes*_
 > 1. Be aware that as for the others preset modes, ``Activity`` will only be proposed if it's correctly configure. In other words, the 4 configuration keys have to be set if you want to see Activity in home assistant Interface
 
 ## Configure the power management
 
 If you choose the ```Power management``` feature, click on 'Validate' on the previous page and you will get there:
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/config-power.png?raw=true)
+![image](images/config-power.png)
 
 This feature allows you to regulate the power consumption of your radiators. Known as shedding, this feature allows you to limit the electrical power consumption of your heater if overpowering conditions are detected. Give a **sensor to the current power consumption of your house**, a **sensor to the max power** that should not be exceeded, the **power consumption of your heaters linked to the VTherm** (in the first step of the configuration) and the algorithm will not start a radiator if the max power will be exceeded after radiator starts.
 
@@ -479,7 +479,7 @@ This feature allows you to regulate the power consumption of your radiators. Kno
 Note that all power values should have the same units (kW or W for example).
 This allows you to change the max power along time using a Scheduler or whatever you like.
 
-> ![Tip](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/tips.png?raw=true)  _*Notes*_
+> ![Tip](images/tips.png)  _*Notes*_
 > 1. When shedding is encountered, the heater is set to the preset named ``power``. This is a hidden preset, you cannot select it manually.
 > 2. I use this to avoid exceeded the limit of my electrical power contract when an electrical vehicle is charging. This makes a kind of auto-regulation.
 > 3. Always keep a margin, because max power can be briefly exceeded while waiting for the next cycle calculation typically or by not regulated equipement.
@@ -490,7 +490,7 @@ This allows you to change the max power along time using a Scheduler or whatever
 If selected on the first page, this feature allows you to dynamically change the temperature of all configured thermostat presets when no one is home or when someone comes home. To do this, you must configure the temperature that will be used for each preset when presence is disabled. When the presence sensor turns off, these temperatures will be used. When it turns back on, the "normal" temperature configured for the preset is used. See [preset management](#configure-the-preset-temperature).
 To configure presence, complete this form:
 
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/config-presence.png?raw=true)
+![image](images/config-presence.png)
 
 To do this, you must configure:
 1. An **occupancy sensor** whose state must be 'on' or 'home' if someone is present or 'off' or 'not_home' otherwise,
@@ -502,7 +502,7 @@ If AC mode is used, you will also be able to configure temperatures when the equ
 
 ATTENTION: groups of people do not function as a presence sensor. They are not recognized as a presence sensor. You must use a template as described here [Using a group of people as a presence sensor](#using-a-group-of-people-as-a-presence-sensor).
 
-> ![Tip](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/tips.png?raw=true) _*Notes*_
+> ![Tip](images/tips.png) _*Notes*_
 > 1. the change in temperature is immediate and is reflected on the front shutter. The calculation will take into account the new target temperature at the next calculation of the cycle,
 > 2. you can use the person.xxxx direct sensor or a group of Home Assistant sensors. The presence sensor manages the ``on`` or ``home`` states as present and the ``off`` or ``not_home`` states as absent.
 
@@ -510,7 +510,7 @@ ATTENTION: groups of people do not function as a presence sensor. They are not r
 Those parameters allows to fine tune the thermostat.
 The advanced configuration form is the following:
 
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/config-advanced.png?raw=true)
+![image](images/config-advanced.png)
 
 The first delay (minimal_activation_delay_sec) in sec in the minimum delay acceptable for turning on the heater. When calculation gives a power on delay below this value, the heater will stays off.
 
@@ -532,7 +532,7 @@ By default, the outdoor thermometer can trigger a trip if it no longer sends a v
 
 See [example tuning](#examples-tuning) for common tuning examples
 
->![Tip](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/tips.png?raw=true) _*Notes*_
+>![Tip](images/tips.png) _*Notes*_
 > 1. When the temperature sensor comes to life and returns the temperatures, the preset will be restored to its previous value,
 > 2. Attention, two temperatures are needed: internal temperature and external temperature and each must give the temperature, otherwise the thermostat will be in "safety" preset,
 > 3. A service is available that allows you to set the 3 safety parameters. This can be used to adapt the safety function to your use.
@@ -552,7 +552,7 @@ This entity is presented in the form of a list of choices which contains the fol
 It is therefore possible to control all VTherms (only those explicitly designated) with a single control.
 Example rendering:
 
-![central_mode](/images/central_mode.png?raw=true)
+![central_mode](images/central_mode.png)
 
 ## Control of a central boiler
 Since release 5.3, you have the possibility of controlling a centralized boiler. From the moment it is possible to start or stop this boiler from Home Assistant, then Versatile Thermostat will be able to control it directly.
@@ -570,16 +570,16 @@ The principle put in place is generally as follows:
 You therefore always have the information which allows you to control and adjust the activation of the boiler.
 
 All these entities are attached to the central configuration service:
-![The entities controlling the boiler](/images/entitites-central-boiler.png?raw=true)
+![The entities controlling the boiler](images/entitites-central-boiler.png)
 
 ### Setup
 To configure this function, you must have a centralized configuration (see [Configuration](#configuration)) and check the 'Add a central boiler' box:
 
-![Adding a central boiler](/images/config-central-boiler-1.png?raw=true)
+![Adding a central boiler](images/config-central-boiler-1.png)
 
 On the following page you can configure the services to be called when switching the boiler on/off:
 
-![Adding a central boiler](/images/config-central-boiler-2.png?raw=true)
+![Adding a central boiler](images/config-central-boiler-2.png)
 
 The services are configured as indicated on the page:
 1. the general format is `entity_id/service_id[/attribute:value]` (where `/attribute:value` is optional),
@@ -602,11 +602,11 @@ Example:
 
 Under "Development Tools / Service":
 
-![Service configuration](/images/dev-tools-turnon-boiler-1.png?raw=true)
+![Service configuration](images/dev-tools-turnon-boiler-1.png)
 
 In yaml mode:
 
-![Service configuration](/images/dev-tools-turnon-boiler-2.png?raw=true)
+![Service configuration](images/dev-tools-turnon-boiler-2.png)
 
 The service to configure is then the following: `climate.empty_thermostast/climate.set_hvac_mode/hvac_mode:heat` (note the removal of the blank in `hvac_mode:heat`)
 
@@ -651,7 +651,7 @@ context:
 
 ### Warning
 
-> ![Tip](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/tips.png?raw=true) _*Notes*_
+> ![Tip](images/tips.png) _*Notes*_
 > Controlling a central boiler using software or hardware such as home automation can pose risks to its proper functioning. Before using these functions, make sure that your boiler has safety functions and that they are working. Turning on a boiler if all the taps are closed can generate excess pressure, for example.
 
 ## Parameters synthesis
@@ -804,7 +804,7 @@ See some situations at [examples](#some-results).
 
 With the thermostat are available sensors that allow you to view the alerts and the internal status of the thermostat. They are available in the entities of the device associated with the thermostat:
 
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/thermostat-sensors.png?raw=true)
+![image](images/thermostat-sensors.png)
 
 In order, there are:
 1. the main climate thermostat command entity,
@@ -837,7 +837,7 @@ frontend:
 ```
 and choose the ```versatile_thermostat_theme``` theme in the panel configuration. You will get something that will look like this:
 
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/colored-thermostat-sensors.png?raw=true)
+![image](images/colored-thermostat-sensors.png)
 
 # Services
 
@@ -883,7 +883,7 @@ target:
     entity_id: climate.my_thermostat
 ```
 
-> ![Tip](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/tips.png?raw=true)  _*Notes*_
+> ![Tip](images/tips.png)  _*Notes*_
     - after a restart the preset are resetted to the configured temperature. If you want your change to be permanent you should modify the temperature preset into the confguration of the integration.
 
 ## Change safety settings
@@ -936,7 +936,7 @@ You can very easily capture its events in an automation, for example to notify u
 # Custom attributes
 
 To tune the algorithm you have access to all context seen and calculted by the thermostat through dedicated attributes. You can see (and use) those attributes in the "Development tools / states" HMI of HA. Enter your thermostat and you will see something like this:
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/dev-tools-climate.png?raw=true)
+![image](images/dev-tools-climate.png)
 
 Custom attributes are the following:
 
@@ -987,23 +987,23 @@ Custom attributes are the following:
 # Some results
 
 **Convergence of temperature to target configured by preset:**
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/results-1.png?raw=true)
+![image](images/results-1.png)
 
 [Cycle of on/off calculated by the integration:](https://)
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/results-2.png?raw=true)
+![image](images/results-2.png)
 
 **Coef_int too high (oscillations around the target)**
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/results-3.png?raw=true)
+![image](images/results-3.png)
 
 **Algorithm calculation evolution**
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/results-4.png?raw=true)
+![image](images/results-4.png)
 See the code of this component [[below](#even-better-with-apex-chart-to-tune-your-thermostat)]
 
 **Fine tuned thermostat**
 Thank's [impuR_Shozz](https://forum.hacf.fr/u/impur_shozz/summary) !
 We can see stability around the target temperature (consigne) and when at target the on_percent (puissance) is near 0.3 which seems a very good value.
 
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/results-fine-tuned.png?raw=true)
+![image](images/results-fine-tuned.png)
 
 Enjoy !
 
@@ -1042,7 +1042,7 @@ I hope this example helps you, don't hesitate to give me your feedbacks !
 
 ## Even-even better with custom:simple-thermostat front integration
 The ``custom:simple-thermostat`` [here](https://github.com/nervetattoo/simple-thermostat) is a great integration which allow some customisation which fits well with this thermostat.
-You can have something like that very easily ![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/simple-thermostat.png?raw=true)
+You can have something like that very easily ![image](images/simple-thermostat.png)
 Example configuration:
 
 ```
@@ -1084,7 +1084,7 @@ You can customize this component using the HACS card-mod component to adjust the
               }
               {% endif %}
 ```
-![image](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/custom-css-thermostat.png?raw=true)
+![image](images/custom-css-thermostat.png)
 
 ## Even better with Plotly to tune your Thermostat
 You can get curve like presented in [some results](#some-results) with kind of Plotly configuration only using the custom attributes of the thermostat described [here](#custom-attributes):
@@ -1157,7 +1157,7 @@ Replace values in [[ ]] by yours.
 
 Example of graph obtained with Plotly :
 
-![image](/images/plotly-curves.png?raw=true)
+![image](images/plotly-curves.png)
 
 
 ## And always better and better with the NOTIFIER daemon app to notify events
@@ -1350,11 +1350,11 @@ All these parameters are adjusted on the last page of the VTherm configuration: 
 The first symptom is an abnormally low temperature with a slow and regular heating time in each cycle.
 Example:
 
-[safety mode](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/security-mode-symptome1.png?raw=true)
+[safety mode](images/security-mode-symptome1.png)
 
 If you installed the [Versatile Thermostat UI Card](https://github.com/jmcollin78/versatile-thermostat-ui-card), the VTherm in question will have this shape:
 
-[safety mode UI Card](https://github.com/jmcollin78/versatile_thermostat/blob/main/images/security-mode-symptome2.png?raw=true)
+[safety mode UI Card](images/security-mode-symptome2.png)
 
 You can also check in the VTherm attributes the dates of receipt of the different dates. Attributes are available in Development Tools / Reports.
 


### PR DESCRIPTION
While adding documentation for PR #345, I edited configuration image files on my local workstation for the README files and previewed them locally with relative URLs, but I noticed that the majority of existing image URLs are absolute.

Is there a reason to prefer absolute image URLs in the README files? Relative URLs have the advantage that it is easier to preview modifications locally before committing the files to Github.

As for the `?raw=true` query string at the end of the absolute URLs, I gather that it causes a HTTP 302 redirect:

```sh
$ curl -v https://github.com/jmcollin78/versatile_thermostat/blob/main/images/new-icon.png?raw=true >/dev/null
...
< HTTP/2 302
< location: https://github.com/jmcollin78/versatile_thermostat/raw/main/images/new-icon.png
```

```
$ curl -v https://github.com/jmcollin78/versatile_thermostat/blob/main/images/new-icon.png >/dev/null
...
< HTTP/2 200
```

I understand that this redirect is useful when linking files from outside of Github, but in the README files (“inside Github”) I think it just slows things down a bit.

As an experiment, this PR replaces all absolute URLs with relative URLs, and deletes the `?raw=true` query string. I think this improves performance both locally on VSCode (the image files are loaded locally) and on Github (no redirects).

I have previewed the changes on Github by clicking on the three horizontal dots to the right of the file names and selecting “View file”, and I have previewed the changes locally on VS Code. It all looks fine. I cannot guarantee that there aren’t side effects, but if there are, it would also be straightforward to revert the changes with either `git checkout <commit> -- README.md` or by reinserting the URLs with “find and replace” in VS Code.
