### PR TITLE
Prevent “Heating will be disabled” warning loop while HVACMode is OFF

### DIFF
--- a/custom_components/versatile_thermostat/base_thermostat.py
+++ b/custom_components/versatile_thermostat/base_thermostat.py
@@ -799,7 +799,7 @@ class BaseThermostat(ClimateEntity, RestoreEntity):
                         self._target_temp,
                         self._cur_temp,
                         self._cur_ext_temp,
-                        self._hvac_mode == HVACMode.COOL,
+                        self._hvac_mode or HVACMode.OFF,
                     )
 
             self.hass.create_task(self._check_initial_state())

--- a/custom_components/versatile_thermostat/prop_algorithm.py
+++ b/custom_components/versatile_thermostat/prop_algorithm.py
@@ -1,6 +1,8 @@
 """ The TPI calculation module """
 import logging
 
+from homeassistant.components.climate import HVACMode
+
 _LOGGER = logging.getLogger(__name__)
 
 PROPORTIONAL_FUNCTION_ATAN = "atan"
@@ -46,19 +48,20 @@ class PropAlgorithm:
 
     def calculate(
         self,
-        target_temp: float,
-        current_temp: float,
-        ext_current_temp: float,
-        cooling=False,
+        target_temp: float | None,
+        current_temp: float | None,
+        ext_current_temp: float | None,
+        hvac_mode: HVACMode,
     ):
         """Do the calculation of the duration"""
         if target_temp is None or current_temp is None:
-            _LOGGER.warning(
+            log = _LOGGER.debug if hvac_mode == HVACMode.OFF else _LOGGER.warning
+            log(
                 "Proportional algorithm: calculation is not possible cause target_temp or current_temp is null. Heating/cooling will be disabled"  # pylint: disable=line-too-long
             )
             self._calculated_on_percent = 0
         else:
-            if cooling:
+            if hvac_mode == HVACMode.COOL:
                 delta_temp = current_temp - target_temp
                 delta_ext_temp = (
                     ext_current_temp

--- a/custom_components/versatile_thermostat/thermostat_switch.py
+++ b/custom_components/versatile_thermostat/thermostat_switch.py
@@ -183,7 +183,7 @@ class ThermostatOverSwitch(BaseThermostat):
             self._target_temp,
             self._cur_temp,
             self._cur_ext_temp,
-            self._hvac_mode == HVACMode.COOL,
+            self._hvac_mode or HVACMode.OFF,
         )
         self.update_custom_attributes()
         self.async_write_ha_state()

--- a/custom_components/versatile_thermostat/thermostat_valve.py
+++ b/custom_components/versatile_thermostat/thermostat_valve.py
@@ -234,7 +234,7 @@ class ThermostatOverValve(BaseThermostat):
             self._target_temp,
             self._cur_temp,
             self._cur_ext_temp,
-            self._hvac_mode == HVACMode.COOL,
+            self._hvac_mode or HVACMode.OFF,
         )
 
         new_valve_percent = round(


### PR DESCRIPTION
My Home Assistant logs were full of the following warning messages (printed about every 30 seconds) even though Versatile Thermostat was turned off (`self._hvac_mode is HVACMode.OFF`):

```
2024-02-04 17:02:53.951 WARNING (MainThread) [custom_components.versatile_thermostat.prop_algorithm] Proportional algorithm: calculation is not possible cause target_temp or current_temp is null. Heating/cooling will be disabled
2024-02-04 17:03:23.946 WARNING (MainThread) [custom_components.versatile_thermostat.prop_algorithm] Proportional algorithm: calculation is not possible cause target_temp or current_temp is null. Heating/cooling will be disabled
2024-02-04 17:03:53.978 WARNING (MainThread) [custom_components.versatile_thermostat.prop_algorithm] Proportional algorithm: calculation is not possible cause target_temp or current_temp is null. Heating/cooling will be disabled
...
```

`current_temp` was indeed `None`, because I had unplugged a MQTT heater + temperature sensor from the wall socket while it was not being used.

It is a useful warning message while Versatile Thermostat is turned on (`HVACMode.HEAT`, `HVACMode.COOL`), but I think it is counterproductive while Versatile Thermostat is turned off (`HVACMode.OFF`). Warning that _“Heating/cooling will be disabled”_ when the user has already turned heating/cooling off is redundant. The warning that `target_temp` or `current_temp` are null is interesting but not in a loop while `HVACMode` is `OFF`, in a scenario like mine where the controlled heater + temperature sensors were unplugged.

This PR proposes dynamically amending the log level of that message depending on the on/off state of Versatile Thermostat.
