### PR TITLE
Make the switch keep-alive callback conditional on the entity state

### DIFF
--- a/tests/test_switch_keep_alive.py
+++ b/tests/test_switch_keep_alive.py
@@ -210,6 +210,7 @@ class TestKeepAlive:
             common_mocks,
             [call("switch", SERVICE_TURN_ON, {"entity_id": "switch.mock_switch"})],
         )
+        common_mocks.mock_is_state.return_value = True
 
         # Call the keep-alive callback a few times (as if `async_track_time_interval`
         # had done it) and assert that the callback function is replaced each time.
@@ -240,6 +241,7 @@ class TestKeepAlive:
             common_mocks,
             [call("switch", SERVICE_TURN_OFF, {"entity_id": "switch.mock_switch"})],
         )
+        common_mocks.mock_is_state.return_value = False
 
         # Call the keep-alive callback a few times (as if `async_track_time_interval`
         # had done it) and assert that the callback function is replaced each time.


### PR DESCRIPTION
This PR is motivated by discussion #379. It is *not* clear that it fixes any bug, because we have *not* identified a bug: We have not been able to reproduce the issue reported by the user. All my tests — both automated unit tests and manual end-to-end tests — behaved the same way before and after this PR.

Having said that, the added logic in this PR fends off against some theoretical speculation of what might happen in some corner cases. See other comments for more details.