### PR TITLE
Improvements to the development environment

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,2 @@
+FROM mcr.microsoft.com/devcontainers/python:1-3.11
+RUN apt update && apt install -y ffmpeg

--- a/.devcontainer/configuration.yaml
+++ b/.devcontainer/configuration.yaml
@@ -1,8 +1,5 @@
 default_config:
 
-# ffmeg
-ffmpeg:
-
 logger:
     default: info
     logs:

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,9 @@
 // See https://aka.ms/vscode-remote/devcontainer.json for format details.
 // "image": "ghcr.io/ludeeus/devcontainer/integration:latest",
 {
-	"image": "mcr.microsoft.com/devcontainers/python:1-3.11-bullseye",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
 	"name": "Versatile Thermostat integration",
 	"appPort": [
 		"8123:8123"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,8 @@
 {
     "[python]": {
         "editor.defaultFormatter": "ms-python.black-formatter",
-        "editor.formatOnSave": true
+        "editor.formatOnSave": true,
+        "editor.formatOnSaveMode": "modifications"
     },
     "pylint.lintOnChange": false,
     "files.associations": {

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,2 +1,2 @@
-homeassistant==2023.12.1
+homeassistant==2024.2.1
 ffmpeg

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,2 +1,1 @@
 homeassistant==2024.2.1
-ffmpeg


### PR DESCRIPTION
The main benefit of this PR is to avoid the following `ffmpeg` error when starting Home Assistant in the VSCode devcontainer:

```
2024-02-15 19:35:54.772 ERROR (MainThread) [haffmpeg.core] FFmpeg fails [Errno 2] No such file or directory: 'ffmpeg'
Traceback (most recent call last):
  File "/home/vscode/.local/lib/python3.11/site-packages/haffmpeg/core.py", line 137, in open
    self._proc = await self._loop.run_in_executor(None, proc_func)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/subprocess.py", line 1026, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/local/lib/python3.11/subprocess.py", line 1950, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'ffmpeg'
2024-02-15 19:35:54.776 WARNING (MainThread) [haffmpeg.tools] Error starting FFmpeg.
```

See other comments for more details.