### PR TITLE
Enhance temperature regulation when working with internal device temperature

### DIFF
--- a/custom_components/versatile_thermostat/thermostat_climate.py
+++ b/custom_components/versatile_thermostat/thermostat_climate.py
@@ -168,11 +168,17 @@ class ThermostatOverClimate(BaseThermostat[UnderlyingClimate]):
 
         _LOGGER.info("%s - regulation calculation will be done", self)
 
+        # use _attr_target_temperature_step to round value if _auto_regulation_dtemp is equal to 0
+        regulation_step = self._auto_regulation_dtemp if self._auto_regulation_dtemp else self._attr_target_temperature_step
+        _LOGGER.debug("%s - usage of regulation_step: %.2f ",
+                      self,
+                      regulation_step)
+        
         new_regulated_temp = round_to_nearest(
             self._regulation_algo.calculate_regulated_temperature(
                 self.current_temperature, self._cur_ext_temp
             ),
-            self._auto_regulation_dtemp,
+            regulation_step,
         )
         dtemp = new_regulated_temp - self._regulated_target_temp
 
@@ -216,7 +222,7 @@ class ThermostatOverClimate(BaseThermostat[UnderlyingClimate]):
             ):
                 offset_temp = device_temp - self.current_temperature
 
-            target_temp = round_to_nearest(self.regulated_target_temp + offset_temp, self._auto_regulation_dtemp)
+            target_temp = round_to_nearest(self.regulated_target_temp + offset_temp, regulation_step)
 
             _LOGGER.debug(
                 "%s - The device offset temp for regulation is %.2f - internal temp is %.2f. New target is %.2f",

--- a/tests/test_auto_regulation.py
+++ b/tests/test_auto_regulation.py
@@ -557,7 +557,7 @@ async def test_over_climate_regulation_dtemp_null(
         title="TheOverClimateMockName",
         unique_id="uniqueId",
         # This is include a medium regulation
-        data=PARTIAL_CLIMATE_AC_CONFIG | {CONF_AUTO_REGULATION_DTEMP: 0, CONF_STEP_TEMPERATURE: 0.5},
+        data=PARTIAL_CLIMATE_AC_CONFIG | {CONF_AUTO_REGULATION_DTEMP: 0, CONF_STEP_TEMPERATURE: 0.1},
     )
 
     tz = get_tz(hass)  # pylint: disable=invalid-name
@@ -566,7 +566,7 @@ async def test_over_climate_regulation_dtemp_null(
 
     # Creates the regulated VTherm over climate
     # change temperature so that the heating will start
-    event_timestamp = now - timedelta(minutes=10)
+    event_timestamp = now - timedelta(minutes=20)
 
     with patch(
         "custom_components.versatile_thermostat.commons.NowClass.get_now",
@@ -591,56 +591,69 @@ async def test_over_climate_regulation_dtemp_null(
         assert entity.hvac_action == HVACAction.OFF
 
         # change temperature so that the heating will start
-        await send_temperature_change_event(entity, 30, event_timestamp)
-        await send_ext_temperature_change_event(entity, 35, event_timestamp)
+        await send_temperature_change_event(entity, 15, event_timestamp)
+        await send_ext_temperature_change_event(entity, 10, event_timestamp)
 
         # set manual target temp
-        event_timestamp = now - timedelta(minutes=7)
+        event_timestamp = now - timedelta(minutes=17)
         with patch(
             "custom_components.versatile_thermostat.commons.NowClass.get_now",
             return_value=event_timestamp,
         ):
-            await entity.async_set_temperature(temperature=25)
+            await entity.async_set_temperature(temperature=20)
 
             fake_underlying_climate.set_hvac_action(
-                HVACAction.COOLING
+                HVACAction.HEATING
             )  # simulate under cooling
-            assert entity.hvac_action == HVACAction.COOLING
+            assert entity.hvac_action == HVACAction.HEATING
             assert entity.preset_mode == PRESET_NONE  # Manual mode
 
             # the regulated temperature should be lower
-            assert entity.regulated_target_temp < entity.target_temperature
+            assert entity.regulated_target_temp > entity.target_temperature
             assert (
-                entity.regulated_target_temp == 25 - 2.5
-            )  # In medium we could go up to -3 degre
-            assert entity.hvac_action == HVACAction.COOLING
+                entity.regulated_target_temp == 20 + 2.4
+            )  # In medium we could go up to +3 degre
+            assert entity.hvac_action == HVACAction.HEATING
 
         # change temperature so that the regulated temperature should slow down
-        event_timestamp = now - timedelta(minutes=5)
+        event_timestamp = now - timedelta(minutes=15)
         with patch(
             "custom_components.versatile_thermostat.commons.NowClass.get_now",
             return_value=event_timestamp,
         ):
-            await send_temperature_change_event(entity, 26, event_timestamp)
-            await send_ext_temperature_change_event(entity, 35, event_timestamp)
-
-            # the regulated temperature should be under
-            assert entity.regulated_target_temp < entity.target_temperature
-            assert (
-                entity.regulated_target_temp == 25 - 1
-            )  # +2.3 without round_to_nearest
-
-            # change temperature so that the regulated temperature should slow down
-        event_timestamp = now - timedelta(minutes=3)
-        with patch(
-            "custom_components.versatile_thermostat.commons.NowClass.get_now",
-            return_value=event_timestamp,
-        ):
-            await send_temperature_change_event(entity, 18, event_timestamp)
-            await send_ext_temperature_change_event(entity, 25, event_timestamp)
+            await send_temperature_change_event(entity, 19, event_timestamp)
+            await send_ext_temperature_change_event(entity, 10, event_timestamp)
 
             # the regulated temperature should be greater
             assert entity.regulated_target_temp > entity.target_temperature
             assert (
-                entity.regulated_target_temp == 25 + 3
-            )  # +0.4 without round_to_nearest
+                entity.regulated_target_temp == 20 + 0.9
+            ) 
+
+            # change temperature so that the regulated temperature should slow down
+        event_timestamp = now - timedelta(minutes=13)
+        with patch(
+            "custom_components.versatile_thermostat.commons.NowClass.get_now",
+            return_value=event_timestamp,
+        ):
+            await send_temperature_change_event(entity, 20, event_timestamp)
+            await send_ext_temperature_change_event(entity, 10, event_timestamp)
+
+            # the regulated temperature should be greater
+            assert entity.regulated_target_temp > entity.target_temperature
+            assert (
+                entity.regulated_target_temp == 20 + 0.5
+            ) 
+
+        old_regulated_temp = entity.regulated_target_temp
+        # change temperature so that dtemp < 0.5 and time is > period_min (+ 3min)
+        event_timestamp = now - timedelta(minutes=10)
+        with patch(
+            "custom_components.versatile_thermostat.commons.NowClass.get_now",
+            return_value=event_timestamp,
+        ):
+            await send_temperature_change_event(entity, 19.6, event_timestamp)
+            await send_ext_temperature_change_event(entity, 10, event_timestamp)
+
+            # the regulated temperature should be greater. This does not work if dtemp is not null
+            assert entity.regulated_target_temp > old_regulated_temp

--- a/tests/test_auto_regulation.py
+++ b/tests/test_auto_regulation.py
@@ -646,7 +646,7 @@ async def test_over_climate_regulation_dtemp_null(
             ) 
 
         old_regulated_temp = entity.regulated_target_temp
-        # change temperature so that dtemp < 0.5 and time is > period_min (+ 3min)
+        # Test if a small temperature change is taken into account : change temperature so that dtemp < 0.5 and time is > period_min (+ 3min)
         event_timestamp = now - timedelta(minutes=10)
         with patch(
             "custom_components.versatile_thermostat.commons.NowClass.get_now",


### PR DESCRIPTION
Hi,
I use Versatile thermostat from several weeks and really appreciate it to regulate my climate devices that have a bad thermal regulation because of the position of the sensor. Thank you for your big work on this. 
I suggest a small adjustment : a behavior that prevents the system from forgetting the regulation when using the device's internal temperature as an offset.

Although the regulation itself remains unchanged, variations in the device's internal temperature necessitate adjustments to the target temperature to maintain effective regulation. This code modification specifically bypasses the forget mechanism for minor adjustments, while the forget mechanism based on duration is still maintained.

Here is an history of the underlying climate before : 
![image](https://github.com/jmcollin78/versatile_thermostat/assets/9569564/f77b2cb6-c694-4b92-a6c2-09d96fb2a273)
and after (with 2 minutes of interval which is fast) : 
![image](https://github.com/jmcollin78/versatile_thermostat/assets/9569564/95a7e679-d4e2-42f7-a428-55b254de3884)
