### PR TITLE
Change VTherm temperature unit to HA's preferred unit.

### DIFF
--- a/custom_components/versatile_thermostat/thermostat_climate.py
+++ b/custom_components/versatile_thermostat/thermostat_climate.py
@@ -207,7 +207,7 @@ class ThermostatOverClimate(BaseThermostat[UnderlyingClimate]):
                 # regulation can use the device_temp
                 self.auto_regulation_use_device_temp
                 # and we have access to the device temp
-                and (device_temp := under.underlying_current_temperature) is not None
+                and (device_temp := self._hass.states.get(under._entity_id).attributes.get("current_temperature")) is not None
                 # and target is not reach (ie we need regulation)
                 and (
                     (
@@ -900,10 +900,7 @@ class ThermostatOverClimate(BaseThermostat[UnderlyingClimate]):
     @property
     def temperature_unit(self) -> str:
         """Return the unit of measurement."""
-        if self.underlying_entity(0):
-            return self.underlying_entity(0).temperature_unit
-
-        return self._unit
+        return self.hass.config.units.temperature_unit
 
     @property
     def supported_features(self):

--- a/custom_components/versatile_thermostat/thermostat_climate.py
+++ b/custom_components/versatile_thermostat/thermostat_climate.py
@@ -207,7 +207,7 @@ class ThermostatOverClimate(BaseThermostat[UnderlyingClimate]):
                 # regulation can use the device_temp
                 self.auto_regulation_use_device_temp
                 # and we have access to the device temp
-                and (device_temp := self._hass.states.get(under._entity_id).attributes.get("current_temperature")) is not None
+                and (device_temp := under.underlying_current_temperature) is not None
                 # and target is not reach (ie we need regulation)
                 and (
                     (

--- a/custom_components/versatile_thermostat/underlyings.py
+++ b/custom_components/versatile_thermostat/underlyings.py
@@ -30,6 +30,7 @@ from homeassistant.components.number import SERVICE_SET_VALUE
 
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.event import async_call_later
+from homeassistant.util.unit_conversion import TemperatureConverter
 
 from .const import UnknownEntity, overrides
 from .keep_alive import IntervalCaller
@@ -704,7 +705,7 @@ class UnderlyingClimate(UnderlyingEntity):
         if not hasattr(self._underlying_climate, "current_temperature"):
             return None
 
-        return self._underlying_climate.current_temperature
+        return self._hass.states.get(self._entity_id).attributes.get("current_temperature")
 
     def turn_aux_heat_on(self) -> None:
         """Turn auxiliary heater on."""
@@ -731,8 +732,12 @@ class UnderlyingClimate(UnderlyingEntity):
             self._underlying_climate.min_temp is not None
             and self._underlying_climate is not None
         ):
-            min_val = self._hass.states.get(self._entity_id).attributes.get("min_temp")
-            max_val = self._hass.states.get(self._entity_id).attributes.get("max_temp")
+            min_val = TemperatureConverter.convert(
+                self._underlying_climate.min_temp, self._underlying_climate.temperature_unit, self._hass.config.units.temperature_unit
+            )
+            max_val = TemperatureConverter.convert(
+                self._underlying_climate.max_temp, self._underlying_climate.temperature_unit, self._hass.config.units.temperature_unit
+            )
 
             new_value = max(min_val, min(value, max_val))
         else:

--- a/custom_components/versatile_thermostat/underlyings.py
+++ b/custom_components/versatile_thermostat/underlyings.py
@@ -731,8 +731,8 @@ class UnderlyingClimate(UnderlyingEntity):
             self._underlying_climate.min_temp is not None
             and self._underlying_climate is not None
         ):
-            min_val = self._underlying_climate.min_temp
-            max_val = self._underlying_climate.max_temp
+            min_val = self._hass.states.get(self._entity_id).attributes.get("min_temp")
+            max_val = self._hass.states.get(self._entity_id).attributes.get("max_temp")
 
             new_value = max(min_val, min(value, max_val))
         else:

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,1 +1,1 @@
-homeassistant==2024.4.3
+homeassistant==2024.6.1


### PR DESCRIPTION
With this change, I no longer suffer from #240. 

I made 2 basic changes to the code, simplifying the changes I mentioned in #240. 

- Firstly, I changed the unit used by VTherm to match HA's preferred unit.
- Secondly, I changed the references to the underlying entity's temperatures to use HA's state references. This automatically includes HA's converted values, and should be robust against having mismatched temperature units. I propose that all references to the underlying entity use HA's state, rather than directly accessing the values from the entity.

Example:

Change: 
`max_val = self._underlying_climate.max_temp`

To:
`max_val = self._hass.states.get(self._entity_id).attributes.get("max_temp")`

This results in the correct converted value being grabbed if the underlying entity uses a different unit of temperature than HA's preferred unit. This should make no difference for those who have entities that match their HA's preferred unit. I only made the minimum changes to allow for my use case to work, but there may be other attributes that should be changed to reflect this.