### PR TITLE
Reduce keep-alive warning logs when the controlled entity becomes unavailable

### DIFF
--- a/custom_components/versatile_thermostat/keep_alive.py
+++ b/custom_components/versatile_thermostat/keep_alive.py
@@ -10,12 +10,86 @@ the keep_alive setting of Home Assistant's Generic Thermostat integration:
 import logging
 from collections.abc import Awaitable, Callable
 from datetime import timedelta, datetime
+from time import monotonic
 
 from homeassistant.core import HomeAssistant, CALLBACK_TYPE
 from homeassistant.helpers.event import async_track_time_interval
 
 
 _LOGGER = logging.getLogger(__name__)
+
+
+class BackoffTimer:
+    """Exponential backoff timer with a non-blocking polling-style implementation.
+
+    Usage example:
+        timer = BackoffTimer(multiplier=1.5, upper_limit_sec=600)
+        while some_condition:
+            if timer.is_ready():
+                do_something()
+    """
+
+    def __init__(
+        self,
+        *,
+        multiplier=2.0,
+        lower_limit_sec=30,
+        upper_limit_sec=86400,
+        initially_ready=True,
+    ):
+        """Initialize a BackoffTimer instance.
+
+        Args:
+            multiplier (int, optional): Period multiplier applied when is_ready() is True.
+            lower_limit_sec (int, optional): Initial backoff period in seconds.
+            upper_limit_sec (int, optional): Maximum backoff period in seconds.
+            initially_ready (bool, optional): Whether is_ready() should return True the
+            first time it is called, or after a call to reset().
+        """
+        self._multiplier = multiplier
+        self._lower_limit_sec = lower_limit_sec
+        self._upper_limit_sec = upper_limit_sec
+        self._initially_ready = initially_ready
+
+        self._timestamp = 0
+        self._period_sec = self._lower_limit_sec
+
+    @property
+    def in_progress(self) -> bool:
+        """Whether the backoff timer is in progress (True after a call to is_ready())."""
+        return bool(self._timestamp)
+
+    def reset(self):
+        """Reset a BackoffTimer instance."""
+        self._timestamp = 0
+        self._period_sec = self._lower_limit_sec
+
+    def is_ready(self) -> bool:
+        """Check whether an exponentially increasing period of time has passed.
+
+        Whenever is_ready() returns True, the timer period is multiplied so that
+        it takes longer until is_ready() returns True again.
+        Returns:
+            bool: True if enough time has passed since one of the following events,
+            in relation to an instance of this class:
+            - The last time when this method returned True, if it ever did.
+            - Or else, when this method was first called after a call to reset().
+            - Or else, when this method was first called.
+            False otherwise.
+        """
+        now = monotonic()
+        if self._timestamp == 0:
+            self._timestamp = now
+            return self._initially_ready
+        elif now - self._timestamp >= self._period_sec:
+            self._timestamp = now
+            self._period_sec = max(
+                self._lower_limit_sec,
+                min(self._upper_limit_sec, self._period_sec * self._multiplier),
+            )
+            return True
+
+        return False
 
 
 class IntervalCaller:
@@ -28,6 +102,7 @@ class IntervalCaller:
         self._hass = hass
         self._interval_sec = interval_sec
         self._remove_handle: CALLBACK_TYPE | None = None
+        self.backoff_timer = BackoffTimer()
 
     @property
     def interval_sec(self) -> float:


### PR DESCRIPTION
Recently I powered off a heating appliance for the summer months (it will be used again when the weather gets colder). The appliance has a MQTT switch controlled by Versatile Thermostat using a thermostat-over-switch configuration with a short keep-alive period of 15 seconds. As a result of powering it off, the Home Assistant logs got flooded with the following warning messages, logged every 15 seconds:

```
2024-06-23 02:23:05.810 WARNING (MainThread) [homeassistant.helpers.service] Referenced entities switch.my_switch are missing or not currently available
2024-06-23 02:23:20.813 WARNING (MainThread) [homeassistant.helpers.service] Referenced entities switch.my_switch are missing or not currently available
2024-06-23 02:23:35.816 WARNING (MainThread) [homeassistant.helpers.service] Referenced entities switch.my_switch are missing or not currently available
...
```

These log messages are printed by Home Assistant Core (not Versatile Thermostat directly) when Versatile Thermostat uses a Home Assistant service to request the underlying switch to be turned on or off.

These log messages are relevant and informative, but not if they flood the logs. This PR proposes a solution that consists of testing whether the underlying switch entity is available before the keep-alive feature makes a call to the turn on or turn off services. If it is unavailable, VTherm itself prints a warning message, but not too often, by using a backoff timer: After a warning message is logged, the next message is logged no sooner than 30 seconds, then 60s, 120s, 240s... capped at 86400s = 24h. This way, if the controlled switched is unavailable for 3 months of summer, the warning message will be printed a moderate number of times on the first day, then only once a day from the second day onwards. (This starts again when HASS is restarted, but I think that’s OK.) Example:

```txt
2024-06-25 16:17:39.618 WARNING (MainThread) [custom_components.versatile_thermostat.underlyings] Entity switch.my_switch is unavailable (state: None). Will keep trying keep alive calls, but won't log this condition every time.
2024-06-25 16:18:09.621 WARNING (MainThread) [custom_components.versatile_thermostat.underlyings] Entity switch.my_switch is unavailable (state: None). Will keep trying keep alive calls, but won't log this condition every time.
2024-06-25 16:19:09.626 WARNING (MainThread) [custom_components.versatile_thermostat.underlyings] Entity switch.my_switch is unavailable (state: None). Will keep trying keep alive calls, but won't log this condition every time.
...
```



