### PR TITLE
Fix Home Assistant deprecation warnings (EventType, helpers.service)

### DIFF
--- a/custom_components/versatile_thermostat/__init__.py
+++ b/custom_components/versatile_thermostat/__init__.py
@@ -13,6 +13,7 @@ from homeassistant.const import SERVICE_RELOAD, EVENT_HOMEASSISTANT_STARTED
 
 from homeassistant.config_entries import ConfigEntry, ConfigType
 from homeassistant.core import HomeAssistant, CoreState, callback
+from homeassistant.helpers.service import async_register_admin_service
 
 from .base_thermostat import BaseThermostat
 
@@ -115,7 +116,8 @@ async def async_setup(
     else:
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, _async_startup_internal)
 
-    hass.helpers.service.async_register_admin_service(
+    async_register_admin_service(
+        hass,
         DOMAIN,
         SERVICE_RELOAD,
         _handle_reload,

--- a/custom_components/versatile_thermostat/base_thermostat.py
+++ b/custom_components/versatile_thermostat/base_thermostat.py
@@ -22,7 +22,6 @@ from homeassistant.components.climate import ClimateEntity
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.device_registry import DeviceInfo, DeviceEntryType
-from homeassistant.helpers.typing import EventType as HASSEventType
 
 from homeassistant.helpers.event import (
     async_track_state_change_event,
@@ -1790,7 +1789,7 @@ class BaseThermostat(ClimateEntity, RestoreEntity, Generic[T]):
             _LOGGER.error("Unable to update external temperature from sensor: %s", ex)
 
     @callback
-    async def _async_power_changed(self, event: HASSEventType[EventStateChangedData]):
+    async def _async_power_changed(self, event: Event[EventStateChangedData]):
         """Handle power changes."""
         _LOGGER.debug("Thermostat %s - Receive new Power event", self.name)
         _LOGGER.debug(event)
@@ -1816,9 +1815,7 @@ class BaseThermostat(ClimateEntity, RestoreEntity, Generic[T]):
             _LOGGER.error("Unable to update current_power from sensor: %s", ex)
 
     @callback
-    async def _async_max_power_changed(
-        self, event: HASSEventType[EventStateChangedData]
-    ):
+    async def _async_max_power_changed(self, event: Event[EventStateChangedData]):
         """Handle power max changes."""
         _LOGGER.debug("Thermostat %s - Receive new Power Max event", self.name)
         _LOGGER.debug(event)
@@ -1843,9 +1840,7 @@ class BaseThermostat(ClimateEntity, RestoreEntity, Generic[T]):
             _LOGGER.error("Unable to update current_power from sensor: %s", ex)
 
     @callback
-    async def _async_presence_changed(
-        self, event: HASSEventType[EventStateChangedData]
-    ):
+    async def _async_presence_changed(self, event: Event[EventStateChangedData]):
         """Handle presence changes."""
         new_state = event.data.get("new_state")
         _LOGGER.info(

--- a/custom_components/versatile_thermostat/thermostat_climate.py
+++ b/custom_components/versatile_thermostat/thermostat_climate.py
@@ -3,13 +3,12 @@
 import logging
 from datetime import timedelta, datetime
 
-from homeassistant.core import HomeAssistant, State, callback
+from homeassistant.core import Event, HomeAssistant, State, callback
 from homeassistant.helpers.event import (
     async_track_state_change_event,
     async_track_time_interval,
     EventStateChangedData,
 )
-from homeassistant.helpers.typing import EventType as HASSEventType
 from homeassistant.components.climate import (
     HVACAction,
     HVACMode,
@@ -600,7 +599,7 @@ class ThermostatOverClimate(BaseThermostat[UnderlyingClimate]):
         )
 
     @callback
-    async def _async_climate_changed(self, event: HASSEventType[EventStateChangedData]):
+    async def _async_climate_changed(self, event: Event[EventStateChangedData]):
         """Handle unerdlying climate state changes.
         This method takes the underlying values and update the VTherm with them.
         To avoid loops (issues #121 #101 #95 #99), we discard the event if it is received

--- a/custom_components/versatile_thermostat/thermostat_switch.py
+++ b/custom_components/versatile_thermostat/thermostat_switch.py
@@ -2,12 +2,11 @@
 
 """ A climate over switch classe """
 import logging
-from homeassistant.core import callback
+from homeassistant.core import Event, callback
 from homeassistant.helpers.event import (
     async_track_state_change_event,
     EventStateChangedData,
 )
-from homeassistant.helpers.typing import EventType as HASSEventType
 from homeassistant.components.climate import HVACMode
 
 from .const import (
@@ -212,7 +211,7 @@ class ThermostatOverSwitch(BaseThermostat[UnderlyingSwitch]):
         )
 
     @callback
-    def _async_switch_changed(self, event: HASSEventType[EventStateChangedData]):
+    def _async_switch_changed(self, event: Event[EventStateChangedData]):
         """Handle heater switch state changes."""
         new_state = event.data.get("new_state")
         old_state = event.data.get("old_state")

--- a/custom_components/versatile_thermostat/thermostat_valve.py
+++ b/custom_components/versatile_thermostat/thermostat_valve.py
@@ -8,8 +8,7 @@ from homeassistant.helpers.event import (
     async_track_time_interval,
     EventStateChangedData,
 )
-from homeassistant.helpers.typing import EventType as HASSEventType
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.components.climate import HVACMode
 
 from .base_thermostat import BaseThermostat, ConfigData
@@ -149,7 +148,7 @@ class ThermostatOverValve(BaseThermostat[UnderlyingValve]):  # pylint: disable=a
         )
 
     @callback
-    async def _async_valve_changed(self, event: HASSEventType[EventStateChangedData]):
+    async def _async_valve_changed(self, event: Event[EventStateChangedData]):
         """Handle unerdlying valve state changes.
         This method just log the change. It changes nothing to avoid loops.
         """


### PR DESCRIPTION
This PR fixes the following log warning messages printed when Home Assistant version 2024.7.1 starts:

```
2024-07-06 10:19:21.491 WARNING (ImportExecutor_0) [homeassistant.helpers.typing] 
  EventType was used from versatile_thermostat, this is a deprecated alias which will be removed in HA Core 2025.5.
  Use homeassistant.core.Event instead, please report it to the author of the 'versatile_thermostat' custom integration
```
```
2024-07-06 10:19:21.601 WARNING (MainThread) [homeassistant.helpers.frame] 
  Detected that custom integration 'versatile_thermostat' accesses hass.helpers.service.
  This is deprecated and will stop working in Home Assistant 2024.11, it should be updated
  to import functions used from service directly at custom_components/versatile_thermostat/__init__.py,
  line 118: hass.helpers.service.async_register_admin_service(, 
  please create a bug report at https://github.com/jmcollin78/versatile_thermostat/issues
```