### PR TITLE
FIX #518 TypeError: unsupported operand type(s) for -: 'int' and 'NoneType'

### DIFF
--- a/custom_components/versatile_thermostat/thermostat_climate.py
+++ b/custom_components/versatile_thermostat/thermostat_climate.py
@@ -692,8 +692,9 @@ class ThermostatOverClimate(BaseThermostat[UnderlyingClimate]):
             else None
         )
 
+        last_sent_temperature = under.last_sent_temperature or 0
         under_temp_diff = (
-            (new_target_temp - under.last_sent_temperature) if new_target_temp else 0
+            (new_target_temp - last_sent_temperature) if new_target_temp else 0
         )
         if -1 < under_temp_diff < 1:
             under_temp_diff = 0


### PR DESCRIPTION
FIX #518 TypeError: unsupported operand type(s) for -: 'int' and 'NoneType'