### PR TITLE
Filter out-of-range target temperature sent from underlying climate devices

### DIFF
--- a/custom_components/versatile_thermostat/thermostat_climate.py
+++ b/custom_components/versatile_thermostat/thermostat_climate.py
@@ -719,6 +719,22 @@ class ThermostatOverClimate(BaseThermostat[UnderlyingClimate]):
             )
             return
 
+        # Forget event when the new target temperature is out of range
+        if (
+            not new_target_temp is None
+            and not self._attr_min_temp is None
+            and not self._attr_max_temp is None
+            and (new_target_temp < self._attr_min_temp or new_target_temp > self._attr_max_temp)
+        ):
+            _LOGGER.debug(
+                "%s - underlying sent a target temperature (%s) which is out of configured min/max range (%s / %s). The value will be ignored",
+                self,
+                new_target_temp,
+                self._attr_min_temp,
+                self._attr_max_temp,
+            )
+            return
+
         # A real changes have to be managed
         _LOGGER.info(
             "%s - Underlying climate %s have changed. new_hvac_mode is %s (vs %s), new_hvac_action=%s (vs %s), new_target_temp=%s (vs %s), new_fan_mode=%s (vs %s)",

--- a/custom_components/versatile_thermostat/thermostat_climate.py
+++ b/custom_components/versatile_thermostat/thermostat_climate.py
@@ -724,7 +724,7 @@ class ThermostatOverClimate(BaseThermostat[UnderlyingClimate]):
             not new_target_temp is None
             and not self._attr_min_temp is None
             and not self._attr_max_temp is None
-            and (new_target_temp < self._attr_min_temp or new_target_temp > self._attr_max_temp)
+            and not (self._attr_min_temp <= new_target_temp <= self._attr_max_temp)
         ):
             _LOGGER.debug(
                 "%s - underlying sent a target temperature (%s) which is out of configured min/max range (%s / %s). The value will be ignored",


### PR DESCRIPTION
My initial goal was to filter out stupid data from my Bosch BTH-RA thermostat. But this change makes also sense in the grand scheme of things, because it unifies the user experience. It doesn't matter whether you change the target temperature via the HA frontend or directly with an underlying, min and max are considered in both scenarios.

At the moment there are no unit tests, as I still have to figure out how to create one for this scenario, but I will try to do that in the next days.

This implements #576.