### PR TITLE
Fix side effect of out-of-range temperature filtering

### DIFF
--- a/custom_components/versatile_thermostat/thermostat_climate.py
+++ b/custom_components/versatile_thermostat/thermostat_climate.py
@@ -725,7 +725,7 @@ class ThermostatOverClimate(BaseThermostat[UnderlyingClimate]):
             )
             return
 
-        # Forget event when the new target temperature is out of range
+        # Ignore new target temperature when out of range
         if (
             not new_target_temp is None
             and not self._attr_min_temp is None
@@ -739,7 +739,8 @@ class ThermostatOverClimate(BaseThermostat[UnderlyingClimate]):
                 self._attr_min_temp,
                 self._attr_max_temp,
             )
-            return
+            new_target_temp = None
+            under_temp_diff = 0
 
         # A real changes have to be managed
         _LOGGER.info(


### PR DESCRIPTION
At the moment if a change event from an underlying has an out-of-range temperature, then the whole event is ignored. However this can lead to inconsisent states as relevant changes from the underlying might be ignored, i.e. `hvac_action`.

In this case the underlying will be in state `off/idle`, while the vtherm will stay in state `off/heating`. This will resolve itself eventually when another type of event comes in, e.g. from a temperature sensor. But until then it is confusing and annoying.

With this change just the detected target temperature change is filtered out, the other fields of the new underlying state can still be processed.

I'll add or change an unit test to cover this case, but won't have time for it until tonight. So please don't merge yet :smiley: 