### PR TITLE
fix for 'It's not possible to set regulation mode to Expert using Automations'

### DIFF
--- a/custom_components/versatile_thermostat/climate.py
+++ b/custom_components/versatile_thermostat/climate.py
@@ -118,7 +118,7 @@ async def async_setup_entry(
         SERVICE_SET_AUTO_REGULATION_MODE,
         {
             vol.Required("auto_regulation_mode"): vol.In(
-                ["None", "Light", "Medium", "Strong", "Slow"]
+                ["None", "Light", "Medium", "Strong", "Slow", "Expert"]
             ),
         },
         "service_set_auto_regulation_mode",


### PR DESCRIPTION
Fix for https://github.com/jmcollin78/versatile_thermostat/issues/717

`'Failed to perform the action versatile_thermostat.set_auto_regulation_mode. value must be one of ['Light', 'Medium', 'None', 'Slow', 'Strong'] for dictionary value @ data['auto_regulation_mode']. Got None'`
