### PR TITLE
issue #733 - VTherm over_climate not following TRV device setpoint when step if < 1

### DIFF
--- a/custom_components/versatile_thermostat/thermostat_climate.py
+++ b/custom_components/versatile_thermostat/thermostat_climate.py
@@ -709,7 +709,9 @@ class ThermostatOverClimate(BaseThermostat[UnderlyingClimate]):
         under_temp_diff = (
             (new_target_temp - last_sent_temperature) if new_target_temp else 0
         )
-        if -1 < under_temp_diff < 1:
+
+        step = self.target_temperature_step or 1
+        if -step < under_temp_diff < step:
             under_temp_diff = 0
 
         # Issue 99 - some AC turn hvac_mode=cool and hvac_action=idle when sending a HVACMode_OFF command

--- a/tests/test_overclimate.py
+++ b/tests/test_overclimate.py
@@ -323,7 +323,7 @@ async def test_underlying_change_follow(
         assert entity.target_temperature == entity.min_temp + 1
         assert entity.preset_mode is PRESET_NONE
 
-        # 4. Change the target temp with < 1 value. The value should not be taken
+        # 4. Change the target temp with < 0.1 (step) value. The value should not be taken
         # Wait 11 sec
         event_timestamp = now + timedelta(seconds=11)
         await send_climate_change_event_with_temperature(
@@ -333,7 +333,7 @@ async def test_underlying_change_follow(
             HVACAction.OFF,
             HVACAction.OFF,
             event_timestamp,
-            entity.min_temp + 1.5,
+            entity.min_temp + 1.09,
             True,
             "climate.mock_climate",  # the underlying climate entity id
         )


### PR DESCRIPTION
issue #733 - VTherm over_climate not following TRV device setpoint when step if < 1