### PR TITLE
Change percent_open calculation method

### DIFF
--- a/custom_components/versatile_thermostat/underlyings.py
+++ b/custom_components/versatile_thermostat/underlyings.py
@@ -1080,9 +1080,15 @@ class UnderlyingValveRegulation(UnderlyingValve):
             )
             return
 
-        # Send opening_degree
-        if 0 < self._percent_open < self._min_opening_degree:
-            self._percent_open = self._min_opening_degree
+        # Caclulate opening_degree
+        if self._percent_open >= 1:
+            self._percent_open = round(self._min_opening_degree + (self._percent_open * (100 - self._min_opening_degree) / 100))
+        else:
+            self._percent_open = 0
+
+#        # Send opening_degree
+#        if 0 < self._percent_open < self._min_opening_degree:
+#            self._percent_open = self._min_opening_degree
 
         await super().send_percent_open()
 

--- a/custom_components/versatile_thermostat/underlyings.py
+++ b/custom_components/versatile_thermostat/underlyings.py
@@ -1082,13 +1082,13 @@ class UnderlyingValveRegulation(UnderlyingValve):
 
         # Caclulate opening_degree
         if self._percent_open >= 1:
-            self._percent_open = round(self._min_opening_degree + (self._percent_open * (100 - self._min_opening_degree) / 100))
+            self._percent_open = round(
+                self._min_opening_degree
+                + (self._percent_open
+                   * (100 - self._min_opening_degree) / 100)
+                )
         else:
             self._percent_open = 0
-
-#        # Send opening_degree
-#        if 0 < self._percent_open < self._min_opening_degree:
-#            self._percent_open = self._min_opening_degree
 
         await super().send_percent_open()
 

--- a/custom_components/versatile_thermostat/underlyings.py
+++ b/custom_components/versatile_thermostat/underlyings.py
@@ -1080,7 +1080,7 @@ class UnderlyingValveRegulation(UnderlyingValve):
             )
             return
 
-        # Caclulate opening_degree
+        # Caclulate percent_open
         if self._percent_open >= 1:
             self._percent_open = round(
                 self._min_opening_degree
@@ -1090,6 +1090,7 @@ class UnderlyingValveRegulation(UnderlyingValve):
         else:
             self._percent_open = 0
 
+        # Send opening_degree
         await super().send_percent_open()
 
         # Send closing_degree if set

--- a/tests/test_overclimate_valve.py
+++ b/tests/test_overclimate_valve.py
@@ -627,11 +627,11 @@ async def test_over_climate_valve_multi_min_opening_degrees(
         assert mock_service_call.call_count == 6
         mock_service_call.assert_has_calls([
             # min is 60
-            call(domain='number', service='set_value', service_data={'value': 60}, target={'entity_id': 'number.mock_opening_degree1'}),
-            call(domain='number', service='set_value', service_data={'value': 40}, target={'entity_id': 'number.mock_closing_degree1'}),
+            call(domain='number', service='set_value', service_data={'value': 68}, target={'entity_id': 'number.mock_opening_degree1'}),
+            call(domain='number', service='set_value', service_data={'value': 32}, target={'entity_id': 'number.mock_closing_degree1'}),
             call(domain='number', service='set_value', service_data={'value': 3.0}, target={'entity_id': 'number.mock_offset_calibration1'}),
-            call(domain='number', service='set_value', service_data={'value': 70}, target={'entity_id': 'number.mock_opening_degree2'}),
-            call(domain='number', service='set_value', service_data={'value': 30}, target={'entity_id': 'number.mock_closing_degree2'}),
+            call(domain='number', service='set_value', service_data={'value': 76}, target={'entity_id': 'number.mock_opening_degree2'}),
+            call(domain='number', service='set_value', service_data={'value': 24}, target={'entity_id': 'number.mock_closing_degree2'}),
             call(domain='number', service='set_value', service_data={'value': 12}, target={'entity_id': 'number.mock_offset_calibration2'})
             ]
         )


### PR DESCRIPTION
Modified 'percent_open' calculation method :

  - Before : If percent_open < min_opening_degree then it is set to min_opening_degree
  - Now : Each % step is calculated (100 - min_opening_degree)/100 so 1% ~> min_opening_degree

Sample :

  - Before :
    min_opening_degree = 15, percent calculated = 1, percent_open = 15
    min_opening_degree = 15, percent calculated = 5, percent_open = 15

  - Now :
    min_opening_degree = 15, percent calculated = 1, percent open = round(15.85)
    min_opening_degree = 15, percent calculated = 5, percent open = round(19.25)