### PR TITLE
Allow `coef_ext` values with up to three decimals precision

### DIFF
--- a/custom_components/versatile_thermostat/config_schema.py
+++ b/custom_components/versatile_thermostat/config_schema.py
@@ -232,7 +232,7 @@ STEP_TPI_DATA_SCHEMA = vol.Schema(  # pylint: disable=invalid-name
 STEP_CENTRAL_TPI_DATA_SCHEMA = vol.Schema(  # pylint: disable=invalid-name
     {
         vol.Required(CONF_TPI_COEF_INT, default=0.6): selector.NumberSelector(selector.NumberSelectorConfig(min=0.0, max=1.0, step=0.01, mode=selector.NumberSelectorMode.BOX)),
-        vol.Required(CONF_TPI_COEF_EXT, default=0.01): selector.NumberSelector(selector.NumberSelectorConfig(min=0.0, max=1.0, mode=selector.NumberSelectorMode.BOX)),
+        vol.Required(CONF_TPI_COEF_EXT, default=0.01): selector.NumberSelector(selector.NumberSelectorConfig(min=0.0, max=1.0, step=0.001, mode=selector.NumberSelectorMode.BOX)),
     }
 )
 


### PR DESCRIPTION
This is a friendly suggestion for improving the `coef_ext` input field.

When setting my own heating, I realised that the permitted step size of `0.01` is too coarse for me. A value of 0.01 leads to the temperature being too low and 0.02 to it being too high. But it is not possible to enter a value in between! I had to use my browser's developer tools to hack the step-size attribute of the input field and after some trial and error ended up with 0.016 as my ideal value.

This change aims to fix this shortcoming by setting the step size to `0.001` and thus allowing more precise numbers. 