### PR TITLE
`hvac_off_reason` could stay at `auto_start_stop` when the VTherm is 'on' (hvac_mode=Heat)

### DIFF
--- a/custom_components/versatile_thermostat/feature_auto_start_stop_manager.py
+++ b/custom_components/versatile_thermostat/feature_auto_start_stop_manager.py
@@ -70,6 +70,10 @@ class FeatureAutoStartStopManager(BaseFeatureManager):
             self._auto_start_stop_level, self.name
         )
 
+        # Fix an eventual incoherent state
+        if self._vtherm.is_on and self._vtherm.hvac_off_reason == HVAC_OFF_REASON_AUTO_START_STOP:
+            self._vtherm.hvac_off_reason = None
+
     @overrides
     async def start_listening(self):
         """Start listening the underlying entity"""


### PR DESCRIPTION
Fixes #828 - `hvac_off_reason` could stay at `auto_start_stop` when the VTherm is 'on' (hvac_mode=Heat)