### PR TITLE
Windows Bypass not checked

### DIFF
--- a/custom_components/versatile_thermostat/feature_window_manager.py
+++ b/custom_components/versatile_thermostat/feature_window_manager.py
@@ -504,10 +504,10 @@ class FeatureWindowManager(BaseFeatureManager):
 
     @property
     def is_window_detected(self) -> bool:
-        """Return true if the presence is configured and presence sensor is OFF"""
+        """Return true if the window is configured and open and bypass is not ON"""
         return self._is_configured and (
             self._window_state == STATE_ON or self._window_auto_state == STATE_ON
-        )
+        ) and not self._is_window_bypass
 
     @property
     def window_sensor_entity_id(self) -> bool:


### PR DESCRIPTION
Hello,

Il semblerait que le window_bypass n'est pas checké par la fonction permettant de retourner l'état des fenêtres.
Par conséquent, lors d'un changement de température alors que la fenêtre est ouverte il n'est pas exécuter .

J'en ai profiter pour changer la description de la fonction qui était un copier-coller.

Bonne journée,
