### PR TITLE
feat: allow NUMBER_DOMAIN for temp sensor

### DIFF
--- a/custom_components/versatile_thermostat/config_schema.py
+++ b/custom_components/versatile_thermostat/config_schema.py
@@ -52,10 +52,10 @@ STEP_MAIN_DATA_SCHEMA = vol.Schema(  # pylint: disable=invalid-name
     {
         vol.Required(CONF_NAME): cv.string,
         vol.Required(CONF_TEMP_SENSOR): selector.EntitySelector(
-            selector.EntitySelectorConfig(domain=[SENSOR_DOMAIN, INPUT_NUMBER_DOMAIN]),
+            selector.EntitySelectorConfig(domain=[SENSOR_DOMAIN, INPUT_NUMBER_DOMAIN, NUMBER_DOMAIN]),
         ),
         vol.Optional(CONF_LAST_SEEN_TEMP_SENSOR): selector.EntitySelector(
-            selector.EntitySelectorConfig(domain=[SENSOR_DOMAIN, INPUT_DATETIME_DOMAIN]),
+            selector.EntitySelectorConfig(domain=[SENSOR_DOMAIN, INPUT_DATETIME_DOMAIN, NUMBER_DOMAIN]),
         ),
         vol.Required(CONF_CYCLE_MIN, default=5): selector.NumberSelector(selector.NumberSelectorConfig(min=1, max=1000, step=1, mode=selector.NumberSelectorMode.BOX)),
         vol.Optional(CONF_DEVICE_POWER, default="1"): vol.Coerce(float),


### PR DESCRIPTION
Hello, here is a pr to allow NUMBER_DOMAIN for temp sensor, I'm using z2m with mqtt and the temp of my valve belongs to domain number.