### PR TITLE
Add entity_category for all entities except climate

### DIFF
--- a/custom_components/versatile_thermostat/base_entity.py
+++ b/custom_components/versatile_thermostat/base_entity.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 from homeassistant.core import HomeAssistant, callback, Event
 from homeassistant.components.climate import ClimateEntity
 from homeassistant.components.climate.const import DOMAIN as CLIMATE_DOMAIN
+from homeassistant.const import EntityCategory
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.device_registry import DeviceInfo, DeviceEntryType
@@ -31,6 +32,7 @@ class VersatileThermostatBaseEntity(Entity):
         self.hass = hass
         self._config_id = config_id
         self._device_name = device_name
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._my_climate = None
         self._cancel_call = None
         self._attr_has_entity_name = True

--- a/custom_components/versatile_thermostat/number.py
+++ b/custom_components/versatile_thermostat/number.py
@@ -4,6 +4,7 @@
 import logging
 
 # from homeassistant.const import EVENT_HOMEASSISTANT_START
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, CoreState  # , callback
 
 from homeassistant.components.number import (
@@ -386,6 +387,7 @@ class TemperatureNumber(  # pylint: disable=abstract-method
 
         self._attr_unique_id = f"{self._device_name}_preset_{preset_name}"
         self._attr_device_class = NumberDeviceClass.TEMPERATURE
+        self._attr_entity_category = EntityCategory.CONFIG
         self._attr_native_unit_of_measurement = hass.config.units.temperature_unit
 
         self._has_central_main_attributes = entry_infos.get(

--- a/custom_components/versatile_thermostat/switch.py
+++ b/custom_components/versatile_thermostat/switch.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from homeassistant.core import HomeAssistant, callback
 
+from homeassistant.const import EntityCategory
 from homeassistant.components.switch import SwitchEntity
 
 from homeassistant.config_entries import ConfigEntry
@@ -55,6 +56,7 @@ class AutoStartStopEnable(VersatileThermostatBaseEntity, SwitchEntity, RestoreEn
         super().__init__(hass, unique_id, name)
         self._attr_name = "Enable auto start/stop"
         self._attr_unique_id = f"{self._device_name}_enable_auto_start_stop"
+        self._attr_entity_category = EntityCategory.CONFIG
         self._default_value = (
             entry_infos.data.get(CONF_AUTO_START_STOP_LEVEL)
             != AUTO_START_STOP_LEVEL_NONE
@@ -125,6 +127,7 @@ class FollowUnderlyingTemperatureChange(
         self._attr_name = "Follow underlying temp change"
         self._attr_unique_id = f"{self._device_name}_follow_underlying_temp_change"
         self._attr_is_on = False
+        self._attr_entity_category = EntityCategory.CONFIG
 
     @property
     def icon(self) -> str | None:


### PR DESCRIPTION
This assumes that in general all non climate entities are either DIAGNOSTIC or in the case of numbers and switches CONFIG entities, as the category is set in the custom base classes.

I have applied the patch to my own installation, but some more testing might be required. I do not know if the current approach by setting this in the base class is the best, but as only the climate entities should be primary this would ensure all relevant entities are affected.


Closes #1080 