### PR TITLE
Disable last temperature date sensors by default

### DIFF
--- a/custom_components/versatile_thermostat/sensor.py
+++ b/custom_components/versatile_thermostat/sensor.py
@@ -439,6 +439,7 @@ class LastTemperatureSensor(VersatileThermostatBaseEntity, SensorEntity):
         """Initialize the last temperature datetime sensor"""
         super().__init__(hass, unique_id, entry_infos.get(CONF_NAME))
         self._attr_name = "Last temperature date"
+        self._attr_entity_registry_enabled_default = False
         self._attr_unique_id = f"{self._device_name}_last_temp_datetime"
 
     @callback
@@ -468,6 +469,7 @@ class LastExtTemperatureSensor(VersatileThermostatBaseEntity, SensorEntity):
         """Initialize the last temperature datetime sensor"""
         super().__init__(hass, unique_id, entry_infos.get(CONF_NAME))
         self._attr_name = "Last external temperature date"
+        self._attr_entity_registry_enabled_default = False
         self._attr_unique_id = f"{self._device_name}_last_ext_temp_datetime"
 
     @callback


### PR DESCRIPTION
This sensors are prone to update very frequently, as per https://developers.home-assistant.io/docs/core/entity/#registry-properties set them to disabled by default.