### PR TITLE
Allow dev container to run in Windows

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,16 +5,16 @@
         "dockerfile": "Dockerfile"
     },
     "name": "Versatile Thermostat integration",
-    "appPort": ["8123:8123"],
+    "appPort": [
+        "8123:8123"
+    ],
     // "postCreateCommand": "container install",
     "postCreateCommand": "./container dev-setup",
-
     "mounts": [
-        "source=${localEnv:HOME}/.ssh,target=/home/vscode/.ssh,type=bind,consistency=cached",
+        "source=${localEnv:HOME}${localEnv:USERPROFILE}/.ssh,target=/home/vscode/.ssh,type=bind,consistency=cached",
         // uncomment this to get the versatile-thermostat-ui-card
-        "source=${localEnv:HOME}/SugarSync/Projets/home-assistant/versatile-thermostat-ui-card/dist,target=/workspaces/versatile_thermostat/config/www/community/versatile-thermostat-ui-card,type=bind,consistency=cached"
+        //"source=${localEnv:HOME}/SugarSync/Projets/home-assistant/versatile-thermostat-ui-card/dist,target=/workspaces/versatile_thermostat/config/www/community/versatile-thermostat-ui-card,type=bind,consistency=cached"
     ],
-
     "customizations": {
         "vscode": {
             "extensions": [
@@ -56,7 +56,10 @@
                 "python.analysis.autoSearchPaths": true,
                 "pylint.lintOnChange": false,
                 "python.formatting.provider": "black",
-                "python.formatting.blackArgs": ["--line-length", "180"],
+                "python.formatting.blackArgs": [
+                    "--line-length",
+                    "180"
+                ],
                 "python.formatting.blackPath": "/usr/local/py-utils/bin/black",
                 "editor.formatOnPaste": false,
                 "editor.formatOnSave": true,

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
Fix for https://github.com/jmcollin78/versatile_thermostat/issues/1285

- The mount source=${localEnv:HOME}/.ssh does not exist in Windows environments
=> Use the concatenation of the Unix environment variable and the Windows one. Since the other one will be empty, it will yield the correct home variable for both OS (see https://code.visualstudio.com/remote/advancedcontainers/add-local-file-mount)

- The line ending is different in Windows and Unix systems, and the container file is not an executable when run from Windows.
=> Use a .gitattributes file to force the lf ending in text files, even on Windows systems (see https://code.visualstudio.com/docs/devcontainers/tips-and-tricks#_resolving-git-line-ending-issues-in-containers-resulting-in-many-modified-files).
