### PR TITLE
fix warning when centralboiler is not configured 

### DIFF
--- a/custom_components/versatile_thermostat/feature_central_boiler_manager.py
+++ b/custom_components/versatile_thermostat/feature_central_boiler_manager.py
@@ -301,12 +301,19 @@ class FeatureCentralBoilerManager(BaseFeatureManager):
 
         old_ready = self._is_ready
         self._is_ready = self.is_configured and len(self._all_boiler_entities) == 4 and self._central_boiler_entity is not None
-        if not self._is_ready:
+        if not self._is_ready and self.is_configured:
             _LOGGER.warning(
                 "%s - central boiler manager is not fully configured. Found only %d/4 entities and central boiler entity=%s. Central boiler control will not work properly. This could a temporary message at startup.",
                 self,
                 len(self._all_boiler_entities),
                 self._central_boiler_entity,
+            )
+            return []
+        if not self._is_ready and not self.is_configured:
+            # Silence warning if the feature is not configured (user doesn't want it)
+            _LOGGER.debug(
+                "%s - central boiler manager is not configured. Ignoring initialization.",
+                self,
             )
             return []
         if self._is_ready != old_ready and self._central_boiler_entity:

--- a/custom_components/versatile_thermostat/prop_algorithm.py
+++ b/custom_components/versatile_thermostat/prop_algorithm.py
@@ -143,7 +143,7 @@ class PropAlgorithm:
                 if self._function == PROPORTIONAL_FUNCTION_TPI and hvac_mode not in [VThermHvacMode_OFF, VThermHvacMode_SLEEP]:
                     self._calculated_on_percent = self._tpi_coef_int * delta_temp + self._tpi_coef_ext * delta_ext_temp
                 else:
-                    _LOGGER.warning(
+                    _LOGGER.debug(
                         "%s - Proportional algorithm: VTherm is off or unknown %s function. Heating will be disabled",
                         self._vtherm_entity_id,
                         self._function,


### PR DESCRIPTION
Starting HA gives this warning even when centralBoilerManager is not used:

`FeatureCentralBoilerManager-None - central boiler manager is not fully configured. Found only 0/4 entities and central boiler entity=None. Central boiler control will not work properly. This could a temporary message at startup.`
