### PR TITLE
Revert "Use unique_id to generate _attr_unique_id"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,3 @@ custom_components/localtuya
 
 .coverage
 htmlcov
-
-.idea/
-

--- a/custom_components/versatile_thermostat/__init__.py
+++ b/custom_components/versatile_thermostat/__init__.py
@@ -9,7 +9,7 @@ import logging
 import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 
-from homeassistant.const import SERVICE_RELOAD, EVENT_HOMEASSISTANT_STARTED, CONF_NAME
+from homeassistant.const import SERVICE_RELOAD, EVENT_HOMEASSISTANT_STARTED
 
 from homeassistant.config_entries import ConfigEntry, ConfigType
 from homeassistant.core import HomeAssistant, CoreState, callback
@@ -58,7 +58,6 @@ from .const import (
     CONF_THERMOSTAT_CLIMATE,
     CONF_THERMOSTAT_VALVE,
     CONF_MAX_ON_PERCENT,
-    CONF_UNIQUE_ATTR_ID,
 )
 
 from .vtherm_api import VersatileThermostatAPI
@@ -237,9 +236,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
 
         thermostat_type = config_entry.data.get(CONF_THERMOSTAT_TYPE)
 
-        old_version = config_entry.version * 100 + config_entry.minor_version
-
-        if old_version < 201 and thermostat_type == CONF_THERMOSTAT_CENTRAL_CONFIG:
+        if thermostat_type == CONF_THERMOSTAT_CENTRAL_CONFIG:
             new[CONF_USE_WINDOW_FEATURE] = True
             new[CONF_USE_MOTION_FEATURE] = True
             new[CONF_USE_POWER_FEATURE] = new.get(CONF_POWER_SENSOR, None) is not None
@@ -297,7 +294,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
 
             # Migration 2.0 to 2.1 -> rename security parameters into safety
 
-        if old_version < 201:
+        if config_entry.version == CONFIG_VERSION and config_entry.minor_version == 0:
             for key in [
                 "security_delay_min",
                 "security_min_on_percent",
@@ -308,9 +305,6 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
                 if old_value is not None:
                     new[new_key] = old_value
                 new.pop(key, None)
-
-        if old_version < 202:
-            new[CONF_UNIQUE_ATTR_ID] = config_entry.data.get(CONF_NAME)
 
         hass.config_entries.async_update_entry(
             config_entry,

--- a/custom_components/versatile_thermostat/binary_sensor.py
+++ b/custom_components/versatile_thermostat/binary_sensor.py
@@ -37,7 +37,6 @@ from .const import (
     CONF_USE_CENTRAL_BOILER_FEATURE,
     overrides,
     EventType,
-    gen_attr_uniq_id,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -98,7 +97,7 @@ class SafetyBinarySensor(VersatileThermostatBaseEntity, BinarySensorEntity):
         """Initialize the SafetyState Binary sensor"""
         super().__init__(hass, unique_id, name)
         self._attr_name = "Safety state"
-        self._attr_unique_id = gen_attr_uniq_id(unique_id, entry_infos, "safety_state")
+        self._attr_unique_id = f"{self._device_name}_safety_state"
         self._attr_is_on = False
 
     @callback
@@ -137,7 +136,7 @@ class OverpoweringBinarySensor(VersatileThermostatBaseEntity, BinarySensorEntity
         """Initialize the OverpoweringState Binary sensor"""
         super().__init__(hass, unique_id, entry_infos.get(CONF_NAME))
         self._attr_name = "Overpowering state"
-        self._attr_unique_id = gen_attr_uniq_id(unique_id, entry_infos, "overpowering_state")
+        self._attr_unique_id = f"{self._device_name}_overpowering_state"
         self._attr_is_on = False
 
     @callback
@@ -176,7 +175,7 @@ class WindowBinarySensor(VersatileThermostatBaseEntity, BinarySensorEntity):
         """Initialize the WindowState Binary sensor"""
         super().__init__(hass, unique_id, entry_infos.get(CONF_NAME))
         self._attr_name = "Window state"
-        self._attr_unique_id = gen_attr_uniq_id(unique_id, entry_infos, "window_state")
+        self._attr_unique_id = f"{self._device_name}_window_state"
         self._attr_is_on = False
 
     @callback
@@ -226,7 +225,7 @@ class MotionBinarySensor(VersatileThermostatBaseEntity, BinarySensorEntity):
         """Initialize the MotionState Binary sensor"""
         super().__init__(hass, unique_id, entry_infos.get(CONF_NAME))
         self._attr_name = "Motion state"
-        self._attr_unique_id = gen_attr_uniq_id(unique_id, entry_infos, "motion_state")
+        self._attr_unique_id = f"{self._device_name}_motion_state"
         self._attr_is_on = False
 
     @callback
@@ -266,7 +265,7 @@ class PresenceBinarySensor(VersatileThermostatBaseEntity, BinarySensorEntity):
         """Initialize the PresenceState Binary sensor"""
         super().__init__(hass, unique_id, entry_infos.get(CONF_NAME))
         self._attr_name = "Presence state"
-        self._attr_unique_id = gen_attr_uniq_id(unique_id, entry_infos, "presence_state")
+        self._attr_unique_id = f"{self._device_name}_presence_state"
         self._attr_is_on = False
 
     @callback
@@ -307,7 +306,7 @@ class WindowByPassBinarySensor(VersatileThermostatBaseEntity, BinarySensorEntity
         """Initialize the WindowByPass Binary sensor"""
         super().__init__(hass, unique_id, entry_infos.get(CONF_NAME))
         self._attr_name = "Window bypass"
-        self._attr_unique_id = gen_attr_uniq_id(unique_id, entry_infos, "window_bypass_state")
+        self._attr_unique_id = f"{self._device_name}_window_bypass_state"
         self._attr_is_on = False
 
     @callback

--- a/custom_components/versatile_thermostat/const.py
+++ b/custom_components/versatile_thermostat/const.py
@@ -38,7 +38,7 @@ from .vtherm_state import VThermState  # pylint: disable=unused-import
 _LOGGER = logging.getLogger(__name__)
 
 CONFIG_VERSION = 2
-CONFIG_MINOR_VERSION = 2
+CONFIG_MINOR_VERSION = 1
 
 DEVICE_MANUFACTURER = "JMCOLLIN"
 DEVICE_MODEL = "Versatile Thermostat"
@@ -172,8 +172,6 @@ CONF_CENTRAL_BOILER_ACTIVATION_DELAY_SEC = "central_boiler_activation_delay_sec"
 
 CONF_USED_BY_CENTRAL_BOILER = "used_by_controls_central_boiler"
 CONF_WINDOW_ACTION = "window_action"
-
-CONF_UNIQUE_ATTR_ID = "unique_attr_id"
 
 CONF_AUTO_START_STOP_LEVEL = "auto_start_stop_level"
 AUTO_START_STOP_LEVEL_NONE = "auto_start_stop_none"
@@ -552,12 +550,6 @@ def get_tz(hass: HomeAssistant):
     """Get the current timezone"""
 
     return dt_util.get_time_zone(hass.config.time_zone)
-
-
-def gen_attr_uniq_id(unique_id: str, data: dict, suffix: str):
-    """Returns attr_uniq_id based on specified unique_id and entry data"""
-    prefix = data.get(CONF_UNIQUE_ATTR_ID, unique_id)
-    return f"{prefix}_{suffix}"
 
 
 class NowClass:

--- a/custom_components/versatile_thermostat/number.py
+++ b/custom_components/versatile_thermostat/number.py
@@ -43,7 +43,6 @@ from .const import (
     CONF_USE_PRESENCE_FEATURE,
     CONF_USE_CENTRAL_BOILER_FEATURE,
     overrides,
-    gen_attr_uniq_id,
     CONF_USE_MAIN_CENTRAL_CONFIG,
 )
 
@@ -434,7 +433,7 @@ class TemperatureNumber(  # pylint: disable=abstract-method
         self._attr_translation_key = preset_name
         self.entity_id = f"{NUMBER_DOMAIN}.{slugify(name)}_preset_{preset_name}"
 
-        self._attr_unique_id = gen_attr_uniq_id(unique_id, entry_infos, f"_preset_{preset_name}")
+        self._attr_unique_id = f"{self._device_name}_preset_{preset_name}"
         self._attr_device_class = NumberDeviceClass.TEMPERATURE
         self._attr_entity_category = EntityCategory.CONFIG
         self._attr_native_unit_of_measurement = hass.config.units.temperature_unit

--- a/custom_components/versatile_thermostat/sensor.py
+++ b/custom_components/versatile_thermostat/sensor.py
@@ -51,7 +51,6 @@ from .const import (
     CONF_AUTO_REGULATION_VALVE,
     CONF_AUTO_REGULATION_MODE,
     overrides,
-    gen_attr_uniq_id,
 )
 
 THRESHOLD_WATT_KILO = 100
@@ -129,7 +128,7 @@ class EnergySensor(VersatileThermostatBaseEntity, SensorEntity):
         """Initialize the energy sensor"""
         super().__init__(hass, unique_id, entry_infos.get(CONF_NAME))
         self._attr_name = "Energy"
-        self._attr_unique_id = gen_attr_uniq_id(unique_id, entry_infos, "energy")
+        self._attr_unique_id = f"{self._device_name}_energy"
 
     @callback
     async def async_my_climate_changed(self, event: Event = None):
@@ -184,7 +183,7 @@ class MeanPowerSensor(VersatileThermostatBaseEntity, SensorEntity):
         """Initialize the energy sensor"""
         super().__init__(hass, unique_id, entry_infos.get(CONF_NAME))
         self._attr_name = "Mean power cycle"
-        self._attr_unique_id = gen_attr_uniq_id(unique_id, entry_infos, "mean_power_cycle")
+        self._attr_unique_id = f"{self._device_name}_mean_power_cycle"
 
     @callback
     async def async_my_climate_changed(self, event: Event = None):
@@ -242,7 +241,7 @@ class OnPercentSensor(VersatileThermostatBaseEntity, SensorEntity):
         """Initialize the energy sensor"""
         super().__init__(hass, unique_id, entry_infos.get(CONF_NAME))
         self._attr_name = "Power percent"
-        self._attr_unique_id = gen_attr_uniq_id(unique_id, entry_infos, "power_percent")
+        self._attr_unique_id = f"{self._device_name}_power_percent"
 
     @callback
     async def async_my_climate_changed(self, event: Event = None):
@@ -297,7 +296,7 @@ class ValveOpenPercentSensor(VersatileThermostatBaseEntity, SensorEntity):
         """Initialize the energy sensor"""
         super().__init__(hass, unique_id, entry_infos.get(CONF_NAME))
         self._attr_name = "Valve open percent"
-        self._attr_unique_id = gen_attr_uniq_id(unique_id, entry_infos, "valve_open_percent")
+        self._attr_unique_id = f"{self._device_name}_valve_open_percent"
 
     @callback
     async def async_my_climate_changed(self, event: Event = None):
@@ -343,7 +342,7 @@ class OnTimeSensor(VersatileThermostatBaseEntity, SensorEntity):
         """Initialize the energy sensor"""
         super().__init__(hass, unique_id, entry_infos.get(CONF_NAME))
         self._attr_name = "On time"
-        self._attr_unique_id = gen_attr_uniq_id(unique_id, entry_infos, "on_time")
+        self._attr_unique_id = f"{self._device_name}_on_time"
 
     @callback
     async def async_my_climate_changed(self, event: Event = None):
@@ -392,7 +391,7 @@ class OffTimeSensor(VersatileThermostatBaseEntity, SensorEntity):
         """Initialize the energy sensor"""
         super().__init__(hass, unique_id, entry_infos.get(CONF_NAME))
         self._attr_name = "Off time"
-        self._attr_unique_id = gen_attr_uniq_id(unique_id, entry_infos, "off_time")
+        self._attr_unique_id = f"{self._device_name}_off_time"
 
     @callback
     async def async_my_climate_changed(self, event: Event = None):
@@ -441,7 +440,7 @@ class LastTemperatureSensor(VersatileThermostatBaseEntity, SensorEntity):
         super().__init__(hass, unique_id, entry_infos.get(CONF_NAME))
         self._attr_name = "Last temperature date"
         self._attr_entity_registry_enabled_default = False
-        self._attr_unique_id = gen_attr_uniq_id(unique_id, entry_infos, "last_temp_datetime")
+        self._attr_unique_id = f"{self._device_name}_last_temp_datetime"
 
     @callback
     async def async_my_climate_changed(self, event: Event = None):
@@ -471,7 +470,7 @@ class LastExtTemperatureSensor(VersatileThermostatBaseEntity, SensorEntity):
         super().__init__(hass, unique_id, entry_infos.get(CONF_NAME))
         self._attr_name = "Last external temperature date"
         self._attr_entity_registry_enabled_default = False
-        self._attr_unique_id = gen_attr_uniq_id(unique_id, entry_infos, "last_ext_temp_datetime")
+        self._attr_unique_id = f"{self._device_name}_last_ext_temp_datetime"
 
     @callback
     async def async_my_climate_changed(self, event: Event = None):
@@ -500,7 +499,7 @@ class TemperatureSlopeSensor(VersatileThermostatBaseEntity, SensorEntity):
         """Initialize the slope sensor"""
         super().__init__(hass, unique_id, entry_infos.get(CONF_NAME))
         self._attr_name = "Temperature slope"
-        self._attr_unique_id = gen_attr_uniq_id(unique_id, entry_infos, "temperature_slope")
+        self._attr_unique_id = f"{self._device_name}_temperature_slope"
 
     @callback
     async def async_my_climate_changed(self, event: Event = None):
@@ -553,7 +552,7 @@ class RegulatedTemperatureSensor(VersatileThermostatBaseEntity, SensorEntity):
         """Initialize the regulated temperature sensor"""
         super().__init__(hass, unique_id, entry_infos.get(CONF_NAME))
         self._attr_name = "Regulated temperature"
-        self._attr_unique_id = gen_attr_uniq_id(unique_id, entry_infos, "regulated_temperature")
+        self._attr_unique_id = f"{self._device_name}_regulated_temperature"
 
     @callback
     async def async_my_climate_changed(self, event: Event = None):
@@ -604,7 +603,7 @@ class EMATemperatureSensor(VersatileThermostatBaseEntity, SensorEntity):
         """Initialize the regulated temperature sensor"""
         super().__init__(hass, unique_id, entry_infos.get(CONF_NAME))
         self._attr_name = "EMA temperature"
-        self._attr_unique_id = gen_attr_uniq_id(unique_id, entry_infos, "ema_temperature")
+        self._attr_unique_id = f"{self._device_name}_ema_temperature"
 
     @callback
     async def async_my_climate_changed(self, event: Event = None):

--- a/custom_components/versatile_thermostat/switch.py
+++ b/custom_components/versatile_thermostat/switch.py
@@ -55,7 +55,7 @@ class AutoStartStopEnable(VersatileThermostatBaseEntity, SwitchEntity, RestoreEn
     ):
         super().__init__(hass, unique_id, name)
         self._attr_name = "Enable auto start/stop"
-        self._attr_unique_id = gen_attr_uniq_id(unique_id, entry_infos.data, "enable_auto_start_stop")
+        self._attr_unique_id = f"{self._device_name}_enable_auto_start_stop"
         self._attr_entity_category = EntityCategory.CONFIG
         self._default_value = (
             entry_infos.data.get(CONF_AUTO_START_STOP_LEVEL)
@@ -123,7 +123,7 @@ class FollowUnderlyingTemperatureChange(
     ):
         super().__init__(hass, unique_id, name)
         self._attr_name = "Follow underlying temp change"
-        self._attr_unique_id = gen_attr_uniq_id(unique_id, entry_infos.data, "follow_underlying_temp_change")
+        self._attr_unique_id = f"{self._device_name}_follow_underlying_temp_change"
         self._attr_is_on = False
         self._attr_entity_category = EntityCategory.CONFIG
 

--- a/tests/commons.py
+++ b/tests/commons.py
@@ -732,11 +732,6 @@ def search_entity(hass: HomeAssistant, entity_id, domain) -> Any | None:
     return None
 
 
-def search_simple_entity(hass: HomeAssistant, entity_id) -> Any | None:
-    """Search and return the entity, taking domain from entity id"""
-    return search_entity(hass, entity_id, entity_id.split('.', 1)[0])
-
-
 def count_entities(hass: HomeAssistant, entity_id, domain) -> int:
     """Search and return the entity in the domain"""
     component = hass.data[domain]

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -144,43 +144,6 @@ async def test_over_climate_full_start(hass: HomeAssistant, skip_hass_states_is_
 
 @pytest.mark.parametrize("expected_lingering_tasks", [True])
 @pytest.mark.parametrize("expected_lingering_timers", [True])
-async def test_duplicate_name(hass: HomeAssistant, skip_hass_states_is_state):
-    """Test that sub entries are generated correctly when multiple thermostat entries have the same title"""
-
-    fake_underlying_climate = MockClimate(hass, "mockUniqueId", "MockClimateName", {}, hvac_modes=[VThermHvacMode_HEAT, VThermHvacMode_OFF, VThermHvacMode_HEAT_COOL])
-
-    with patch(
-        "custom_components.versatile_thermostat.base_thermostat.BaseThermostat.send_event"
-    ) as mock_send_event, patch(
-        "custom_components.versatile_thermostat.underlyings.UnderlyingClimate.find_underlying_climate",
-        return_value=fake_underlying_climate,
-    ) as mock_find_climate:
-        for idx in range(1, 4):
-            entry = MockConfigEntry(
-                domain=DOMAIN,
-                title="TheOverClimateMockName",
-                unique_id=f"uniqueId_{idx}",
-                data=PARTIAL_CLIMATE_CONFIG,
-                version=2,
-                minor_version=2 if idx > 1 else 1,
-            )
-
-            entity = await create_thermostat(hass, entry, f"climate.theoverclimatemockname_{idx}")
-
-            assert entity
-            assert isinstance(entity, ThermostatOverClimate)
-
-            entity_id_suffix = "" if idx == 1 else f"_{idx}"
-            sensor_suffix = "_safety_state"
-            sensor = search_simple_entity(hass, f"binary_sensor.theoverclimatemockname{sensor_suffix}{entity_id_suffix}")
-            assert sensor is not None
-            # Check that we use entry title in unique_id for old entries.
-            if idx == 1:
-                assert sensor.unique_id == entry.title + sensor_suffix
-
-
-@pytest.mark.parametrize("expected_lingering_tasks", [True])
-@pytest.mark.parametrize("expected_lingering_timers", [True])
 async def test_over_4switch_full_start(hass: HomeAssistant, skip_hass_states_is_state):
     """Test the normal full start of a thermostat in thermostat_over_switch with 4 switches type"""
 


### PR DESCRIPTION
Reverts jmcollin78/versatile_thermostat#1337

This breaks the entity name and not only the entity_id but creating a new entity with _2 suffix. This is not possible for all users.