### PR TITLE
make power_threshold mandatory for calibrate_capacity service

### DIFF
--- a/custom_components/versatile_thermostat/auto_tpi_manager.py
+++ b/custom_components/versatile_thermostat/auto_tpi_manager.py
@@ -1414,9 +1414,9 @@ class AutoTpiManager:
         ext_temp_entity_id: str,
         hvac_mode: str,
         save_to_config: bool,
+        min_power_threshold: float,
         start_date: datetime | str | None = None,
         end_date: datetime | str | None = None,
-        min_power_threshold: float = 0.95,
     ) -> dict:
         """
         Orchestrates the capacity calibration service using temperature_slope

--- a/custom_components/versatile_thermostat/climate.py
+++ b/custom_components/versatile_thermostat/climate.py
@@ -181,7 +181,7 @@ async def async_setup_entry(
             vol.Optional("end_date"): selector.DateTimeSelector(),
             vol.Required("hvac_mode"): vol.In(["heat", "cool"]),
             vol.Optional("save_to_config", default=False): vol.In([True, False]),
-            vol.Optional("min_power_threshold", default=100): selector.NumberSelector(
+            vol.Required("min_power_threshold"): selector.NumberSelector(
                 selector.NumberSelectorConfig(min=80, max=100, step=1, mode=selector.NumberSelectorMode.SLIDER)
             ),
         },

--- a/custom_components/versatile_thermostat/services.yaml
+++ b/custom_components/versatile_thermostat/services.yaml
@@ -329,10 +329,9 @@ auto_tpi_calibrate_capacity:
         min_power_threshold:
             name: Minimum Power Threshold
             description: Minimum power percentage to consider a cycle as saturated (default 95%). Lower values (e.g., 90%) will include more cycles but may be less accurate.
-            required: false
+            required: true
             advanced: true
-            example: 100
-            default: 95
+            example: 95
             selector:
                 number:
                     min: 80

--- a/custom_components/versatile_thermostat/thermostat_tpi.py
+++ b/custom_components/versatile_thermostat/thermostat_tpi.py
@@ -456,9 +456,9 @@ class ThermostatTPI(BaseThermostat[T], Generic[T]):
         self,
         hvac_mode: str,
         save_to_config: bool,
+        min_power_threshold: int,
         start_date: datetime | None = None,
         end_date: datetime | None = None,
-        min_power_threshold: int = 95,
     ):
         """Called by a service call:
         service: versatile_thermostat.auto_tpi_calibrate_capacity

--- a/tests/test_auto_tpi.py
+++ b/tests/test_auto_tpi.py
@@ -293,13 +293,11 @@ async def test_service_calibrate_capacity(mock_vtherm_for_capacity):
 
         # 1. Simulate the service call - assuming BaseThermostat.service_auto_tpi_calibrate_capacity is now correct
         await vtherm.service_auto_tpi_calibrate_capacity(
-            "climate.test_thermostat",
-            "sensor.outdoor_temp",
-            10, # cycle_time_min
-            95, # min_power_percent
-            None, # kext_override
-            None, # start_date
-            None # end_date
+            hvac_mode="heat",
+            save_to_config=True,
+            min_power_threshold=95,
+            start_date=None,
+            end_date=None,
         )
 
         # 2. Check that the manager's calculate_capacity_from_history was called


### PR DESCRIPTION
Remove checkbox in calibrate_capacity , it's mandatory