### PR TITLE
[Auto-TPI] - Handle Auto TPI failures with learning-aware logic

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -5,6 +5,7 @@
 aiodiscover
 ulid_transform
 pytest
+pytest-socket
 coverage
 pytest-asyncio
 pytest-homeassistant-custom-component

--- a/tests/test_auto_tpi.py
+++ b/tests/test_auto_tpi.py
@@ -1,11 +1,12 @@
 """Test the AutoTpiManager class."""
-import pytest
-from unittest.mock import MagicMock, patch, AsyncMock
+import logging
 from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
 
-from homeassistant.core import HomeAssistant
+import pytest
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import STATE_ON, STATE_OFF
+from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
 
 from custom_components.versatile_thermostat.auto_tpi_manager import (
     AutoTpiManager,
@@ -18,8 +19,8 @@ from custom_components.versatile_thermostat.const import (
     CONF_TPI_COEF_EXT,
 )
 
-import logging
 _LOGGER = logging.getLogger(__name__)
+
 
 # Log test execution
 @pytest.fixture(autouse=True)
@@ -29,11 +30,13 @@ def log_test_execution(request):
     yield
     _LOGGER.info("Finished test: %s", request.node.name)
 
+
 # Patch async_call_later to avoid loop issues
 @pytest.fixture(autouse=True)
 def mock_async_call_later():
     with patch("custom_components.versatile_thermostat.auto_tpi_manager.async_call_later") as mock_call_later:
         yield mock_call_later
+
 
 @pytest.fixture
 def mock_hass():
@@ -45,12 +48,14 @@ def mock_hass():
     hass.config_entries = MagicMock()
     return hass
 
+
 @pytest.fixture
 def mock_config_entry():
     """Mock ConfigEntry."""
     entry = MagicMock(spec=ConfigEntry)
     entry.data = {}
     return entry
+
 
 @pytest.fixture
 def mock_store():
@@ -60,6 +65,7 @@ def mock_store():
         store_instance.async_load = AsyncMock(return_value=None)
         store_instance.async_save = AsyncMock()
         yield store_instance
+
 
 @pytest.fixture
 def manager(mock_hass, mock_store, mock_config_entry):
@@ -76,6 +82,7 @@ def manager(mock_hass, mock_store, mock_config_entry):
         heater_cooling_time=5,
     )
 
+
 async def test_initialization(manager):
     """Test initialization with defaults."""
     assert manager._unique_id == "test_id"
@@ -83,22 +90,22 @@ async def test_initialization(manager):
     assert manager._cycle_min == 5
     assert manager.state.coeff_indoor_heat == 0.6
     assert manager.state.coeff_outdoor_heat == 0.01
-    
+
     # Check storage initialization
     assert manager._store is not None
 
 async def test_load_data_no_existing(manager, mock_store):
     """Test loading when no data exists."""
     mock_store.async_load.return_value = None
-    
+
     await manager.async_load_data()
-    
+
     # Should use defaults
     assert manager.state.coeff_indoor_heat == 0.6
     assert manager.state.coeff_outdoor_heat == 0.01
     assert manager.state.total_cycles == 0
     # Counters should be initialized with initial weight
-    assert manager.state.coeff_indoor_autolearn == 1 
+    assert manager.state.coeff_indoor_autolearn == 1
 
 async def test_load_data_existing(manager, mock_store):
     """Test loading existing data."""
@@ -110,9 +117,9 @@ async def test_load_data_existing(manager, mock_store):
         coeff_outdoor_autolearn=50
     )
     mock_store.async_load.return_value = existing_state.to_dict()
-    
+
     await manager.async_load_data()
-    
+
     assert manager.state.coeff_indoor_heat == 0.3
     assert manager.state.coeff_outdoor_heat == 0.05
     assert manager.state.total_cycles == 100
@@ -122,7 +129,7 @@ async def test_save_data(manager, mock_store):
     """Test saving data."""
     manager.state.total_cycles = 10
     await manager.async_save_data()
-    
+
     mock_store.async_save.assert_called_once()
     saved_data = mock_store.async_save.call_args[0][0]
     assert saved_data["total_cycles"] == 10
@@ -135,7 +142,7 @@ async def test_update_state(manager):
         target_temp=21.0,
         hvac_mode="heat"
     )
-    
+
     assert manager._current_temp_in == 20.0
     assert manager._current_temp_out == 5.0
     assert manager._current_target_temp == 21.0
@@ -151,7 +158,7 @@ async def test_should_learn_basic(manager):
     manager.state.last_state = "heat"
     manager._current_temp_out = 0
     manager.state.last_temp_in = 19
-    
+
     assert manager._should_learn() is True
 
 async def test_should_learn_disabled(manager):
@@ -162,11 +169,11 @@ async def test_should_learn_disabled(manager):
 async def test_should_learn_power_saturation(manager):
     """Test _should_learn power saturation."""
     manager.state.autolearn_enabled = True
-    
+
     # 0%
     manager.state.last_power = 0.0
     assert manager._should_learn() is False
-    
+
     # 100%
     manager.state.last_power = 1.0  # > 0.99
     assert manager._should_learn() is False
@@ -175,9 +182,79 @@ async def test_should_learn_failures(manager):
     """Test _should_learn failure limit."""
     manager.state.autolearn_enabled = True
     manager.state.last_power = 0.5
-    
+
     manager.state.consecutive_failures = 3
     assert manager._should_learn() is False
+
+
+async def test_detect_failures_keeps_learning_when_not_saturated(manager):
+    """Ensure failure detection does not disable learning when power is below saturation."""
+
+    manager.state.autolearn_enabled = True
+    manager.state.last_state = "heat"
+    manager.state.last_order = 20.0
+    manager.state.last_temp_in = 20.5
+    manager.state.last_power = 0.6  # 60% duty cycle leaves margin to learn
+    manager.state.coeff_indoor_autolearn = 30
+    manager.state.consecutive_failures = 1
+
+    await manager._detect_failures(current_temp_in=18.5)
+
+    assert manager.state.consecutive_failures == 0
+    assert manager.state.autolearn_enabled is True
+    assert manager.state.last_learning_status == "temp_drop_with_spare_capacity"
+
+
+async def test_detect_failures_counts_when_saturated(manager):
+    """Ensure failures are still tracked when power is saturated."""
+
+    manager.state.autolearn_enabled = True
+    manager.state.last_state = "heat"
+    manager.state.last_order = 20.0
+    manager.state.last_temp_in = 20.5
+    manager.state.last_power = 1.0  # Saturated
+    manager.state.coeff_indoor_autolearn = 30
+    manager.state.consecutive_failures = 0
+
+    await manager._detect_failures(current_temp_in=18.5)
+
+    assert manager.state.consecutive_failures == 1
+
+
+async def test_detect_failures_does_not_stop_continuous_learning(mock_hass, mock_store, mock_config_entry):
+    """Ensure continuous learning is not stopped after consecutive failures."""
+
+    continuous_manager = AutoTpiManager(
+        hass=mock_hass,
+        config_entry=mock_config_entry,
+        unique_id="test_id",
+        name="test_name",
+        cycle_min=5,
+        coef_int=0.6,
+        coef_ext=0.01,
+        heater_heating_time=10,
+        heater_cooling_time=5,
+        continuous_learning=True,
+    )
+
+    continuous_manager.state.autolearn_enabled = True
+    continuous_manager.state.last_state = "heat"
+    continuous_manager.state.last_order = 20.0
+    continuous_manager.state.last_temp_in = 20.5
+    continuous_manager.state.last_power = 1.0  # Saturated (failure branch trigger)
+    continuous_manager.state.coeff_indoor_autolearn = 30
+    continuous_manager.state.consecutive_failures = 2
+
+    mock_hass.services = MagicMock()
+    mock_hass.services.async_call = AsyncMock()
+
+    with patch("custom_components.versatile_thermostat.auto_tpi_manager.translation.async_get_translations", new=AsyncMock()) as mock_translations:
+        await continuous_manager._detect_failures(current_temp_in=18.5)
+
+    assert continuous_manager.state.consecutive_failures == 3
+    assert continuous_manager.state.autolearn_enabled is True
+    mock_translations.assert_not_awaited()
+    mock_hass.services.async_call.assert_not_called()
 
 async def test_perform_learning_indoor(manager):
     """Test indoor coefficient learning."""
@@ -188,18 +265,18 @@ async def test_perform_learning_indoor(manager):
     manager.state.max_capacity_heat = 2.0 # deg/h
     manager.state.last_power = 0.5 # 50%
     manager._last_cycle_power_efficiency = 1.0
-    
+
     # Current state (end of cycle)
     # Rise = 0.2 deg
     # Target diff (at start) = 1.0
     current_temp_in = 19.2
     current_temp_out = 0.0
-    
+
     # Mock capability to ensure we use max_capacity
     manager._use_capacity_as_rate = True
-    
+
     await manager._perform_learning(current_temp_in, current_temp_out)
-    
+
     assert manager.state.last_learning_status.startswith("learned_indoor")
     assert manager.state.coeff_indoor_heat != 0.5 # Should have changed
 
@@ -214,19 +291,19 @@ async def test_cycle_lifecycle(manager):
         on_percent=0.5,
         hvac_mode="heat"
     )
-    
+
     assert manager.state.cycle_active is True
     assert manager.state.last_power == 0.5
     assert manager.state.last_state == "heat"
     assert manager._timer_capture_remove_callback is not None
-    
+
     # 2. Complete Cycle
     await manager.on_cycle_completed(
         on_time_sec=150,
         off_time_sec=150,
         hvac_mode="heat"
     )
-    
+
     assert manager.state.cycle_active is False
     assert manager.state.total_cycles == 1
 
@@ -240,13 +317,13 @@ def mock_vtherm_for_capacity():
     vtherm.entity_id = "climate.test_thermostat"
     vtherm.name = "Test Thermostat"
     vtherm.tpi_coef_ext = 0.01
-    
+
     # Mock auto_tpi_manager that is only for the sake of setting max_capacity_heat/cool
     manager = MagicMock(spec=AutoTpiManager)
     manager.state = MagicMock()
     manager.state.max_capacity_heat = 0.0
     manager.state.max_capacity_cool = 0.0
-    
+
     # Mock the renamed utility function called by the service method
     manager.calculate_capacity_from_history = AsyncMock(
         return_value={"success": True, "capacity": 7.5, "kext": 0.015, "kint": 0.5}
@@ -258,7 +335,7 @@ def mock_vtherm_for_capacity():
         """Simulate the service call by executing the core manager logic"""
         # The actual service implementation is expected to call this method on the manager
         res = await vtherm.auto_tpi_manager.calculate_capacity_from_history()
-        
+
         # The service is also expected to update the config entry if successful
         if res.get("success"):
             # The test is responsible for patching vtherm._async_update_tpi_config_entry
@@ -269,7 +346,7 @@ def mock_vtherm_for_capacity():
 
     # Set the service method on the mock to be an AsyncMock with the logic
     vtherm.service_auto_tpi_calibrate_capacity = AsyncMock(side_effect=mock_service_calibrate_capacity_impl)
-    
+
     return vtherm
 
 
@@ -282,7 +359,7 @@ async def test_service_calibrate_capacity(mock_vtherm_for_capacity):
     # The new=AsyncMock() is crucial to make the patched method awaitable for the side_effect function
     with patch("custom_components.versatile_thermostat.base_thermostat.history.get_significant_states") as mock_get_history, \
          patch.object(vtherm, "_async_update_tpi_config_entry", new=AsyncMock()) as mock_update_config:
-        
+
         # history.get_significant_states is called, it should return a mockable result (even though the inner calculation is mocked)
         now = datetime.now(timezone.utc)
         mock_history_states = [
@@ -303,7 +380,7 @@ async def test_service_calibrate_capacity(mock_vtherm_for_capacity):
         # 2. Check that the manager's calculate_capacity_from_history was called
         # This confirms BaseThermostat is calling the correct manager method
         vtherm.auto_tpi_manager.calculate_capacity_from_history.assert_called_once()
-        
+
         # 3. Assertions: ONLY capacity is updated (using the mock return value)
         # The mock returns 7.5 for capacity.
         assert vtherm.auto_tpi_manager.state.max_capacity_heat == pytest.approx(7.5, abs=0.1)


### PR DESCRIPTION
Avoid counting sub-saturation deviations as failures, keep continuous learning active after consecutive issues, add coverage and pytest-socket test dependency.