### PR TITLE
Fix #1445 - Central boiler activation with power threshold don't work anymore for `over_climate` with direct valve control

### DIFF
--- a/custom_components/versatile_thermostat/feature_power_manager.py
+++ b/custom_components/versatile_thermostat/feature_power_manager.py
@@ -296,13 +296,13 @@ class FeaturePowerManager(BaseFeatureManager):
         if not self._device_power:
             return None
 
+        if self._vtherm.proportional_algorithm:
+            return float(round_to_nearest(self._device_power * self._vtherm.proportional_algorithm.on_percent, 0.1))
+
         if self._vtherm.is_over_climate:
             return self._device_power if self._vtherm.is_device_active else 0.0
 
-        if not self._vtherm.proportional_algorithm:
-            return None
-
-        return float(round_to_nearest(self._device_power * self._vtherm.proportional_algorithm.on_percent, 0.1))
+        return None
 
     def __str__(self):
         return f"PowerManager-{self.name}"

--- a/custom_components/versatile_thermostat/thermostat_climate.py
+++ b/custom_components/versatile_thermostat/thermostat_climate.py
@@ -947,11 +947,6 @@ class ThermostatOverClimate(BaseThermostat[UnderlyingClimate]):
         return [VThermHvacMode_HEAT, VThermHvacMode_OFF]
 
     @property
-    def mean_cycle_power(self) -> float | None:
-        """Returns the mean power consumption during the cycle"""
-        return None
-
-    @property
     def fan_mode(self) -> str | None:
         """Return the fan setting.
 


### PR DESCRIPTION
Fixes #1445