### PR TITLE
Fix #1419 - Presets not available to set since 8.3.1

### DIFF
--- a/custom_components/versatile_thermostat/thermostat_climate.py
+++ b/custom_components/versatile_thermostat/thermostat_climate.py
@@ -420,6 +420,13 @@ class ThermostatOverClimate(BaseThermostat[UnderlyingClimate]):
             except ValueError:
                 return None
 
+        def determine_fan_mode_contains_speed(fan_modes: list[str]) -> bool:
+            """Determine if the fan_modes contains speed modes by searching for the keywords "low"/"1"."""
+            for val in ["low", "1"]:
+                if find_fan_mode(fan_modes, val):
+                    return True
+            return False
+
         def fix_order_speed_modes(speed_modes: list) -> list:
             """Determine if speed_modes list is ordered from high to low speed and reverse it"""
             index = -1
@@ -465,6 +472,17 @@ class ThermostatOverClimate(BaseThermostat[UnderlyingClimate]):
         #    |CONF_AUTO_FAN_HIGH    |medium_high |
         #    |CONF_AUTO_FAN_TURBO   |high        |
         target_index = -1
+
+        if determine_fan_mode_contains_speed(fan_modes) is False:
+            self._auto_activated_fan_mode = None
+            _LOGGER.warning(
+                "%s - #1419 - choose_auto_fan_mode cannot define value because fan_modes=%s doesn't contains speed values",
+                self,
+                self.fan_modes,
+            )
+
+            return
+
         if auto_fan_mode == CONF_AUTO_FAN_LOW:
             if num_speeds >= 4:
                 target_index = num_speeds - 4

--- a/tests/test_auto_fan_mode.py
+++ b/tests/test_auto_fan_mode.py
@@ -567,3 +567,93 @@ async def test_over_climate_auto_fan_mode_with_descending_speed_list(hass: HomeA
         await entity.service_set_auto_fan_mode("Low")
         assert entity._auto_activated_fan_mode == "diffuse"
         assert entity._auto_deactivated_fan_mode == "auto"
+
+
+@pytest.mark.parametrize("expected_lingering_tasks", [True])
+@pytest.mark.parametrize("expected_lingering_timers", [True])
+async def test_over_climate_auto_fan_mode_with_none_fan_speed_values(
+    hass: HomeAssistant, skip_hass_states_is_state, skip_send_event
+):
+    """Test the init of an over climate thermostat with none fan speed values"""
+
+    fan_modes = ["on", "auto", "diffuse"]
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="TheOverClimateMockName",
+        unique_id="uniqueId",
+        data={
+            CONF_NAME: "TheOverClimateMockName",
+            CONF_THERMOSTAT_TYPE: CONF_THERMOSTAT_CLIMATE,
+            CONF_TEMP_SENSOR: "sensor.mock_temp_sensor",
+            CONF_EXTERNAL_TEMP_SENSOR: "sensor.mock_ext_temp_sensor",
+            CONF_CYCLE_MIN: 5,
+            CONF_TEMP_MIN: 15,
+            CONF_TEMP_MAX: 30,
+            "eco_temp": 17,
+            "comfort_temp": 18,
+            "boost_temp": 19,
+            CONF_USE_WINDOW_FEATURE: False,
+            CONF_USE_MOTION_FEATURE: False,
+            CONF_USE_POWER_FEATURE: False,
+            CONF_USE_PRESENCE_FEATURE: False,
+            CONF_UNDERLYING_LIST: ["climate.mock_climate"],
+            CONF_MINIMAL_ACTIVATION_DELAY: 30,
+            CONF_MINIMAL_DEACTIVATION_DELAY: 0,
+            CONF_SAFETY_DELAY_MIN: 5,
+            CONF_SAFETY_MIN_ON_PERCENT: 0.3,
+            CONF_AUTO_FAN_MODE: CONF_AUTO_FAN_TURBO,
+        },
+    )
+
+    fake_underlying_climate = MockClimate(
+        hass=hass,
+        unique_id="mockUniqueId",
+        name="MockClimateName",
+        fan_modes=fan_modes,
+    )
+
+    # 1. Init with CONF_AUTO_FAN_TURBO
+    with patch(
+        "custom_components.versatile_thermostat.underlyings.UnderlyingClimate.find_underlying_climate",
+        return_value=fake_underlying_climate,
+    ):
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        assert entry.state is ConfigEntryState.LOADED
+
+        entity: ThermostatOverClimate = search_entity(hass, "climate.theoverclimatemockname", "climate")
+
+        assert entity
+        assert isinstance(entity, ThermostatOverClimate)
+
+        assert entity.name == "TheOverClimateMockName"
+        assert entity.is_over_climate is True
+        assert entity.fan_modes == fan_modes
+        assert entity._auto_fan_mode == "auto_fan_turbo"
+        assert entity._auto_activated_fan_mode is None
+        assert entity._auto_deactivated_fan_mode is None
+
+    # 2. Change auto_fan_mode by CONF_AUTO_FAN_HIGH
+    with patch(
+        "custom_components.versatile_thermostat.underlyings.UnderlyingClimate.set_fan_mode"
+    ) as mock_send_fan_mode:
+        await entity.service_set_auto_fan_mode("High")
+        assert entity._auto_activated_fan_mode is None
+        assert entity._auto_deactivated_fan_mode is None
+
+    # 3. Change auto_fan_mode by CONF_AUTO_FAN_MEDIUM
+    with patch(
+        "custom_components.versatile_thermostat.underlyings.UnderlyingClimate.set_fan_mode"
+    ) as mock_send_fan_mode:
+        await entity.service_set_auto_fan_mode("Medium")
+        assert entity._auto_activated_fan_mode is None
+        assert entity._auto_deactivated_fan_mode is None
+
+    # 4. Change auto_fan_mode by CONF_AUTO_FAN_LOW
+    with patch(
+        "custom_components.versatile_thermostat.underlyings.UnderlyingClimate.set_fan_mode"
+    ) as mock_send_fan_mode:
+        await entity.service_set_auto_fan_mode("Low")
+        assert entity._auto_activated_fan_mode is None
+        assert entity._auto_deactivated_fan_mode is None


### PR DESCRIPTION
Some underlyings do not have a selectable speed. In this case, auto_fan_mode need to be skip.