### PR TITLE
Fix # 1458 - Some AC units (e.g. Daikin) do not handle multiple consecutive commands well

### DIFF
--- a/custom_components/versatile_thermostat/thermostat_climate.py
+++ b/custom_components/versatile_thermostat/thermostat_climate.py
@@ -1,6 +1,7 @@
 # pylint: disable=line-too-long, too-many-lines, abstract-method
 """ A climate over climate classe """
 import logging
+
 from datetime import timedelta, datetime
 
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN

--- a/tests/test_auto_fan_mode.py
+++ b/tests/test_auto_fan_mode.py
@@ -3,7 +3,7 @@
 """ Test the auto fan mode of a over_climate thermostat """
 from unittest.mock import patch, call
 
-from datetime import datetime  # , timedelta
+from datetime import datetime, timedelta
 
 from homeassistant.core import HomeAssistant
 
@@ -657,3 +657,132 @@ async def test_over_climate_auto_fan_mode_with_none_fan_speed_values(
         await entity.service_set_auto_fan_mode("Low")
         assert entity._auto_activated_fan_mode is None
         assert entity._auto_deactivated_fan_mode is None
+
+
+@pytest.mark.parametrize("expected_lingering_tasks", [True])
+@pytest.mark.parametrize("expected_lingering_timers", [True])
+async def test_over_climate_auto_fan_mode_check_delay_command(hass: HomeAssistant, skip_hass_states_is_state, skip_send_event):
+    """Test the delay of the fan_mode command when the setpoint temperature triggers auto_fan_mode"""
+
+    fan_modes = ["low", "medium", "high", "boost", "mute", "auto", "turbo"]
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="TheOverClimateMockName",
+        unique_id="uniqueId",
+        data={
+            CONF_NAME: "TheOverClimateMockName",
+            CONF_THERMOSTAT_TYPE: CONF_THERMOSTAT_CLIMATE,
+            CONF_TEMP_SENSOR: "sensor.mock_temp_sensor",
+            CONF_EXTERNAL_TEMP_SENSOR: "sensor.mock_ext_temp_sensor",
+            CONF_CYCLE_MIN: 5,
+            CONF_TEMP_MIN: 15,
+            CONF_TEMP_MAX: 30,
+            "eco_temp": 17,
+            "comfort_temp": 18,
+            "boost_temp": 19,
+            "eco_ac_temp": 25,
+            "comfort_ac_temp": 23,
+            "boost_ac_temp": 21,
+            CONF_USE_WINDOW_FEATURE: False,
+            CONF_USE_MOTION_FEATURE: False,
+            CONF_USE_POWER_FEATURE: False,
+            CONF_USE_PRESENCE_FEATURE: False,
+            CONF_UNDERLYING_LIST: ["climate.mock_climate"],
+            CONF_MINIMAL_ACTIVATION_DELAY: 30,
+            CONF_MINIMAL_DEACTIVATION_DELAY: 0,
+            CONF_SAFETY_DELAY_MIN: 5,
+            CONF_SAFETY_MIN_ON_PERCENT: 0.3,
+            CONF_AUTO_FAN_MODE: CONF_AUTO_FAN_TURBO,
+            CONF_AC_MODE: True,
+        },
+    )
+
+    tz = get_tz(hass)  # pylint: disable=invalid-name
+    now: datetime = datetime.now(tz=tz)
+
+    fake_underlying_climate = MockClimate(
+        hass=hass,
+        unique_id="mockUniqueId",
+        name="MockClimateName",
+        fan_modes=fan_modes,
+    )
+
+    # Init fan mode and turn on the thermostat
+    with patch(
+        "custom_components.versatile_thermostat.underlyings.UnderlyingClimate.find_underlying_climate",
+        return_value=fake_underlying_climate,
+    ):
+        entity = await create_thermostat(hass, entry, "climate.theoverclimatemockname")
+
+        assert entity
+        assert isinstance(entity, ThermostatOverClimate)
+
+        assert entity.name == "TheOverClimateMockName"
+        assert entity.is_over_climate is True
+        assert entity.fan_modes == fan_modes
+        assert entity.fan_mode is None
+
+        assert entity._auto_fan_mode == "auto_fan_turbo"
+        assert entity._auto_activated_fan_mode == "turbo"
+        assert entity._auto_deactivated_fan_mode == "mute"
+
+        # Force heating mode and preset
+        await entity.async_set_hvac_mode(VThermHvacMode_HEAT)
+        await entity.async_set_preset_mode(VThermPreset.COMFORT)
+
+        assert entity.hvac_mode == VThermHvacMode_HEAT
+        assert entity.preset_mode == VThermPreset.COMFORT
+        assert entity.target_temperature == 18
+
+    planned_commands = []
+
+    def fake_async_call_later(hass, delay, callback):
+        value = None
+        if hasattr(callback, "__closure__") and callback.__closure__:
+            free_vars = callback.__code__.co_freevars
+            if "fan_mode" in free_vars:
+                index = free_vars.index("fan_mode")
+                value = callback.__closure__[index].cell_contents
+
+        planned_commands.append({"delay": delay, "fan_mode": value})
+        return lambda: None
+
+    # room temp is 18°C
+    await send_temperature_change_event(entity, 18, now)
+
+    with patch(
+        "custom_components.versatile_thermostat.underlyings.async_call_later", 
+        side_effect=fake_async_call_later
+    ) as mock_send:
+        # --------------------------------------------------
+        # 1. Temperature target at 20°C (+2 °C) → auto fan_mode (DELAYED)
+        # --------------------------------------------------
+        underlying = entity._underlyings[0]
+        underlying._last_command_sent_datetime = now + timedelta(seconds=-10)
+
+        await entity.async_set_temperature(temperature=20)
+
+        assert len(planned_commands) == 1
+        assert planned_commands[0]["delay"] == 2.0
+        assert planned_commands[0]["fan_mode"] == "turbo"
+
+        # --------------------------------------------------
+        # 2. Manual fan_mode change withou previous command → NO DELAY
+        # --------------------------------------------------
+        underlying._last_command_sent_datetime = now + timedelta(seconds=-10)
+
+        await entity.async_set_fan_mode("high")
+        assert len(planned_commands) == 1
+        assert entity._fan_mode == "high"
+
+        # --------------------------------------------------
+        # 3. Temperature target at 18°C (like room temp) → auto deactivation (DELAYED)
+        # --------------------------------------------------
+        underlying._last_command_sent_datetime = now + timedelta(seconds=-10)
+
+        await entity.async_set_temperature(temperature=18)
+
+        assert len(planned_commands) == 2
+        assert planned_commands[1]["delay"] == 2.0
+        assert planned_commands[1]["fan_mode"] == "mute"

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -185,7 +185,7 @@ async def test_bug_272(
 
         mock_service_call.assert_has_calls(
             [
-                call.async_call(
+                call(
                     "climate",
                     SERVICE_SET_TEMPERATURE,
                     {
@@ -194,16 +194,24 @@ async def test_bug_272(
                         # "target_temp_high": 30,
                         # "target_temp_low": 15,
                     },
+                    False,
+                    None,
+                    None,
+                    False,
                 ),
             ]
         )
 
         assert not any(
             c
-            == call.async_call(
+            == call(
                 "climate",
                 SERVICE_SET_HVAC_MODE,
                 {"entity_id": "climate.mock_climate", "hvac_mode": VThermHvacMode_HEAT},
+                False,
+                None,
+                None,
+                False
             )
             for c in mock_service_call.call_args_list
         )
@@ -228,7 +236,7 @@ async def test_bug_272(
         assert mock_service_call.call_count >= 1
         mock_service_call.assert_has_calls(
             [
-                call.async_call(
+                call(
                     "climate",
                     SERVICE_SET_TEMPERATURE,
                     {
@@ -237,6 +245,10 @@ async def test_bug_272(
                         # "target_temp_high": 30,
                         # "target_temp_low": 15,
                     },
+                    False,
+                    None,
+                    None,
+                    False
                 ),
             ]
         )
@@ -258,7 +270,7 @@ async def test_bug_272(
         assert mock_service_call.call_count >= 1
         mock_service_call.assert_has_calls(
             [
-                call.async_call(
+                call(
                     "climate",
                     SERVICE_SET_TEMPERATURE,
                     {
@@ -267,6 +279,10 @@ async def test_bug_272(
                         # "target_temp_high": 30,
                         # "target_temp_low": 15,
                     },
+                    False,
+                    None,
+                    None,
+                    False
                 ),
             ]
         )

--- a/tests/test_overclimate.py
+++ b/tests/test_overclimate.py
@@ -574,6 +574,10 @@ async def test_bug_508(
                         "target_temp_high": 10,
                         "target_temp_low": 10,
                     },
+                    False,
+                    None,
+                    None,
+                    False,
                 ),
             ]
         )
@@ -597,6 +601,10 @@ async def test_bug_508(
                         "target_temp_high": 31,
                         "target_temp_low": 31,
                     },
+                    False,
+                    None,
+                    None,
+                    False,
                 ),
             ]
         )

--- a/tests/test_overclimate_sync_device_temp.py
+++ b/tests/test_overclimate_sync_device_temp.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta
 import logging
 
 from homeassistant.core import HomeAssistant, State
+from homeassistant.components.number import SERVICE_SET_VALUE
 
 from custom_components.versatile_thermostat.thermostat_climate_valve import (
     ThermostatOverClimateValve,
@@ -139,8 +140,8 @@ async def test_over_climate_valve_multi_sync_calibration(
         # Calibration should have changed
         assert mock_service_call.call_count == 2
         mock_service_call.assert_has_calls([
-            call(domain='number', service='set_value', service_data={'value': 3.0}, target={'entity_id': 'number.mock_offset_calibration1'}), # 18 - 15 + 0
-            call(domain='number', service='set_value', service_data={'value': 12}, target={'entity_id': 'number.mock_offset_calibration2'})   # 18 - 15 + 10 < 12 max
+            call('number', SERVICE_SET_VALUE, {'value': 3.0}, False, None, {'entity_id': 'number.mock_offset_calibration1'}, False), # 18 - 15 + 0
+            call('number', SERVICE_SET_VALUE, {'value': 12}, False, None, {'entity_id': 'number.mock_offset_calibration2'}, False)   # 18 - 15 + 10 < 12 max
             ]
         )
 
@@ -166,8 +167,8 @@ async def test_over_climate_valve_multi_sync_calibration(
         # Calibration should have changed
         assert mock_service_call.call_count == 2
         mock_service_call.assert_has_calls([
-            call(domain='number', service='set_value', service_data={'value': 5.0}, target={'entity_id': 'number.mock_offset_calibration1'}), # 15 - 13 + 3
-            call(domain='number', service='set_value', service_data={'value': 6}, target={'entity_id': 'number.mock_offset_calibration2'})   # 15 - 21 + 12
+            call('number', SERVICE_SET_VALUE, {'value': 5.0}, False, None, {'entity_id': 'number.mock_offset_calibration1'}, False), # 15 - 13 + 3
+            call('number', SERVICE_SET_VALUE, {'value': 6}, False, None, {'entity_id': 'number.mock_offset_calibration2'}, False)   # 15 - 21 + 12
             ]
         )
 
@@ -296,8 +297,8 @@ async def test_over_climate_valve_multi_sync_temperature(
         # Calibration should have changed
         assert mock_service_call.call_count == 2
         mock_service_call.assert_has_calls([
-            call(domain='number', service='set_value', service_data={'value': 18.0}, target={'entity_id': 'number.mock_ext_temp1'}),
-            call(domain='number', service='set_value', service_data={'value': 18.0}, target={'entity_id': 'number.mock_ext_temp2'})
+            call('number', SERVICE_SET_VALUE, {'value': 18.0}, False, None, {'entity_id': 'number.mock_ext_temp1'}, False),
+            call('number', SERVICE_SET_VALUE, {'value': 18.0}, False, None, {'entity_id': 'number.mock_ext_temp2'}, False)
             ]
         )
 
@@ -323,8 +324,8 @@ async def test_over_climate_valve_multi_sync_temperature(
         # Calibration should have changed
         assert mock_service_call.call_count == 2
         mock_service_call.assert_has_calls([
-            call(domain='number', service='set_value', service_data={'value': 15}, target={'entity_id': 'number.mock_ext_temp1'}),
-            call(domain='number', service='set_value', service_data={'value': 15}, target={'entity_id': 'number.mock_ext_temp2'})
+            call('number', SERVICE_SET_VALUE, {'value': 15}, False, None, {'entity_id': 'number.mock_ext_temp1'}, False),
+            call('number', SERVICE_SET_VALUE, {'value': 15}, False, None, {'entity_id': 'number.mock_ext_temp2'}, False)
             ]
         )
 

--- a/tests/test_overclimate_valve.py
+++ b/tests/test_overclimate_valve.py
@@ -7,6 +7,8 @@ from datetime import datetime, timedelta
 import logging
 
 from homeassistant.core import HomeAssistant, State
+from homeassistant.components.climate import SERVICE_SET_TEMPERATURE
+from homeassistant.components.number import SERVICE_SET_VALUE
 
 from custom_components.versatile_thermostat.thermostat_climate_valve import (
     ThermostatOverClimateValve,
@@ -139,8 +141,8 @@ async def test_over_climate_valve_mono(hass: HomeAssistant, skip_hass_states_get
         assert mock_service_call.call_count == 2
         mock_service_call.assert_has_calls(
             [
-                call(domain='number', service='set_value', service_data={'value': 0}, target={'entity_id': 'number.mock_opening_degree'}),
-                call(domain='number', service='set_value', service_data={'value': 100}, target={'entity_id': 'number.mock_closing_degree'}),
+                call('number', SERVICE_SET_VALUE, {'value': 0}, False, None, {'entity_id': 'number.mock_opening_degree'}, False),
+                call('number', SERVICE_SET_VALUE, {'value': 100}, False, None, {'entity_id': 'number.mock_closing_degree'}, False),
                 # issue #1012 - the set temperature is not called when the VTherm is off
                 # call("climate","set_temperature",{
                 #         "entity_id": "climate.mock_climate",
@@ -188,9 +190,9 @@ async def test_over_climate_valve_mono(hass: HomeAssistant, skip_hass_states_get
         assert mock_service_call.call_count == 3
         mock_service_call.assert_has_calls(
             [
-                call('climate', 'set_temperature', {'entity_id': 'climate.mock_climate', 'temperature': 19.0}),
-                call(domain='number', service='set_value', service_data={'value': 40}, target={'entity_id': 'number.mock_opening_degree'}),
-                call(domain='number', service='set_value', service_data={'value': 60}, target={'entity_id': 'number.mock_closing_degree'}),
+                call('climate', SERVICE_SET_TEMPERATURE, {'entity_id': 'climate.mock_climate', 'temperature': 19.0}, False, None, None, False),
+                call('number', SERVICE_SET_VALUE, {'value': 40}, False, None, {'entity_id': 'number.mock_opening_degree'}, False),
+                call('number', SERVICE_SET_VALUE, {'value': 60}, False, None, {'entity_id': 'number.mock_closing_degree'}, False),
                 # 3 = 18 (room) - 15 (current of underlying) + 0 (current offset)
                 # call(domain='number', service='set_value', service_data={'value': 3.0}, target={'entity_id': 'number.mock_offset_calibration'})
             ]
@@ -236,10 +238,10 @@ async def test_over_climate_valve_mono(hass: HomeAssistant, skip_hass_states_get
         assert mock_service_call.call_count == 3 # opening, closing, offset cause temp changed
         mock_service_call.assert_has_calls(
             [
-                call(domain='number', service='set_value', service_data={'value': 13}, target={'entity_id': 'number.mock_opening_degree'}),
-                call(domain='number', service='set_value', service_data={'value': 87}, target={'entity_id': 'number.mock_closing_degree'}),
+                call('number', SERVICE_SET_VALUE, {'value': 13}, False, None, {'entity_id': 'number.mock_opening_degree'}, False),
+                call('number', SERVICE_SET_VALUE, {'value': 87}, False, None, {'entity_id': 'number.mock_closing_degree'}, False),
                 # 6 = 18 (room) - 15 (current of underlying) + 3 (current offset)
-                call(domain='number', service='set_value', service_data={'value': 6.9}, target={'entity_id': 'number.mock_offset_calibration'})
+                call('number', SERVICE_SET_VALUE, {'value': 6.9}, False, None, {'entity_id': 'number.mock_offset_calibration'}, False)
             ]
         )
 
@@ -282,10 +284,10 @@ async def test_over_climate_valve_mono(hass: HomeAssistant, skip_hass_states_get
         assert mock_service_call.call_count == 3 # opening, closing, offset cause temp changed
         mock_service_call.assert_has_calls(
             [
-                call(domain='number', service='set_value', service_data={'value': 0}, target={'entity_id': 'number.mock_opening_degree'}),
-                call(domain='number', service='set_value', service_data={'value': 100}, target={'entity_id': 'number.mock_closing_degree'}),
+                call('number', SERVICE_SET_VALUE, {'value': 0}, False, None, {'entity_id': 'number.mock_opening_degree'}, False),
+                call('number', SERVICE_SET_VALUE, {'value': 100}, False, None, {'entity_id': 'number.mock_closing_degree'}, False),
                 # 6 = 18 (room) - 15 (current of underlying) + 3 (current offset)
-                call(domain='number', service='set_value', service_data={'value': 9.0}, target={'entity_id': 'number.mock_offset_calibration'})
+                call('number', SERVICE_SET_VALUE, {'value': 9.0}, False, None, {'entity_id': 'number.mock_offset_calibration'}, False)
             ]
         )
 
@@ -434,13 +436,13 @@ async def test_over_climate_valve_multi_presence(
         # the underlying set temperature call and the call to the valve
         assert mock_service_call.call_count == 6
         mock_service_call.assert_has_calls([
-            call('climate', 'set_temperature', {'entity_id': 'climate.mock_climate1', 'temperature': 19.0}),
-            call('climate', 'set_temperature', {'entity_id': 'climate.mock_climate2', 'temperature': 19.0}),
-            call(domain='number', service='set_value', service_data={'value': 40}, target={'entity_id': 'number.mock_opening_degree1'}),
-            call(domain='number', service='set_value', service_data={'value': 60}, target={'entity_id': 'number.mock_closing_degree1'}),
+            call('climate', SERVICE_SET_TEMPERATURE, {'entity_id': 'climate.mock_climate1', 'temperature': 19.0}, False, None, None, False),
+            call('climate', SERVICE_SET_TEMPERATURE, {'entity_id': 'climate.mock_climate2', 'temperature': 19.0}, False, None, None, False),
+            call('number', SERVICE_SET_VALUE, {'value': 40}, False, None, {'entity_id': 'number.mock_opening_degree1'}, False),
+            call('number', SERVICE_SET_VALUE, {'value': 60}, False, None, {'entity_id': 'number.mock_closing_degree1'}, False),
             # call(domain='number', service='set_value', service_data={'value': 3.0}, target={'entity_id': 'number.mock_offset_calibration1'}),
-            call(domain='number', service='set_value', service_data={'value': 40}, target={'entity_id': 'number.mock_opening_degree2'}),
-            call(domain='number', service='set_value', service_data={'value': 60}, target={'entity_id': 'number.mock_closing_degree2'}),
+            call('number', SERVICE_SET_VALUE, {'value': 40}, False, None, {'entity_id': 'number.mock_opening_degree2'}, False),
+            call('number', SERVICE_SET_VALUE, {'value': 60}, False, None, {'entity_id': 'number.mock_closing_degree2'}, False),
             # call(domain='number', service='set_value', service_data={'value': 12}, target={'entity_id': 'number.mock_offset_calibration2'})
             ]
         )
@@ -465,13 +467,13 @@ async def test_over_climate_valve_multi_presence(
         # the underlying set temperature call and the call to the valve
         assert mock_service_call.call_count == 6
         mock_service_call.assert_has_calls([
-            call('climate', 'set_temperature', {'entity_id': 'climate.mock_climate1', 'temperature': 17.2}),
-            call('climate', 'set_temperature', {'entity_id': 'climate.mock_climate2', 'temperature': 17.2}),
-            call(domain='number', service='set_value', service_data={'value': 0}, target={'entity_id': 'number.mock_opening_degree1'}),
-            call(domain='number', service='set_value', service_data={'value': 100}, target={'entity_id': 'number.mock_closing_degree1'}),
+            call('climate', SERVICE_SET_TEMPERATURE, {'entity_id': 'climate.mock_climate1', 'temperature': 17.2}, False, None, None, False),
+            call('climate', SERVICE_SET_TEMPERATURE, {'entity_id': 'climate.mock_climate2', 'temperature': 17.2}, False, None, None, False),
+            call('number', 'set_value', {'value': 0}, False, None, {'entity_id': 'number.mock_opening_degree1'}, False),
+            call('number', 'set_value', {'value': 100}, False, None, {'entity_id': 'number.mock_closing_degree1'}, False),
             # call(domain='number', service='set_value', service_data={'value': 3.0}, target={'entity_id': 'number.mock_offset_calibration1'}),
-            call(domain='number', service='set_value', service_data={'value': 0}, target={'entity_id': 'number.mock_opening_degree2'}),
-            call(domain='number', service='set_value', service_data={'value': 100}, target={'entity_id': 'number.mock_closing_degree2'}),
+            call('number', 'set_value', {'value': 0}, False, None, {'entity_id': 'number.mock_opening_degree2'}, False),
+            call('number', 'set_value', {'value': 100}, False, None, {'entity_id': 'number.mock_closing_degree2'}, False),
             # call(domain='number', service='set_value', service_data={'value': 12}, target={'entity_id': 'number.mock_offset_calibration2'})
             ]
         )
@@ -627,12 +629,12 @@ async def test_over_climate_valve_multi_min_opening_degrees(
         assert mock_service_call.call_count == 6
         mock_service_call.assert_has_calls([
             # min is 60
-            call(domain='number', service='set_value', service_data={'value': 68}, target={'entity_id': 'number.mock_opening_degree1'}),
-            call(domain='number', service='set_value', service_data={'value': 32}, target={'entity_id': 'number.mock_closing_degree1'}),
-            call(domain='number', service='set_value', service_data={'value': 3.0}, target={'entity_id': 'number.mock_offset_calibration1'}),
-            call(domain='number', service='set_value', service_data={'value': 76}, target={'entity_id': 'number.mock_opening_degree2'}),
-            call(domain='number', service='set_value', service_data={'value': 24}, target={'entity_id': 'number.mock_closing_degree2'}),
-            call(domain='number', service='set_value', service_data={'value': 12}, target={'entity_id': 'number.mock_offset_calibration2'})
+            call('number', SERVICE_SET_VALUE, {'value': 68}, False, None, {'entity_id': 'number.mock_opening_degree1'}, False),
+            call('number', SERVICE_SET_VALUE, {'value': 32}, False, None, {'entity_id': 'number.mock_closing_degree1'}, False),
+            call('number', SERVICE_SET_VALUE, {'value': 3.0}, False, None, {'entity_id': 'number.mock_offset_calibration1'}, False),
+            call('number', SERVICE_SET_VALUE, {'value': 76}, False, None, {'entity_id': 'number.mock_opening_degree2'}, False),
+            call('number', SERVICE_SET_VALUE, {'value': 24}, False, None, {'entity_id': 'number.mock_closing_degree2'}, False),
+            call('number', SERVICE_SET_VALUE, {'value': 12}, False, None, {'entity_id': 'number.mock_offset_calibration2'}, False)
             ],
             any_order=True
         )
@@ -657,12 +659,12 @@ async def test_over_climate_valve_multi_min_opening_degrees(
         # the underlying set temperature call and the call to the valve to close them (max closing=90)
         assert mock_service_call.call_count == 6
         mock_service_call.assert_has_calls([
-            call(domain='number', service='set_value', service_data={'value': 10}, target={'entity_id': 'number.mock_opening_degree1'}),
-            call(domain='number', service='set_value', service_data={'value': 90}, target={'entity_id': 'number.mock_closing_degree1'}),
-            call(domain='number', service='set_value', service_data={'value': 7.0}, target={'entity_id': 'number.mock_offset_calibration1'}),
-            call(domain='number', service='set_value', service_data={'value': 10}, target={'entity_id': 'number.mock_opening_degree2'}),
-            call(domain='number', service='set_value', service_data={'value': 90}, target={'entity_id': 'number.mock_closing_degree2'}),
-            call(domain='number', service='set_value', service_data={'value': 12}, target={'entity_id': 'number.mock_offset_calibration2'})
+            call('number', SERVICE_SET_VALUE, {'value': 10}, False, None, {'entity_id': 'number.mock_opening_degree1'}, False),
+            call('number', SERVICE_SET_VALUE, {'value': 90}, False, None, {'entity_id': 'number.mock_closing_degree1'}, False),
+            call('number', SERVICE_SET_VALUE, {'value': 7.0}, False, None, {'entity_id': 'number.mock_offset_calibration1'}, False),
+            call('number', SERVICE_SET_VALUE, {'value': 10}, False, None, {'entity_id': 'number.mock_opening_degree2'}, False),
+            call('number', SERVICE_SET_VALUE, {'value': 90}, False, None, {'entity_id': 'number.mock_closing_degree2'}, False),
+            call('number', SERVICE_SET_VALUE, {'value': 12}, False, None, {'entity_id': 'number.mock_offset_calibration2'}, False)
             ],
             any_order=True
         )
@@ -685,12 +687,12 @@ async def test_over_climate_valve_multi_min_opening_degrees(
         assert mock_service_call.call_count == 6
         mock_service_call.assert_has_calls([
             # min is 60
-            call(domain='number', service='set_value', service_data={'value': 68}, target={'entity_id': 'number.mock_opening_degree1'}),
-            call(domain='number', service='set_value', service_data={'value': 32}, target={'entity_id': 'number.mock_closing_degree1'}),
-            call(domain='number', service='set_value', service_data={'value': 3.0}, target={'entity_id': 'number.mock_offset_calibration1'}),
-            call(domain='number', service='set_value', service_data={'value': 76}, target={'entity_id': 'number.mock_opening_degree2'}),
-            call(domain='number', service='set_value', service_data={'value': 24}, target={'entity_id': 'number.mock_closing_degree2'}),
-            call(domain='number', service='set_value', service_data={'value': 12}, target={'entity_id': 'number.mock_offset_calibration2'})
+            call('number', SERVICE_SET_VALUE, {'value': 68}, False, None, {'entity_id': 'number.mock_opening_degree1'}, False),
+            call('number', SERVICE_SET_VALUE, {'value': 32}, False, None, {'entity_id': 'number.mock_closing_degree1'}, False),
+            call('number', SERVICE_SET_VALUE, {'value': 3.0}, False, None, {'entity_id': 'number.mock_offset_calibration1'}, False),
+            call('number', SERVICE_SET_VALUE, {'value': 76}, False, None, {'entity_id': 'number.mock_opening_degree2'}, False),
+            call('number', SERVICE_SET_VALUE, {'value': 24}, False, None, {'entity_id': 'number.mock_closing_degree2'}, False),
+            call('number', SERVICE_SET_VALUE, {'value': 12}, False, None, {'entity_id': 'number.mock_offset_calibration2'}, False)
             ],
             any_order=True
         )
@@ -715,11 +717,11 @@ async def test_over_climate_valve_multi_min_opening_degrees(
         # the underlying set temperature call and the call to the valve
         assert mock_service_call.call_count == 4
         mock_service_call.assert_has_calls([
-            call(domain='number', service='set_value', service_data={'value': 10}, target={'entity_id': 'number.mock_opening_degree1'}),
-            call(domain='number', service='set_value', service_data={'value': 90}, target={'entity_id': 'number.mock_closing_degree1'}),
+            call('number', SERVICE_SET_VALUE, {'value': 10}, False, None, {'entity_id': 'number.mock_opening_degree1'}, False),
+            call('number', SERVICE_SET_VALUE, {'value': 90}, False, None, {'entity_id': 'number.mock_closing_degree1'}, False),
             # call(domain='number', service='set_value', service_data={'value': 3.0}, target={'entity_id': 'number.mock_offset_calibration1'}),
-            call(domain='number', service='set_value', service_data={'value': 10}, target={'entity_id': 'number.mock_opening_degree2'}),
-            call(domain='number', service='set_value', service_data={'value': 90}, target={'entity_id': 'number.mock_closing_degree2'}),
+            call('number', SERVICE_SET_VALUE, {'value': 10}, False, None, {'entity_id': 'number.mock_opening_degree2'}, False),
+            call('number', SERVICE_SET_VALUE, {'value': 90}, False, None, {'entity_id': 'number.mock_closing_degree2'}, False),
             # call(domain='number', service='set_value', service_data={'value': 12}, target={'entity_id': 'number.mock_offset_calibration2'})
             ],
             any_order=True
@@ -835,8 +837,8 @@ async def test_over_climate_valve_vtherm_hvac_mode_sleep(hass: HomeAssistant, sk
         assert mock_service_call.call_count == 2
         mock_service_call.assert_has_calls(
             [
-                call(domain='number', service='set_value', service_data={'value': 40}, target={'entity_id': 'number.mock_opening_degree'}),
-                call(domain='number', service='set_value', service_data={'value': 60}, target={'entity_id': 'number.mock_closing_degree'}),
+                call('number', SERVICE_SET_VALUE, {'value': 40}, False, None, {'entity_id': 'number.mock_opening_degree'}, False),
+                call('number', SERVICE_SET_VALUE, {'value': 60}, False, None, {'entity_id': 'number.mock_closing_degree'}, False),
                 # 3 = 18 (room) - 15 (current of underlying) + 0 (current offset)
                 #call(domain='number', service='set_value', service_data={'value': 3.0}, target={'entity_id': 'number.mock_offset_calibration'})
             ]
@@ -862,8 +864,8 @@ async def test_over_climate_valve_vtherm_hvac_mode_sleep(hass: HomeAssistant, sk
         assert mock_service_call.call_count == 2
         mock_service_call.assert_has_calls(
             [
-                call(domain='number', service='set_value', service_data={'value': 100}, target={'entity_id': 'number.mock_opening_degree'}),
-                call(domain='number', service='set_value', service_data={'value': 0}, target={'entity_id': 'number.mock_closing_degree'}),
+                call('number', SERVICE_SET_VALUE, {'value': 100}, False, None, {'entity_id': 'number.mock_opening_degree'}, False),
+                call('number', SERVICE_SET_VALUE, {'value': 0}, False, None, {'entity_id': 'number.mock_closing_degree'}, False),
             ]
         )
 
@@ -891,8 +893,8 @@ async def test_over_climate_valve_vtherm_hvac_mode_sleep(hass: HomeAssistant, sk
         assert mock_service_call.call_count == 2
         mock_service_call.assert_has_calls(
             [
-                call(domain='number', service='set_value', service_data={'value': 40}, target={'entity_id': 'number.mock_opening_degree'}),
-                call(domain='number', service='set_value', service_data={'value': 60}, target={'entity_id': 'number.mock_closing_degree'}),
+                call('number', SERVICE_SET_VALUE, {'value': 40}, False, None, {'entity_id': 'number.mock_opening_degree'}, False),
+                call('number', SERVICE_SET_VALUE, {'value': 60}, False, None, {'entity_id': 'number.mock_closing_degree'}, False),
             ]
         )
 

--- a/tests/test_power.py
+++ b/tests/test_power.py
@@ -4,6 +4,8 @@ from unittest.mock import patch, call, AsyncMock, MagicMock, PropertyMock
 from datetime import datetime, timedelta
 import logging
 
+from homeassistant.components.number import SERVICE_SET_VALUE
+
 from custom_components.versatile_thermostat.thermostat_switch import ThermostatOverSwitch
 from custom_components.versatile_thermostat.thermostat_climate_valve import ThermostatOverClimateValve
 from custom_components.versatile_thermostat.feature_power_manager import FeaturePowerManager
@@ -983,7 +985,7 @@ async def test_power_management_over_climate_valve(hass: HomeAssistant, skip_has
         assert mock_service_call.call_count == 1
         mock_service_call.assert_has_calls(
             [
-                call(domain='number', service='set_value', service_data={'value': 0}, target={'entity_id': 'number.mock_opening_degree'}),
+                call('number', SERVICE_SET_VALUE, {'value': 0}, False, None, {'entity_id': 'number.mock_opening_degree'}, False),
             ]
         )
 

--- a/tests/test_valve.py
+++ b/tests/test_valve.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 
 from homeassistant.core import HomeAssistant, State
 from homeassistant.components.climate import HVACAction
+from homeassistant.components.number import SERVICE_SET_VALUE
 
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -175,11 +176,14 @@ async def test_over_valve_full_start(
                 #     # {"entity_id": "number.mock_valve", "value": 90},
                 # ),
                 call.async_call(
-                    domain="number",
-                    service="set_value",
-                    service_data={"value": 98},
-                    target={"entity_id": "number.mock_valve"},
-                    # {"entity_id": "number.mock_valve", "value": 98},
+                    "number",
+                    SERVICE_SET_VALUE,
+                    {"value": 98},
+                    False,
+                    None,
+                    {"entity_id": "number.mock_valve"},
+                    False,
+                    # {"entity_id": "number.mock_valve", "value": 90},
                 ),
             ]
         )
@@ -232,10 +236,13 @@ async def test_over_valve_full_start(
         mock_service_call.assert_has_calls(
             [
                 call.async_call(
-                    domain="number",
-                    service="set_value",
-                    service_data={"value": 10},
-                    target={"entity_id": "number.mock_valve"},
+                    "number",
+                    SERVICE_SET_VALUE,
+                    {"value": 10},
+                    False,
+                    None,
+                    {"entity_id": "number.mock_valve"},
+                    False,
                 )
             ]
         )
@@ -246,18 +253,22 @@ async def test_over_valve_full_start(
         mock_service_call.assert_has_calls(
             [
                 call.async_call(
-                    domain="number",
-                    service="set_value",
-                    service_data={"value": 10},
-                    target={"entity_id": "number.mock_valve"},  # the min allowed value
+                    "number",
+                    SERVICE_SET_VALUE,
+                    {"value": 10},
+                    False,
+                    None,
+                    {"entity_id": "number.mock_valve"},  # the min allowed value
+                    False,
                 ),
                 call.async_call(
-                    domain="number",
-                    service="set_value",
-                    service_data={
-                        "value": 34
-                    },  # 34 is 50 x open_percent (69%) and is the max allowed value
-                    target={"entity_id": "number.mock_valve"},
+                    "number",
+                    SERVICE_SET_VALUE,
+                    {"value": 34},  # 34 is 50 x open_percent (69%) and is the max allowed value
+                    False,
+                    None,
+                    {"entity_id": "number.mock_valve"},
+                    False,
                 ),
             ]
         )
@@ -460,10 +471,13 @@ async def test_over_valve_regulation(
         mock_service_call.assert_has_calls(
             [
                 call.async_call(
-                    domain="number",
-                    service="set_value",
-                    service_data={"value": 90},
-                    target={"entity_id": "number.mock_valve"},
+                    "number",
+                    SERVICE_SET_VALUE,
+                    {"value": 90},
+                    False,
+                    None,
+                    {"entity_id": "number.mock_valve"},
+                    False,
                 ),
             ]
         )
@@ -519,10 +533,13 @@ async def test_over_valve_regulation(
         mock_service_call.assert_has_calls(
             [
                 call.async_call(
-                    domain="number",
-                    service="set_value",
-                    service_data={"value": 96},
-                    target={"entity_id": "number.mock_valve"},
+                    "number",
+                    SERVICE_SET_VALUE,
+                    {"value": 96},
+                    False,
+                    None,
+                    {"entity_id": "number.mock_valve"},
+                    False,
                 ),
             ]
         )
@@ -636,10 +653,13 @@ async def test_bug_533(
         mock_service_call.assert_has_calls(
             [
                 call.async_call(
-                    domain="number",
-                    service="set_value",
-                    service_data={"value": 100},
-                    target={"entity_id": "number.mock_valve"},
+                    "number",
+                    SERVICE_SET_VALUE,
+                    {"value": 100},
+                    False,
+                    None,
+                    {"entity_id": "number.mock_valve"},
+                    False
                 ),
             ]
         )
@@ -661,10 +681,13 @@ async def test_bug_533(
         mock_service_call.assert_has_calls(
             [
                 call.async_call(
-                    domain="number",
-                    service="set_value",
-                    service_data={"value": 50},
-                    target={"entity_id": "number.mock_valve"},
+                    "number",
+                    SERVICE_SET_VALUE,
+                    {"value": 50},
+                    False,
+                    None,
+                    {"entity_id": "number.mock_valve"},
+                    False
                 ),
             ]
         )
@@ -686,10 +709,13 @@ async def test_bug_533(
         mock_service_call.assert_has_calls(
             [
                 call.async_call(
-                    domain="number",
-                    service="set_value",
-                    service_data={"value": 10},
-                    target={"entity_id": "number.mock_valve"},
+                    "number",
+                    SERVICE_SET_VALUE,
+                    {"value": 10},
+                    False,
+                    None,
+                    {"entity_id": "number.mock_valve"},
+                    False
                 ),
             ]
         )
@@ -711,10 +737,13 @@ async def test_bug_533(
         mock_service_call.assert_has_calls(
             [
                 call.async_call(
-                    domain="number",
-                    service="set_value",
-                    service_data={"value": 0},
-                    target={"entity_id": "number.mock_valve"},
+                    "number",
+                    SERVICE_SET_VALUE,
+                    {"value": 0},
+                    False,
+                    None,
+                    {"entity_id": "number.mock_valve"},
+                    False
                 ),
             ]
         )


### PR DESCRIPTION
Two mechanisms have been introduced to prevent this :
- a locking mechanism when multiple commands compete.
- a throttling mechanism that adds a 1-second delay when commands are sent too close together.