### PR TITLE
Auto tpi updates

### DIFF
--- a/custom_components/versatile_thermostat/climate.py
+++ b/custom_components/versatile_thermostat/climate.py
@@ -170,6 +170,12 @@ async def async_setup_entry(
         {
             vol.Required("auto_tpi_mode"): vol.In([True, False]),
             vol.Optional("reinitialise", default=True): vol.In([True, False]),
+            vol.Optional("allow_kint_boost_on_stagnation", default=False): vol.In(
+                [True, False]
+            ),
+            vol.Optional(
+                "allow_kext_compensation_on_overshoot", default=False
+            ): vol.In([True, False]),
         },
         "service_set_auto_tpi_mode",
     )

--- a/custom_components/versatile_thermostat/feature_central_power_manager.py
+++ b/custom_components/versatile_thermostat/feature_central_power_manager.py
@@ -1,6 +1,7 @@
 """ Implements a central Power Feature Manager for Versatile Thermostat """
 
 import logging
+
 from typing import Any
 from functools import cmp_to_key
 

--- a/custom_components/versatile_thermostat/sensor.py
+++ b/custom_components/versatile_thermostat/sensor.py
@@ -345,6 +345,8 @@ class AutoTpiSensor(VersatileThermostatBaseEntity, SensorEntity):
             "max_capacity_heat": manager.state.max_capacity_heat,
             "max_capacity_cool": manager.state.max_capacity_cool,
             "learning_start_dt": manager.state.learning_start_date,
+            "allow_kint_boost_on_stagnation": manager.state.allow_kint_boost,
+            "allow_kext_compensation_on_overshoot": manager.state.allow_kext_overshoot,
         }
 
         # Add calculated TPI coefficients

--- a/custom_components/versatile_thermostat/services.yaml
+++ b/custom_components/versatile_thermostat/services.yaml
@@ -284,6 +284,22 @@ set_auto_tpi_mode:
             default: true
             selector:
                 boolean:
+        allow_kint_boost_on_stagnation:
+            name: Allow Kint boost
+            description: Allow boosting Kint when temperature stagnates despite demand (default false)
+            required: true
+            advanced: false
+            default: false
+            selector:
+                boolean:
+        allow_kext_compensation_on_overshoot:
+            name: Allow Kext compensation
+            description: Allow adjusting Kext when temperature overshoots (default false)
+            required: true
+            advanced: false
+            default: false
+            selector:
+                boolean:
 
 
 auto_tpi_calibrate_capacity:

--- a/documentation/en/feature-autotpi.md
+++ b/documentation/en/feature-autotpi.md
@@ -152,8 +152,8 @@ Auto TPI operates cyclically:
     *   **Case 1: Indoor Coefficient**. If the temperature moved in the right direction significantly (> 0.05°C), it calculates the ratio between the real evolution **(over the full cycle, including inertia)** and the expected theoretical evolution (corrected by the calibrated capacity). It adjusts `CoeffInt` to reduce the gap.
     *   **Case 2: Outdoor Coefficient**. If indoor learning was not possible (conditions not met or failure) and outdoor learning is relevant (significant temperature gap > 0.1°C), it adjusts `CoeffExt` **progressively** to compensate for thermal losses. The formula allows this coefficient to increase or decrease as needed to reach equilibrium.
     *   **Case 3: Rapid Corrections (Boost/Deboost)**. In parallel, the system monitors critical anomalies:
-        *   **Kint Boost**: If the temperature stagnates despite a heating demand, the indoor coefficient is boosted.
-        *   **Kext Deboost**: If the temperature exceeds the setpoint and does not decrease, the outdoor coefficient is reduced.
+        *   **Kint Boost**: If the temperature stagnates despite a heating demand, the indoor coefficient is boosted. (Optional via `allow_kint_boost_on_stagnation`)
+        *   **Kext Deboost**: If the temperature exceeds the setpoint and does not decrease, the outdoor coefficient is reduced. (Optional via `allow_kext_compensation_on_overshoot`)
         *   *These corrections are weighted by the model's confidence: the more history (learning cycles) the system has, the more moderate the corrections are to avoid destabilizing a reliable model.*
 4.  **Update**: The new coefficients are smoothed and saved for the next cycle.
 
@@ -176,6 +176,8 @@ A dedicated sensor `sensor.<thermostat_name>_auto_tpi_learning_state` allows tra
 *   `last_learning_status`: Reason for the last success or failure (e.g., `learned_indoor_heat`, `power_out_of_range`).
 *   `calculated_coef_int` / `calculated_coef_ext`: Current values of the coefficients.
 *   `learning_start_dt`: Date and time when learning started (useful for graphs).
+*   `allow_kint_boost_on_stagnation`: Indicates if Kint boost on stagnation is enabled.
+*   `allow_kext_compensation_on_overshoot`: Indicates if Kext compensation on overshoot is enabled.
 
 ## Services
 
@@ -224,6 +226,8 @@ This service allows controlling Auto TPI learning without going through the ther
 |-----------|------|---------|-------------|
 | `auto_tpi_mode` | boolean | - | Enables (`true`) or disables (`false`) learning |
 | `reinitialise` | boolean | `true` | Controls data reset when enabling learning |
+| `allow_kint_boost_on_stagnation` | boolean | `false` | Allows Kint boost when temperature stagnates |
+| `allow_kext_compensation_on_overshoot` | boolean | `false` | Allows Kext compensation on overshoot |
 
 #### Behavior of the `reinitialise` parameter
 

--- a/documentation/fr/feature-autotpi.md
+++ b/documentation/fr/feature-autotpi.md
@@ -149,8 +149,8 @@ L'Auto TPI fonctionne de manière cyclique :
     *   **Cas 1 : Coefficient Intérieur**. Si la température a évolué dans le bon sens de manière significative (> 0.05°C), il calcule le ratio entre l'évolution réelle **(sur l'ensemble du cycle, inertie incluse)** et l'évolution théorique attendue (corrigée par la capacité calibrée). Il ajuste `CoeffInt` pour réduire l'écart.
     *   **Cas 2 : Coefficient Extérieur**. Si l'apprentissage intérieur n'a pas été possible (conditions non remplies ou échec) et que l'apprentissage extérieur est pertinent (écart de température significatif > 0.1°C), il ajuste `CoeffExt` **progressivement** pour compenser les pertes thermiques. La formule permet à ce coefficient d'augmenter ou de diminuer selon les besoins pour atteindre l'équilibre.
     *   **Cas 3 : Corrections Rapides (Boost/Deboost)**. En parallèle, le système surveille les anomalies critiques :
-        *   **Boost Kint** : Si la température stagne malgré une demande de chauffe, le coefficient intérieur est boosté.
-        *   **Deboost Kext** : Si la température dépasse la consigne et ne redescend pas, le coefficient extérieur est réduit.
+        *   **Boost Kint** : Si la température stagne malgré une demande de chauffe, le coefficient intérieur est boosté. (Optionnel via `allow_kint_boost_on_stagnation`)
+        *   **Deboost Kext** : Si la température dépasse la consigne et ne redescend pas, le coefficient extérieur est réduit. (Optionnel via `allow_kext_compensation_on_overshoot`)
         *   *Ces corrections sont pondérées par la confiance du modèle : plus le système a d'historique (cycles d'apprentissage), plus les corrections sont modérées pour éviter de déstabiliser un modèle fiable.*
 4.  **Mise à jour** : Les nouveaux coefficients sont lissés et sauvegardés pour le cycle suivant.
 
@@ -173,6 +173,8 @@ Un capteur dédié `sensor.<nom_thermostat>_auto_tpi_learning_state` permet de s
 *   `last_learning_status` : Raison du dernier succès ou échec (ex: `learned_indoor_heat`, `power_out_of_range`).
 *   `calculated_coef_int` / `calculated_coef_ext` : Valeurs actuelles des coefficients.
 *   `learning_start_dt`: Date et heure du début de l'apprentissage (utile pour les graphiques).
+*   `allow_kint_boost_on_stagnation` : Indique si le boost de Kint en cas de stagnation est activé.
+*   `allow_kext_compensation_on_overshoot` : Indique si la correction de Kext en cas d'overshoot est activée.
 
 ## Services
 
@@ -222,6 +224,8 @@ Ce service permet de contrôler l'apprentissage Auto TPI sans passer par la conf
 |-----------|------|--------|-------------|
 | `auto_tpi_mode` | boolean | - | Active (`true`) ou désactive (`false`) l'apprentissage |
 | `reinitialise` | boolean | `true` | Contrôle la réinitialisation des données lors de l'activation |
+| `allow_kint_boost_on_stagnation` | boolean | `false` | Autorise le boost de Kint en cas de stagnation de température |
+| `allow_kext_compensation_on_overshoot` | boolean | `false` | Autorise la compensation de Kext en cas de dépassement (overshoot) |
 
 #### Comportement du paramètre `reinitialise`
 

--- a/tests/test_auto_tpi.py
+++ b/tests/test_auto_tpi.py
@@ -198,6 +198,9 @@ async def test_perform_learning_indoor(manager):
     # Mock capability to ensure we use max_capacity
     manager._use_capacity_as_rate = True
     
+    # Initialize current target temp to match last_order so it doesn't detect a setpoint change
+    manager._current_target_temp = manager.state.last_order
+
     await manager._perform_learning(current_temp_in, current_temp_out)
     
     assert manager.state.last_learning_status.startswith("learned_indoor")


### PR DESCRIPTION
- add Kint boost for T° stagnation
- fix: skip cycle on setpoint change
- add weight to Kint/Kext boost/deboost
- added options on set_auto_tpi_state service to enable kint boost /  kext deboost ( default disabled ) 