### PR TITLE
Auto tpi domains

### DIFF
--- a/auto_tpi_internal_doc.md
+++ b/auto_tpi_internal_doc.md
@@ -131,7 +131,7 @@ Les constantes suivantes sont définies en haut du fichier `auto_tpi_manager.py`
 | `OVERSHOOT_THRESHOLD` | 0.2°C | Seuil de dépassement de température pour déclencher la correction agressive de Kext |
 | `OVERSHOOT_POWER_THRESHOLD` | 0.05 (5%) | Puissance minimale pour considérer le dépassement comme une erreur de Kext |
 | `OVERSHOOT_CORRECTION_BOOST` | 2.0 | Multiplicateur pour alpha (EMA) ou diviseur de poids (Average) lors de la correction |
-| `INSUFFICIENT_RISE_GAP_THRESHOLD` | 0.3°C | Écart minimum entre consigne et température pour déclencher la correction Kint si stagnation |
+| `INSUFFICIENT_RISE_GAP_THRESHOLD` | 0.5°C | Écart minimum entre consigne et température pour déclencher la correction Kint si stagnation |
 | `INSUFFICIENT_RISE_BOOST_FACTOR` | 1.08 | Facteur d'augmentation de Kint (8%) par cycle de stagnation |
 | `MAX_CONSECUTIVE_KINT_BOOSTS` | 5 | Nombre maximum de boosts Kint consécutifs avant avertissement (chauffage sous-dimensionné) |
 
@@ -169,7 +169,7 @@ Les constantes suivantes sont définies en haut du fichier `auto_tpi_manager.py`
 **Activation :** Cette correction est optionnelle et doit être activée via le service `set_auto_tpi_mode` (paramètre `allow_kint_boost_on_stagnation`).
 
 **Conditions de déclenchement :**
-1.  **Écart significatif** : `target_diff > INSUFFICIENT_RISE_GAP_THRESHOLD` (0.3°C par défaut)
+1.  **Écart significatif** : `target_diff > INSUFFICIENT_RISE_GAP_THRESHOLD` (0.5°C par défaut)
 2.  **Température stagnante** : `temp_progress < 0.02°C` (la température n'a pas augmenté pendant le cycle)
 3.  **Puissance non saturée** : `power < 0.99` (le système peut encore augmenter la puissance)
 4.  **Limite non atteinte** : `consecutive_boosts < MAX_CONSECUTIVE_KINT_BOOSTS` (5 par défaut)
@@ -399,7 +399,7 @@ La détection de changement de régime est **uniquement active** lorsque l'appre
     *   Cette méthode n'est plus exposée comme un service externe. Elle est utilisée en interne si un reset complet était nécessaire.
     *   **Action** : Réinitialisation complète de l'état d'apprentissage (`AutoTpiState`), incluant coefficients, compteurs, et capacités.
 *   **Démarrage (`start_learning`)** : L'appel à `start_learning(reset_data, ...)` (ex: via le service `set_auto_tpi_mode`) :
-    *   **Paramètres Optionnels** : le service accepte désormais `allow_kint_boost_on_stagnation` et `allow_kext_compensation_on_overshoot` (défaut `False`) pour activer les logiques de correction spécifiques.
+    *   **Paramètres Optionnels** : le service accepte désormais `allow_kint_boost_on_stagnation` (défaut `True`) et `allow_kext_compensation_on_overshoot` (défaut `False`) pour activer les logiques de correction spécifiques.
     *   **Paramètre `reset_data`** (défaut: `True`) : Contrôle la réinitialisation des données d'apprentissage.
         *   Si `reset_data=True` : Réinitialise les compteurs, les coefficients (sauf si fournis) et la date de démarrage `learning_start_dt`. La capacité calibrée est **conservée**.
         *   Si `reset_data=False` : Reprend l'apprentissage en conservant les coefficients, les compteurs et la date de démarrage existants. Seul le flag `autolearn_enabled` est activé.

--- a/custom_components/versatile_thermostat/auto_tpi_manager.py
+++ b/custom_components/versatile_thermostat/auto_tpi_manager.py
@@ -39,10 +39,10 @@ MIN_KINT = 0.05  # Minimum Kint threshold to maintain temperature responsiveness
 OVERSHOOT_THRESHOLD = 0.2  # Temperature overshoot threshold (°C) to trigger aggressive Kext correction
 OVERSHOOT_POWER_THRESHOLD = 0.05  # Minimum power (5%) to consider overshoot as Kext error
 OVERSHOOT_CORRECTION_BOOST = 2.0  # Multiplier for alpha during overshoot correction
-INSUFFICIENT_RISE_GAP_THRESHOLD = 0.3  # Min gap (°C) to trigger Kint correction when temp stagnates
+KEXT_LEARNING_MAX_GAP = 0.5  # Max gap (°C) to allow Kext learning (Near-Field vs Far-Field)
+INSUFFICIENT_RISE_GAP_THRESHOLD = KEXT_LEARNING_MAX_GAP  # Min gap (°C) to trigger Kint correction when temp stagnates
 INSUFFICIENT_RISE_BOOST_FACTOR = 1.08  # Kint increase factor (8%) per stagnating cycle
 MAX_CONSECUTIVE_KINT_BOOSTS = 5  # Max consecutive Kint boosts before warning (undersized heating)
-KEXT_LEARNING_MAX_GAP = 0.5  # Max gap (°C) to allow Kext learning (Near-Field vs Far-Field)
 
 
 @dataclass
@@ -2164,7 +2164,7 @@ class AutoTpiManager:
         coef_int: float = None,
         coef_ext: float = None,
         reset_data: bool = True,
-        allow_kint_boost: bool = False,
+        allow_kint_boost: bool = True,
         allow_kext_overshoot: bool = False,
     ):
         """Start learning, optionally resetting coefficients and learning data.

--- a/custom_components/versatile_thermostat/services.yaml
+++ b/custom_components/versatile_thermostat/services.yaml
@@ -286,10 +286,10 @@ set_auto_tpi_mode:
                 boolean:
         allow_kint_boost_on_stagnation:
             name: Allow Kint boost
-            description: Allow boosting Kint when temperature stagnates despite demand (default false)
+            description: Allow boosting Kint when temperature stagnates despite demand (default true)
             required: true
             advanced: false
-            default: false
+            default: true
             selector:
                 boolean:
         allow_kext_compensation_on_overshoot:

--- a/documentation/en/feature-autotpi.md
+++ b/documentation/en/feature-autotpi.md
@@ -227,7 +227,7 @@ This service allows controlling Auto TPI learning without going through the ther
 |-----------|------|---------|-------------|
 | `auto_tpi_mode` | boolean | - | Enables (`true`) or disables (`false`) learning |
 | `reinitialise` | boolean | `true` | Controls data reset when enabling learning |
-| `allow_kint_boost_on_stagnation` | boolean | `false` | Allows Kint boost when temperature stagnates |
+| `allow_kint_boost_on_stagnation` | boolean | `true` | Allows Kint boost when temperature stagnates |
 | `allow_kext_compensation_on_overshoot` | boolean | `false` | Allows Kext compensation on overshoot |
 
 #### Behavior of the `reinitialise` parameter

--- a/documentation/fr/feature-autotpi.md
+++ b/documentation/fr/feature-autotpi.md
@@ -225,7 +225,7 @@ Ce service permet de contrôler l'apprentissage Auto TPI sans passer par la conf
 |-----------|------|--------|-------------|
 | `auto_tpi_mode` | boolean | - | Active (`true`) ou désactive (`false`) l'apprentissage |
 | `reinitialise` | boolean | `true` | Contrôle la réinitialisation des données lors de l'activation |
-| `allow_kint_boost_on_stagnation` | boolean | `false` | Autorise le boost de Kint en cas de stagnation de température |
+| `allow_kint_boost_on_stagnation` | boolean | `true` | Autorise le boost de Kint en cas de stagnation de température |
 | `allow_kext_compensation_on_overshoot` | boolean | `false` | Autorise la compensation de Kext en cas de dépassement (overshoot) |
 
 #### Comportement du paramètre `reinitialise`


### PR DESCRIPTION
 Introduce KEXT_LEARNING_MAX_GAP (0.5°C) to block Kext learning during far-field stagnation.
- Prevents `Kext` from being incorrectly inflated during transient ramp-up phases, reducing overshoot.
- Stagnation > 0.5°C is now treated correctly as a `Kint` or Capacity issue.
- Enable kint boost by default