### PR TITLE
fix #1551: safe json conversion for Ha-states & storage

### DIFF
--- a/custom_components/versatile_thermostat/auto_tpi_manager.py
+++ b/custom_components/versatile_thermostat/auto_tpi_manager.py
@@ -2274,7 +2274,7 @@ class AutoTpiManager:
 
         _LOGGER.debug("%s - Auto TPI: Cycle started. On: %.0fs, Off: %.0fs (%.1f%%), Mode: %s", self._name, on_time_sec, off_time_sec, on_percent * 100, hvac_mode)
 
-        now = datetime.now()
+        now = dt_util.now()
 
         # Snapshot current state for learning at the end of the cycle
         self.state.last_temp_in = self._current_temp_in
@@ -2333,7 +2333,7 @@ class AutoTpiManager:
 
         # Update last_heater_stop_time if we were heating
         if self.state.last_state == "heat":
-            self.state.last_heater_stop_time = datetime.now()
+            self.state.last_heater_stop_time = dt_util.now()
 
         # Calculate Power Efficiency based on Heater Warm-up Time and Cold Factor
         # heater_heating_time is the time for the heater to warm up when fully cold.
@@ -2543,7 +2543,7 @@ class AutoTpiManager:
             self.state.total_cycles = 0
             self.state.consecutive_failures = 0
             self.state.last_learning_status = "learning_started"
-            self.state.cycle_start_date = datetime.now()
+            self.state.cycle_start_date = dt_util.now()
             self.state.cycle_active = False
         else:
             _LOGGER.info(
@@ -2559,7 +2559,7 @@ class AutoTpiManager:
 
         # Set start date only if it's a new session (reset) or if it wasn't set (first start)
         if reset_data or self.state.learning_start_date is None:
-            self.state.learning_start_date = datetime.now()
+            self.state.learning_start_date = dt_util.now()
 
         # ===== BOOTSTRAP PHASE LOGIC =====
         # Determine bootstrap strategy (3 modes)
@@ -2681,7 +2681,7 @@ class AutoTpiManager:
         if not self._data_provider:
             return
 
-        now = datetime.now()
+        now = dt_util.now()
 
         # 1. Get fresh data from thermostat FIRST
         # This ensures we have current temperatures for "End of Cycle" validation

--- a/tests/test_auto_tpi_simulation.py
+++ b/tests/test_auto_tpi_simulation.py
@@ -107,10 +107,10 @@ async def test_auto_tpi_convergence_simulation(mock_hass, mock_store, mock_confi
     print(f"\n{'Cycle':<5} | {'RoomT':<8} | {'ExtT':<8} | {'Power%':<8} | {'Kint':<8} | {'Kext':<8} | {'Status'}")
     print("-" * 80)
 
-    with patch("custom_components.versatile_thermostat.auto_tpi_manager.datetime") as mock_datetime, \
+    with patch("custom_components.versatile_thermostat.auto_tpi_manager.dt_util") as mock_dt_util, \
          patch("custom_components.versatile_thermostat.auto_tpi_manager.async_call_later") as mock_call_later:
         
-        mock_datetime.now.side_effect = lambda: sim_time
+        mock_dt_util.now.side_effect = lambda: sim_time
         
         async def data_provider():
             await manager.update(


### PR DESCRIPTION
Not so sure as I couldn't reproduce #1551, but it should prevent the oberved behavior.