### PR TITLE
fix(switch): force cycle cancel when power drops to 0%

### DIFF
--- a/custom_components/versatile_thermostat/underlyings.py
+++ b/custom_components/versatile_thermostat/underlyings.py
@@ -468,6 +468,7 @@ class UnderlyingSwitch(UnderlyingEntity):
                 if on_time_sec == 0 and self.is_device_active:
                     _LOGGER.info("%s - Power is 0%%, turning off device immediately", self)
                     await self.turn_off()
+                    return  # Nothing more to do, device is off
             else:
                 _LOGGER.debug(
                     "%s - A previous cycle is already running and no force -> waits for its end",


### PR DESCRIPTION
Fixes heater continuing to cycle with stale parameters after setpoint change. The internal cycle loop was self-perpetuating and ignored new 0% power commands because force=False. Now, on_time_sec=0 triggers an immediate cycle cancel and device turn-off.

this attend to fix #1546