### PR TITLE
auto-tpi: Added "Aggressiveness" parameter ( 50-100%, default 90% ).

### DIFF
--- a/auto_tpi_internal_doc.md
+++ b/auto_tpi_internal_doc.md
@@ -441,7 +441,7 @@ Elle est **exclue** du flux de configuration de la configuration centrale, car c
 2.  **Auto TPI - Général** (`auto_tpi_1`) :
     *   Si l'Auto TPI est activé, cette étape permet de configurer les paramètres généraux : mise à jour de la config, notifications, temps de chauffe/refroidissement, coefficient max.
 3.  **Auto TPI - Puissance** (`auto_tpi_2`) :
-    *   Elle permet de saisir manuellement les capacités de chauffe (`auto_tpi_heating_rate`) en °C/h.
+    *   Elle permet de saisir manuellement les capacités de chauffe (`auto_tpi_heating_rate`) en °C/h.\n    *   Le paramètre **Agressivité** (`auto_tpi_aggressiveness`) permet de définir le pourcentage de la capacité thermique apprise à utiliser (50-100%, défaut 90%). Des valeurs plus basses donnent des coefficients plus conservateurs, réduisant les risques de dépassement de consigne.
 4.  **Auto TPI - Méthode** (`auto_tpi_2`) :
     *   Choix de la méthode de calcul :
     *   **Moyenne (Average)** : Utilise une moyenne pondérée qui accorde de moins en moins d'importance aux nouvelles valeurs. Idéale pour un apprentissage initial rapide et unique. Ne convient pas à l'apprentissage continu.

--- a/custom_components/versatile_thermostat/base_thermostat.py
+++ b/custom_components/versatile_thermostat/base_thermostat.py
@@ -1936,7 +1936,6 @@ class BaseThermostat(ClimateEntity, RestoreEntity, Generic[T]):
         self,
         save_to_config: bool,
         min_power_threshold: int,
-        capacity_safety_margin: int = 20,
         start_date: datetime | None = None,
         end_date: datetime | None = None,
     ):

--- a/custom_components/versatile_thermostat/climate.py
+++ b/custom_components/versatile_thermostat/climate.py
@@ -189,9 +189,6 @@ async def async_setup_entry(
             vol.Optional("min_power_threshold", default=95): selector.NumberSelector(
                 selector.NumberSelectorConfig(min=80, max=100, step=1, mode=selector.NumberSelectorMode.SLIDER)
             ),
-            vol.Optional("capacity_safety_margin", default=20): selector.NumberSelector(
-                selector.NumberSelectorConfig(min=0, max=90, step=1, mode=selector.NumberSelectorMode.SLIDER)
-            ),
         },
         "service_auto_tpi_calibrate_capacity",
         supports_response=SupportsResponse.OPTIONAL,

--- a/custom_components/versatile_thermostat/config_schema.py
+++ b/custom_components/versatile_thermostat/config_schema.py
@@ -505,6 +505,11 @@ STEP_AUTO_TPI_1_SCHEMA = vol.Schema(
         vol.Optional(CONF_AUTO_TPI_HEATER_HEATING_TIME, default=5): cv.positive_int,
         vol.Optional(CONF_AUTO_TPI_HEATER_COOLING_TIME, default=5): cv.positive_int,
         vol.Required(CONF_AUTO_TPI_HEATING_POWER, default=0.0): vol.Coerce(float),
+        vol.Required(CONF_AUTO_TPI_AGGRESSIVENESS, default=0.9): selector.NumberSelector(
+            selector.NumberSelectorConfig(
+                min=0.5, max=1.0, step=0.01, mode=selector.NumberSelectorMode.SLIDER
+            )
+        ),
 
         vol.Required(CONF_AUTO_TPI_MAX_COEF_INT, default=1.0): selector.NumberSelector(
             selector.NumberSelectorConfig(

--- a/custom_components/versatile_thermostat/const.py
+++ b/custom_components/versatile_thermostat/const.py
@@ -176,6 +176,7 @@ CONF_AUTO_TPI_AVG_INITIAL_WEIGHT = "auto_tpi_avg_initial_weight"
 CONF_AUTO_TPI_MAX_COEF_INT = "auto_tpi_max_coef_int"
 CONF_AUTO_TPI_HEATING_POWER = "auto_tpi_heating_rate"
 CONF_AUTO_TPI_COOLING_POWER = "auto_tpi_cooling_rate"
+CONF_AUTO_TPI_AGGRESSIVENESS = "auto_tpi_aggressiveness"
 
 CONF_AUTO_TPI_EMA_DECAY_RATE = "auto_tpi_ema_decay_rate"
 

--- a/custom_components/versatile_thermostat/services.yaml
+++ b/custom_components/versatile_thermostat/services.yaml
@@ -327,20 +327,6 @@ auto_tpi_calibrate_capacity:
             example: "2023-12-01"
             selector:
                 date:
-        capacity_safety_margin:
-            name: "Safety Margin for Capacity"
-            description: "Margin percentage to subtract from max capacity before saving. Valid range 0-30%. Default is 20%."
-            required: true
-            advanced: false
-            example: 20
-            default: 20
-            selector:
-                number:
-                    min: 0
-                    max: 30
-                    step: 1
-                    unit_of_measurement: "%"
-                    mode: slider
         min_power_threshold:
             name: Minimum Power Threshold
             description: Minimum power percentage to consider a cycle as saturated (default 95%). Lower values (e.g., 90%) will include more cycles but may be less accurate.

--- a/custom_components/versatile_thermostat/thermostat_tpi.py
+++ b/custom_components/versatile_thermostat/thermostat_tpi.py
@@ -117,6 +117,7 @@ class ThermostatTPI(BaseThermostat[T], Generic[T]):
         max_coef_int = self._entry_infos.get(CONF_AUTO_TPI_MAX_COEF_INT, 1.5)
         heating_rate = self._entry_infos.get(CONF_AUTO_TPI_HEATING_POWER, 1.0)
         cooling_rate = self._entry_infos.get(CONF_AUTO_TPI_COOLING_POWER, 1.0)
+        aggressiveness = self._entry_infos.get(CONF_AUTO_TPI_AGGRESSIVENESS, 0.9)
         self._auto_tpi_enable_update_config = self._entry_infos.get(CONF_AUTO_TPI_ENABLE_UPDATE_CONFIG, False)
         self._auto_tpi_enable_notification = self._entry_infos.get(CONF_AUTO_TPI_ENABLE_NOTIFICATION, False)
         self._auto_tpi_continuous_learning = (self._entry_infos.get(CONF_AUTO_TPI_CONTINUOUS_LEARNING, False),)
@@ -145,8 +146,9 @@ class ThermostatTPI(BaseThermostat[T], Generic[T]):
             cooling_rate=cooling_rate,
             continuous_learning=self._auto_tpi_continuous_learning,
             keep_ext_learning=self._auto_tpi_keep_ext_learning,
-            enable_update_config=self._auto_tpi_enable_update_config, # Pass the config flags
-            enable_notification=self._auto_tpi_enable_notification, # Pass the config flags
+            enable_update_config=self._auto_tpi_enable_update_config,
+            enable_notification=self._auto_tpi_enable_notification,
+            aggressiveness=aggressiveness,
         )
         self._auto_tpi_manager.set_is_vtherm_stopping_callback(lambda: self._is_removed)
         _LOGGER.info("%s - DEBUG: AutoTpiManager initialized with defaults: int=%.3f, ext=%.3f",
@@ -505,7 +507,6 @@ class ThermostatTPI(BaseThermostat[T], Generic[T]):
         self,
         save_to_config: bool,
         min_power_threshold: int,
-        capacity_safety_margin: int = 20,
         start_date: datetime | None = None,
         end_date: datetime | None = None,
     ):
@@ -516,7 +517,6 @@ class ThermostatTPI(BaseThermostat[T], Generic[T]):
             end_date: 2023-12-01T00:00:00+00:00
             save_to_config: true
             min_power_threshold: 95
-            capacity_safety_margin: 20
         target:
             entity_id: climate.thermostat_1
         """
@@ -530,7 +530,7 @@ class ThermostatTPI(BaseThermostat[T], Generic[T]):
                 f"{self} - Auto TPI is not enabled in configuration."
             )
 
-        write_event_log(_LOGGER, self, f"Calling SERVICE_AUTO_TPI_CALIBRATE_CAPACITY, save_to_config: {save_to_config}, start_date: {start_date}, end_date: {end_date}, min_power_threshold: {min_power_threshold}, capacity_safety_margin: {capacity_safety_margin}")
+        write_event_log(_LOGGER, self, f"Calling SERVICE_AUTO_TPI_CALIBRATE_CAPACITY, save_to_config: {save_to_config}, start_date: {start_date}, end_date: {end_date}, min_power_threshold: {min_power_threshold}")
 
         if not self._auto_tpi_manager:
             raise ServiceValidationError(f"{self} - Auto TPI Manager not initialized, cannot calibrate capacity.")
@@ -543,11 +543,10 @@ class ThermostatTPI(BaseThermostat[T], Generic[T]):
             start_date=start_date,
             end_date=end_date,
             min_power_threshold=min_power_threshold / 100.0,  # Convert from % to decimal
-            capacity_safety_margin=capacity_safety_margin / 100.0  # Convert from % to decimal
         )
 
         # If capacity was updated, we might need to recalculate (though capacity mainly affects TPI next cycle)
-        if result and result.get("success") and result.get("recommended_capacity"):
+        if result and result.get("success") and result.get("max_capacity"):
             self.recalculate()
 
         self.update_custom_attributes()

--- a/custom_components/versatile_thermostat/translations/en.json
+++ b/custom_components/versatile_thermostat/translations/en.json
@@ -294,7 +294,8 @@
           "heater_heating_time": "Heater warm-up time (min)",
           "heater_cooling_time": "Heater cool-down time (min)",
           "auto_tpi_max_coef_int": "Max Internal Coefficient",
-          "auto_tpi_heating_rate": "Heating rate ({unit}/h)"
+          "auto_tpi_heating_rate": "Heating rate ({unit}/h)",
+          "auto_tpi_aggressiveness": "Aggressiveness"
         },
         "data_description": {
           "auto_tpi_enable_update_config": "Automatically update the configuration with learned coefficients",
@@ -697,7 +698,8 @@
           "heater_heating_time": "Heater warm-up time (min)",
           "heater_cooling_time": "Heater cool-down time (min)",
           "auto_tpi_max_coef_int": "Max Internal Coefficient",
-          "auto_tpi_heating_rate": "Heating rate ({unit}/h)"
+          "auto_tpi_heating_rate": "Heating rate ({unit}/h)",
+          "auto_tpi_aggressiveness": "Aggressiveness"
         },
         "data_description": {
           "auto_tpi_enable_update_config": "Automatically update the configuration with learned coefficients",
@@ -970,10 +972,6 @@
         "min_power_threshold": {
           "name": "Minimum Power Threshold",
           "description": "Minimum power percentage to consider a cycle as saturated (default 95%). Lower values will include more cycles but may be less accurate."
-        },
-        "capacity_safety_margin": {
-          "name": "Safety Margin for Capacity",
-          "description": "Margin percentage to subtract from max capacity before saving. Valid range 0-30%. Default is 20%."
         }
       }
     },

--- a/custom_components/versatile_thermostat/translations/fr.json
+++ b/custom_components/versatile_thermostat/translations/fr.json
@@ -296,7 +296,8 @@
           "heater_heating_time": "Temps de chauffe (min)",
           "heater_cooling_time": "Temps de refroidissement (min)",
           "auto_tpi_max_coef_int": "Coefficient Interne Max",
-          "auto_tpi_heating_rate": "Taux de chauffe ({unit}/h)"
+          "auto_tpi_heating_rate": "Taux de chauffe ({unit}/h)",
+          "auto_tpi_aggressiveness": "Agressivité"
         },
         "data_description": {
           "auto_tpi_enable_update_config": "Mettre à jour automatiquement la configuration avec les coefficients appris",
@@ -306,7 +307,8 @@
           "heater_heating_time": "Temps pour atteindre la pleine puissance (minutes)",
           "heater_cooling_time": "Temps pour refroidir après arrêt (minutes)\n\n| Type | Temps de chauffe | Temps de refroidissement |\n| :--- | :--- | :--- |\n| Radiateur électrique | 5mn | 7mn |\n| Radiateur à eau | 15mn | 20mn |\n| Chauffage par le sol | 30mn | 45mn |",
           "auto_tpi_max_coef_int": "Valeur maximale autorisée pour le coefficient interne (Coeff Int)",
-          "auto_tpi_heating_rate": "Capacité de montée en température du radiateur ({unit} par heure). Peux être estimée depuis le service action 'Calibrer la capacité'"
+          "auto_tpi_heating_rate": "Capacité de montée en température du radiateur ({unit} par heure). Peux être estimée depuis le service action 'Calibrer la capacité'",
+          "auto_tpi_aggressiveness": "Pourcentage de la capacité thermique apprise à utiliser (50-100%). Des valeurs plus basses donnent des coefficients plus conservateurs."
         }
       },
       "auto_tpi_2": {
@@ -688,7 +690,8 @@
           "heater_heating_time": "Temps de chauffe (min)",
           "heater_cooling_time": "Temps de refroidissement (min)",
           "auto_tpi_max_coef_int": "Coefficient Interne Max",
-          "auto_tpi_heating_rate": "Taux de chauffe ({unit}/h)"
+          "auto_tpi_heating_rate": "Taux de chauffe ({unit}/h)",
+          "auto_tpi_aggressiveness": "Agressivité"
         },
         "data_description": {
           "auto_tpi_enable_update_config": "Mettre à jour automatiquement la configuration avec les coefficients appris",
@@ -698,7 +701,8 @@
           "heater_heating_time": "Temps pour atteindre la pleine puissance (minutes)",
           "heater_cooling_time": "Temps pour refroidir après arrêt (minutes)\n\n| Type | Temps de chauffe | Temps de refroidissement |\n| :--- | :--- | :--- |\n| Radiateur électrique | 5mn | 7mn |\n| Radiateur à eau | 15mn | 20mn |\n| Chauffage par le sol | 30mn | 45mn |",
           "auto_tpi_max_coef_int": "Valeur maximale autorisée pour le coefficient interne (Coeff Int)",
-          "auto_tpi_heating_rate": "Capacité de montée en température du radiateur ({unit} par heure). Peux être estimée depuis le service action 'Calibrer la capacité'"
+          "auto_tpi_heating_rate": "Capacité de montée en température du radiateur ({unit} par heure). Peux être estimée depuis le service action 'Calibrer la capacité'",
+          "auto_tpi_aggressiveness": "Pourcentage de la capacité thermique apprise à utiliser (50-100%). Des valeurs plus basses donnent des coefficients plus conservateurs."
         }
       },
       "auto_tpi_2": {
@@ -973,10 +977,6 @@
         "min_power_threshold": {
           "name": "Seuil de puissance minimum",
           "description": "Pourcentage de puissance minimum pour considérer un cycle comme saturé (par défaut 95%). Des valeurs plus basses incluront plus de cycles mais peuvent être moins précises."
-        },
-        "capacity_safety_margin": {
-          "name": "Marge de sécurité",
-          "description": "Marge de sécurité en pourcentage à soustraire de la capacité maximale avant sauvegarde. Plage valide 0-30%. Défaut 20%."
         }
       }
     },

--- a/documentation/fr/feature-autotpi.md
+++ b/documentation/fr/feature-autotpi.md
@@ -45,7 +45,7 @@ Une fois coché, un assistant de configuration dédié s'affiche en plusieurs é
 *   **Temps de chauffe/refroidissement** : Définissez l'inertie de votre radiateur ([voir Configuration Thermique](#configuration-thermique-critique)).
 *   **Plafond Coefficient Intérieur** : Limites de sécurité pour le coefficient Interieur (`max 3.0`). **Remarque** : En cas de modification de cette limite dans le flux de configuration, la nouvelle valeur est **immédiatement** appliquée aux coefficients appris si ces derniers sont supérieurs à la nouvelle limite (ce qui nécessite un rechargement de l'intégration, ce qui est le cas après avoir enregistré une modification via les options).
 
-*   **Taux de chauffe** (`auto_tpi_heating_rate`): Taux cible de montée en température en °C/h. ([voir Configuration des Taux](#configuration-des-taux-de-chauffe) )
+*   **Taux de chauffe** (`auto_tpi_heating_rate`): Taux cible de montée en température en °C/h. ([voir Configuration des Taux](#configuration-des-taux-de-chauffe) )\n*   **Agressivité** (`auto_tpi_aggressiveness`): Pourcentage de la capacité thermique apprise à utiliser (50-100%, défaut 90%). Des valeurs plus basses donnent des coefficients plus conservateurs, réduisant le risque de dépassement de consigne.
 
     *Note: On ne veut pas forcément utiliser le taux de chauffe maximal. Vous pouvez tout à fait utiliser une valeur inférieure selon le dimensionnement du chauffage, **et c'est très conseillé**.
     Plus vous serez proche de la capacité maximale, plus le coefficient Kint trouvé lors de l'apprentissage sera elevé.*


### PR DESCRIPTION
This value represent the percentage of total capacity to use for autotpi calculation. As we use full capacity and it is now updated on-line, it needs to be adjusted for smooth regulation depending of the system heating power.
Lower value will calculate  more conservative coeeficient.

removed deprecated capacity margin parameter from calculate_capacity service.

updated docs