### PR TITLE
fix(auto_tpi): reset current_cycle_params on learning start

### DIFF
--- a/auto_tpi_internal_doc.md
+++ b/auto_tpi_internal_doc.md
@@ -424,7 +424,7 @@ La détection de changement de régime est **uniquement active** lorsque l'appre
 *   **Démarrage (`start_learning`)** : L'appel à `start_learning(reset_data, ...)` (ex: via le service `set_auto_tpi_mode`) :
     *   **Paramètres Optionnels** : le service accepte désormais `allow_kint_boost_on_stagnation` (défaut `False`) et `allow_kext_compensation_on_overshoot` (défaut `False`) pour activer les logiques de correction spécifiques.
     *   **Paramètre `reset_data`** (défaut: `True`) : Contrôle la réinitialisation des données d'apprentissage.
-        *   Si `reset_data=True` : Réinitialise les compteurs, les coefficients (sauf si fournis) et la date de démarrage `learning_start_dt`. La capacité calibrée est **conservée**. `last_learning_status` est mis à `learning_started`.
+        *   Si `reset_data=True` : Réinitialise les compteurs, les coefficients (sauf si fournis), la date de démarrage `learning_start_dt` et les paramètres du cycle courant (`current_cycle_params`). La capacité calibrée est **conservée**. `last_learning_status` est mis à `learning_started`.
         *   Si `reset_data=False` : Reprend l'apprentissage en conservant les coefficients, les compteurs et la date de démarrage existants. Seul le flag `autolearn_enabled` est activé. `last_learning_status` est mis à `learning_resumed`.
 *   **Arrêt de l'apprentissage (`stop_learning`)** : L'appel à `stop_learning()` (ex: via le service `set_auto_tpi_mode` avec `auto_tpi_mode: false`) provoque :
     *   **Désactivation de l'apprentissage** : `autolearn_enabled` est mis à `False`, l'apprentissage s'arrête. `last_learning_status` est mis à `learning_stopped`.

--- a/custom_components/versatile_thermostat/auto_tpi_manager.py
+++ b/custom_components/versatile_thermostat/auto_tpi_manager.py
@@ -2574,6 +2574,7 @@ class AutoTpiManager:
             self.state.last_learning_status = "learning_started"
             self.state.cycle_start_date = dt_util.now()
             self.state.cycle_active = False
+            self.state.current_cycle_params = None  # Ensure first tick starts fresh
         else:
             _LOGGER.info(
                 "%s - Auto TPI: Resuming learning with existing data (coef_int=%.3f, coef_ext=%.3f, cycles=%d)",


### PR DESCRIPTION
When starting Auto TPI learning with reset_data=True, current_cycle_params was not being reset to None. This caused the first tick to incorrectly try to complete a cycle that never started