### PR TITLE
autotpi: filter published attributes depending of heat/cool mode

### DIFF
--- a/custom_components/versatile_thermostat/sensor.py
+++ b/custom_components/versatile_thermostat/sensor.py
@@ -338,6 +338,7 @@ class AutoTpiSensor(VersatileThermostatBaseEntity, SensorEntity):
             self._attr_native_value = "Off" # Or "Completed" / "Idle" depending on context, but "Off" implies not learning.
 
         # Update attributes
+        # Update attributes
         self._attr_extra_state_attributes = {
             "coeff_int_cycles": manager.int_cycles,
             "coeff_ext_cycles": manager.ext_cycles,
@@ -345,16 +346,24 @@ class AutoTpiSensor(VersatileThermostatBaseEntity, SensorEntity):
             "thermal_time_constant_hours": manager.time_constant,  # Building's thermal time constant τ
             "model_confidence": manager.confidence,  # Model confidence (R² or percentage)
             "last_learning_status": manager.state.last_learning_status,  # Reason for last learning outcome
-            "max_capacity_heat": manager.state.max_capacity_heat,
-            "max_capacity_cool": manager.state.max_capacity_cool,
             "learning_start_dt": manager.state.learning_start_date,
             "allow_kint_boost_on_stagnation": manager.state.allow_kint_boost,
             "allow_kext_compensation_on_overshoot": manager.state.allow_kext_overshoot,
-            "capacity_heat_status": "learning" if manager.is_in_bootstrap else "learned",
-            "capacity_heat_value": manager.state.max_capacity_heat,
-            "capacity_heat_count": manager.state.capacity_heat_learn_count,
             "bootstrap_failure_count": manager.state.bootstrap_failure_count,
         }
+
+        # Add mode-specific attributes
+        if manager._current_hvac_mode == "cool":
+            self._attr_extra_state_attributes.update({
+                "max_capacity_cool": manager.state.max_capacity_cool,
+            })
+        else:
+            self._attr_extra_state_attributes.update({
+                "max_capacity_heat": manager.state.max_capacity_heat,
+                "capacity_heat_status": "learning" if manager.is_in_bootstrap else "learned",
+                "capacity_heat_value": manager.state.max_capacity_heat,
+                "capacity_heat_count": manager.state.capacity_heat_learn_count,
+            })
 
         # Add calculated TPI coefficients
         calculated = manager.get_calculated_params()

--- a/custom_components/versatile_thermostat/thermostat_tpi.py
+++ b/custom_components/versatile_thermostat/thermostat_tpi.py
@@ -653,7 +653,7 @@ class ThermostatTPI(BaseThermostat[T], Generic[T]):
         self._attr_extra_state_attributes["specific_states"].update(
             {
                 "auto_tpi_state": ("on" if self._auto_tpi_manager and self._auto_tpi_manager.learning_active else "off"),
-                "auto_tpi_learning": (self._auto_tpi_manager.state.to_dict() if self._auto_tpi_manager and self._auto_tpi_manager.learning_active else {}),
+                "auto_tpi_learning": (self._auto_tpi_manager.get_filtered_state() if self._auto_tpi_manager and self._auto_tpi_manager.learning_active else {}),
             }
         )
 


### PR DESCRIPTION
Removed recent_errors from attributes
publish only related ( heat/cool ) data attributes ( we're still using only heat anyway  ) 