### PR TITLE
feat(auto-tpi): add pre-bootstrap calibration step

### DIFF
--- a/auto_tpi_internal_doc.md
+++ b/auto_tpi_internal_doc.md
@@ -88,6 +88,13 @@ Pour éviter que les systèmes à forte inertie (ex: plancher chauffant) ne rest
 *   Il assigne une capacité par défaut de **0.3 °C/h** (valeur sécuritaire pour système lent).
 *   L'apprentissage reprend ensuite normalement avec des coefficients non forcés.
 
+**Pré-calibration avant Bootstrap (`_try_pre_bootstrap_calibration`) :**
+Avant de démarrer le mode bootstrap agressif, le système tente de calibrer la capacité à partir de l'historique existant :
+*   Appel interne à `service_calibrate_capacity` avec `min_power_threshold=80%` et `save_to_config=false`.
+*   Si `reliability >= MIN_PRE_BOOTSTRAP_CALIBRATION_RELIABILITY` (20% par défaut) et `max_capacity > 0`, la capacité calibrée est utilisée et le bootstrap est sauté.
+*   Sinon, le bootstrap normal se déclenche avec les coefficients agressifs.
+*   **Justification du seuil** : Le bootstrap n'utilise que 3 mesures. Avec la formule de fiabilité `reliability = 100 × min(samples/20, 1) × max(0, 1 - CV/2)`, 20% correspond à environ 4 échantillons avec une variance moyenne, ce qui est déjà plus robuste que 3 cycles de bootstrap.
+
 **Formule (inspirée de regul2.py) :**
 1.  **Capacité Observée** : `Rise / (Duration * Efficiency)`
 2.  **Correction Adiabatique** : On ajoute les pertes estimées pour obtenir la capacité "brute" (isolation parfaite).
@@ -150,6 +157,7 @@ Les constantes suivantes sont définies en haut du fichier `auto_tpi_manager.py`
 | `INSUFFICIENT_RISE_GAP_THRESHOLD` | 0.5°C | Écart minimum entre consigne et température pour déclencher la correction Kint si stagnation |
 | `INSUFFICIENT_RISE_BOOST_FACTOR` | 1.08 | Facteur d'augmentation de Kint (8%) par cycle de stagnation |
 | `MAX_CONSECUTIVE_KINT_BOOSTS` | 5 | Nombre maximum de boosts Kint consécutifs avant avertissement (chauffage sous-dimensionné) |
+| `MIN_PRE_BOOTSTRAP_CALIBRATION_RELIABILITY` | 20.0 (%) | Fiabilité minimale de la calibration historique pour sauter le bootstrap |
 
 #### 2.6. Cas 0 : Correction de Dépassement (`_correct_kext_overshoot`)
 

--- a/documentation/en/feature-autotpi.md
+++ b/documentation/en/feature-autotpi.md
@@ -105,7 +105,8 @@ The system starts with **aggressive TPI coefficients** for the first 3 cycles to
 1. **Automatic Mode (Recommended)** ✅:
    - Leave `auto_tpi_heating_rate` at **0** (default)
    - The system automatically detects that capacity is unknown
-   - It performs 3 cycles with **aggressive TPI coefficients** (200.0/5.0) to provoke a temperature rise and measure capacity
+   - **Pre-calibration**: It first attempts to calibrate capacity from existing history. If data reliability is sufficient (>20%), bootstrap is skipped.
+   - **Bootstrap**: If history is not reliable enough, it performs 3 cycles with **aggressive TPI coefficients** (200.0/5.0) to measure capacity
    - **This is the recommended mode for configuration-free startup**
 
 2. **Manual Mode**:

--- a/documentation/fr/feature-autotpi.md
+++ b/documentation/fr/feature-autotpi.md
@@ -104,7 +104,8 @@ Le système démarre avec des **coefficients TPI agressifs** pour les 3 premiers
 1. **Mode Automatique (Recommandé)** ✅ :
    - Laissez `auto_tpi_heating_rate` à **0** (défaut)
    - Le système détecte automatiquement que la capacité est inconnue
-   - Il effectue 3 cycles avec des **coefficients TPI agressifs** (200.0/5.0) pour provoquer une montée en température et mesurer la capacité
+   - **Pré-calibration** : Il tente d'abord de calibrer la capacité à partir de l'historique existant. Si la fiabilité des données est suffisante (>20%), le bootstrap est sauté.
+   - **Bootstrap** : Si l'historique n'est pas suffisamment fiable, il effectue 3 cycles avec des **coefficients TPI agressifs** (200.0/5.0) pour mesurer la capacité
    - **C'est le mode recommandé pour un démarrage sans configuration**
 
 2. **Mode Manuel** :


### PR DESCRIPTION
When heat_rate is configured to 0, the system now attempts to calibrate capacity from historical data before falling back to aggressive bootstrap mode.

Changes:
- Add MIN_PRE_BOOTSTRAP_CALIBRATION_RELIABILITY constant (20%)
- Add _try_pre_bootstrap_calibration() method that calls calibrate_capacity internally with min_power_threshold=80%
- Modify start_learning() to try pre-calibration before bootstrap
- Skip bootstrap if reliability >= 20% and max_capacity is valid

This improves user experience by avoiding the aggressive bootstrap phase when sufficient historical data is already available.
Now #1600 brings unmatched results to calibrate_capacity service, this can be part of the process.

Documentation:
- Updated auto_tpi_internal_doc.md with pre-calibration logic
- Updated feature-autotpi.md (fr/en) to explain the new behavior