### PR TITLE
feat(auto-tpi): conditional creation and automatic cleanup of AutoTpi sensor entity

### DIFF
--- a/auto_tpi_internal_doc.md
+++ b/auto_tpi_internal_doc.md
@@ -47,6 +47,11 @@ Le système repose sur une intégration étroite entre le manager, le thermostat
 
 3.  **`AutoTpiSensor` (La Visibilité)** :
     *   Expose l'état de l'apprentissage et les métriques internes (nombre de cycles, confiance, coefficients calculés).
+    *   **Création Conditionnelle** : L'entité est créée uniquement si :
+        1.  Le thermostat est TPI-capable (type `switch`, `valve`, ou `climate` avec régulation valve).
+        2.  L'algorithme TPI est sélectionné (`CONF_PROP_FUNCTION == PROPORTIONAL_FUNCTION_TPI`).
+        3.  L'Auto TPI est activé dans la configuration (`CONF_AUTO_TPI_MODE == True`).
+    *   **Nettoyage Automatique** : Lorsque l'Auto TPI est désactivé ou que l'algorithme TPI n'est plus utilisé, l'entité orpheline est automatiquement supprimée du registre des entités via `cleanup_orphan_entity()` (dans `commons.py`) lors du rechargement de la config entry. Cette fonction générique peut être réutilisée pour d'autres entités conditionnelles.
 
 ### B. Flux de Contrôle (La Boucle TPI)
 

--- a/custom_components/versatile_thermostat/commons.py
+++ b/custom_components/versatile_thermostat/commons.py
@@ -4,9 +4,15 @@
 
 import logging
 import warnings
-from .const import ServiceConfigurationError
+
+from homeassistant.core import HomeAssistant
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers import entity_registry as er
+
+from .const import ServiceConfigurationError, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+
 
 def round_to_nearest(n: float, x: float) -> float:
     """Round a number to the nearest x (which should be decimal but not null)
@@ -148,4 +154,43 @@ def deprecated(message):
 def write_event_log(logger: logging.Logger, vtherm: "BaseThermostat", message: str):
     """Write an event log entry for the thermostat."""
     logger.info("")
-    logger.info("--------------------> NEW EVENT: %s - %s --------------------------------------------------------------", vtherm, message)
+    logger.info("---------------------> NEW EVENT: %s - %s --------------------------------------------------------------", vtherm, message)
+
+
+async def cleanup_orphan_entity(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    domain: str,
+    device_name: str,
+    unique_id_suffix: str,
+) -> None:
+    """Remove an orphan entity from entity registry if it exists but is no longer needed.
+
+    This generic function can be used for any entity type that needs to be
+    conditionally created/removed based on configuration changes.
+
+    Args:
+        hass: The Home Assistant instance.
+        entry: The config entry for the thermostat.
+        domain: The entity domain (e.g., "sensor", "binary_sensor", "switch").
+        device_name: The device name used to build the unique_id.
+        unique_id_suffix: The suffix appended to the device name (e.g., "auto_tpi_learning").
+    """
+    registry = er.async_get(hass)
+    # Build the expected unique_id for the entity
+    expected_unique_id = f"{device_name}_{unique_id_suffix}"
+
+    # Find entity by unique_id within this config entry
+    entity_id = registry.async_get_entity_id(
+        domain, DOMAIN, expected_unique_id
+    )
+
+    if entity_id:
+        entity_entry = registry.async_get(entity_id)
+        if entity_entry and entity_entry.config_entry_id == entry.entry_id:
+            _LOGGER.debug(
+                "Removing orphan %s entity %s from registry (feature disabled)",
+                domain,
+                entity_id
+            )
+            registry.async_remove(entity_id)


### PR DESCRIPTION
- AutoTpiSensor is now created only when:
  - TPI algorithm is selected (CONF_PROP_FUNCTION == TPI)
  - Auto TPI mode is enabled (CONF_AUTO_TPI_MODE == True)
- Added generic cleanup_orphan_entity() function in commons.py to automatically
  remove orphan entities from registry when feature is disabled
- Function is reusable for any entity type (sensor, binary_sensor, switch, etc.)

I've made cleanup_orphan_entity() method generic if you want to use it to clean other orphans entities.
Works pretty good.

