### PR TITLE
Fix Auto TPI startup to prioritize persisted capacity

### DIFF
--- a/custom_components/versatile_thermostat/auto_tpi_manager.py
+++ b/custom_components/versatile_thermostat/auto_tpi_manager.py
@@ -504,13 +504,23 @@ class AutoTpiManager:
                 self.state.max_capacity_heat = 0.0
                 self.state.capacity_heat_learn_count = 0
             elif is_capacity_heat_outdated and self._heating_rate > 0.0:
-                _LOGGER.info(
-                    "%s - Auto TPI: Overwriting persisted max_capacity_heat (%.3f) with new configured value (%.3f) on load.",
-                    self._name,
-                    self.state.max_capacity_heat,
-                    self._heating_rate,
-                )
-                self.state.max_capacity_heat = self._heating_rate
+                if self.state.max_capacity_heat == 0.0:
+                    _LOGGER.info(
+                        "%s - Auto TPI: Overwriting persisted max_capacity_heat (0.000) with new configured value (%.3f) on load.",
+                        self._name,
+                        self._heating_rate,
+                    )
+                    self.state.max_capacity_heat = self._heating_rate
+                    self.state.capacity_heat_learn_count = 3  # Assume learned if we take config value
+                else:
+                    _LOGGER.info(
+                        "%s - Auto TPI: Persisted max_capacity_heat (%.3f) differs from config (%.3f). Keeping persisted value.",
+                        self._name,
+                        self.state.max_capacity_heat,
+                        self._heating_rate,
+                    )
+                    # Sync the effective rate to the persisted one
+                    self._heating_rate = self.state.max_capacity_heat
 
             # Handle capacity reset for cooling mode
             if self._cooling_rate == 0.0 and self.state.max_capacity_cool > 0.0:
@@ -522,13 +532,23 @@ class AutoTpiManager:
                 self.state.max_capacity_cool = 0.0
                 # Note: capacity_cool_learn_count does not exist, cooling bootstrap uses different logic
             elif is_capacity_cool_outdated and self._cooling_rate > 0.0:
-                _LOGGER.info(
-                    "%s - Auto TPI: Overwriting persisted max_capacity_cool (%.3f) with new configured value (%.3f) on load.",
-                    self._name,
-                    self.state.max_capacity_cool,
-                    self._cooling_rate,
-                )
-                self.state.max_capacity_cool = self._cooling_rate
+                # Same logic for cooling capacity
+                if self.state.max_capacity_cool == 0.0:
+                    _LOGGER.info(
+                        "%s - Auto TPI: Overwriting persisted max_capacity_cool (0.000) with new configured value (%.3f) on load.",
+                        self._name,
+                        self._cooling_rate,
+                    )
+                    self.state.max_capacity_cool = self._cooling_rate
+                else:
+                    _LOGGER.info(
+                        "%s - Auto TPI: Persisted max_capacity_cool (%.3f) differs from config (%.3f). Keeping persisted value.",
+                        self._name,
+                        self.state.max_capacity_cool,
+                        self._cooling_rate,
+                    )
+                    # Sync the effective rate to the persisted one
+                    self._cooling_rate = self.state.max_capacity_cool
 
             if is_capacity_heat_outdated or is_capacity_cool_outdated:
                 await self.async_save_data()  # Save the new correct config value
@@ -1355,6 +1375,9 @@ class AutoTpiManager:
 
     def _should_learn_capacity(self) -> bool:
         """Check if capacity learning should occur this cycle."""
+        if not self.learning_active:
+             _LOGGER.debug("%s - Not learning capacity: learning is disabled", self._name)
+             return False
         
         # Determine if we are in bootstrap
         in_bootstrap = (
@@ -2813,6 +2836,22 @@ class AutoTpiManager:
                 self.state.capacity_heat_learn_count = 0
                 self.state.bootstrap_failure_count = 0
         else:
+            # Fix for resume with explicit new values
+            # If explicit values are provided (and differ from defaults), we should apply them
+            # This handles the case where start_learning is called with specific targets
+            # that override the current learned state.
+            # We check against _default_coef_int because thermostat_tpi.py passes the default
+            # when it intends to "Resume existing", but an explicit caller might pass a new value.
+            if coef_int is not None and abs(coef_int - self._default_coef_int) > 0.001:
+                _LOGGER.info("%s - Auto TPI: Updating Kint to %.3f (Manual override in resume)", self._name, target_int)
+                self.state.coeff_indoor_heat = target_int
+                self.state.coeff_indoor_cool = target_int
+
+            if coef_ext is not None and abs(coef_ext - self._default_coef_ext) > 0.001:
+                _LOGGER.info("%s - Auto TPI: Updating Kext to %.3f (Manual override in resume)", self._name, target_ext)
+                self.state.coeff_outdoor_heat = target_ext
+                self.state.coeff_outdoor_cool = target_ext
+
             _LOGGER.info(
                 "%s - Auto TPI: Resuming learning with existing data (coef_int=%.3f, coef_ext=%.3f, cycles=%d)",
                 self._name,


### PR DESCRIPTION
- Prevent overwriting learned capacity with configured power at startup
- Fix issue where restart could reset learned capacity to config defaults Fix Auto TPI not starting since refactor

- Fix Auto TPI start_learning ignoring explicit coefficients in resume mode The `start_learning` method was ignoring `coef_int` and `coef_ext` arguments when `reset_data` was False. This prevented tests and legitimate configuration changes from updating the coefficients if the learning was merely resumed (not reset).

same as #1652 for 8.6