### PR TITLE
Refactor VersatileThermostatAPI to fix boolean evaluation bug

### DIFF
--- a/custom_components/versatile_thermostat/__init__.py
+++ b/custom_components/versatile_thermostat/__init__.py
@@ -119,7 +119,7 @@ async def reload_all_vtherm(hass):
     await asyncio.gather(*reload_tasks)
     api: VersatileThermostatAPI = VersatileThermostatAPI.get_vtherm_api(hass)
     if api:
-        await api.reload_central_boiler_entities_list()
+        await api.central_boiler_manager.reload_central_boiler_entities_list()
         await api.init_vtherm_links()
 
 
@@ -161,7 +161,7 @@ async def update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
         await hass.config_entries.async_reload(entry.entry_id)
         # Reload the central boiler list of entities
         api: VersatileThermostatAPI = VersatileThermostatAPI.get_vtherm_api(hass)
-        if api is not None:
+        if api:
             await api.central_boiler_manager.reload_central_boiler_entities_list()
             await api.init_vtherm_links(entry.entry_id)
 
@@ -173,7 +173,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         if api:
             api.remove_entry(entry)
-            await api.reload_central_boiler_entities_list()
+            await api.central_boiler_manager.reload_central_boiler_entities_list()
 
     return unload_ok
 

--- a/custom_components/versatile_thermostat/base_thermostat.py
+++ b/custom_components/versatile_thermostat/base_thermostat.py
@@ -360,7 +360,7 @@ class BaseThermostat(ClimateEntity, RestoreEntity, Generic[T]):
 
         # Read the parameter from configuration.yaml if it exists
         short_ema_params = DEFAULT_SHORT_EMA_PARAMS
-        if api is not None and api.short_ema_params:
+        if api and api.short_ema_params:
             short_ema_params = api.short_ema_params
 
         self._ema_algo = ExponentialMovingAverage(

--- a/custom_components/versatile_thermostat/thermostat_climate.py
+++ b/custom_components/versatile_thermostat/thermostat_climate.py
@@ -380,7 +380,7 @@ class ThermostatOverClimate(BaseThermostat[UnderlyingClimate]):
             api: VersatileThermostatAPI = VersatileThermostatAPI.get_vtherm_api(
                 self._hass
             )
-            if api is not None:
+            if api:
                 if (expert_param := api.self_regulation_expert) is not None:
                     self._regulation_algo = PITemperatureRegulator(
                         self.target_temperature,

--- a/custom_components/versatile_thermostat/vtherm_api.py
+++ b/custom_components/versatile_thermostat/vtherm_api.py
@@ -28,7 +28,7 @@ VTHERM_API_NAME = "vtherm_api"
 _LOGGER = logging.getLogger(__name__)
 
 
-class VersatileThermostatAPI(dict):
+class VersatileThermostatAPI:
     """The VersatileThermostatAPI"""
 
     _hass: HomeAssistant = None
@@ -55,7 +55,7 @@ class VersatileThermostatAPI(dict):
 
     def __init__(self) -> None:
         _LOGGER.debug("building a VersatileThermostatAPI")
-        super().__init__()
+
         self._expert_params = None
         self._short_ema_params = None
         self._safety_mode = None
@@ -100,9 +100,19 @@ class VersatileThermostatAPI(dict):
         _LOGGER.debug("Remove the entry %s", entry.entry_id)
         VersatileThermostatAPI._hass.data[DOMAIN].pop(entry.entry_id)
         # If not more entries are preset, remove the API
-        if len(self) == 0:
+        if (
+            len(
+                [
+                    val
+                    for val in VersatileThermostatAPI._hass.data[DOMAIN].values()
+                    if isinstance(val, ConfigEntry)
+                ]
+            )
+            == 0
+        ):
             _LOGGER.debug("No more entries-> Remove the API from DOMAIN")
-            VersatileThermostatAPI._hass.data.pop(DOMAIN)
+            if DOMAIN in VersatileThermostatAPI._hass.data:
+                VersatileThermostatAPI._hass.data.pop(DOMAIN)
 
     def set_global_config(self, config):
         """Read the global configuration from configuration.yaml file"""
@@ -218,7 +228,8 @@ class VersatileThermostatAPI(dict):
             return
 
         # Remove the API instance from hass.data
-        VersatileThermostatAPI._hass.data[DOMAIN].pop(VTHERM_API_NAME, None)
+        if DOMAIN in VersatileThermostatAPI._hass.data:
+            VersatileThermostatAPI._hass.data[DOMAIN].pop(VTHERM_API_NAME, None)
         VersatileThermostatAPI._hass = None
 
     @property


### PR DESCRIPTION
**The Bug:** 
VersatileThermostatAPI inherited from dict but did not store data within the instance itself (it uses hass.data). 
Consequently, the API instance remained an "empty dictionary" throughout its lifecycle. 

In Python, an empty dictionary evaluates to False in boolean contexts. This caused checks like if api: to evaluate to False even when the API object was fully initialized and valid, leading to silent failures where code blocks were skipped (e.g., entity linking and cleanup).

Some parts in the code had check like this that mitigate the problem. 
      `  if api is not None and api.short_ema_params:`
But other parts were missing it like in __init__.py ( lin 164, 174 )
`if api:`
And this was always evaluating to false, skipping the whole block. 

I could just fix the missing "is not None" on those line, but feels it more proper if somebody else one day use if api: ( looks more natural in python ) , and I think taht VersatileThermosatAPI herited from dict is more a technical debt.
But you will tell me. 

**The Fix:**

Removed dict inheritance from VersatileThermostatAPI so it behaves like a standard Python object (always True when it exists).
Refactored internal logic (like len(self)) to explicitly check hass.data.
Standardized usages to if api: across the codebase, removing now-redundant is not None checks.


Also fixed those errors appearing now the blocks behind "if api:" correctly run. 

- KeyError in reset_vtherm_api during test teardown.
- AttributeError in async_unload_entry by correcting method call.