### PR TITLE
Fix documentation for Error: "stabilization_threshold is an invalid option" since 8.6.1

### DIFF
--- a/documentation/en/troubleshooting.md
+++ b/documentation/en/troubleshooting.md
@@ -20,7 +20,7 @@
   - [VTherm Automatically Switches to 'Cooling' or 'Heating' Mode](#vtherm-automatically-switches-to-cooling-or-heating-mode)
   - [Open Window Detection Does Not Prevent Preset Changes](#open-window-detection-does-not-prevent-preset-changes)
     - [Example:](#example)
-
+  - [Error stabilization_threshold is an invalid option](#error-stabilization_threshold-is-an-invalid-option)
 
 ## Using a Heatzy
 
@@ -258,3 +258,9 @@ If the action mode is set to _Frost Protection_ or _Eco_, the preset temperature
 2. **Window opens and system waits**: The preset remains on Comfort, **but the setpoint temperature switches to 10°C** (frost protection). This state may seem inconsistent because the displayed preset does not match the applied setpoint temperature.
 3. **Preset change to Boost** (by the user or the Scheduler): The preset switches to Boost, but the setpoint temperature remains at 10°C (frost protection). This state may also appear inconsistent.
 4. **Window closes**: The preset remains on Boost, and the setpoint temperature changes to 21°C (Boost). The inconsistency disappears, and the user's preset change is correctly applied.
+
+## Error stabilization_threshold is an invalid option
+
+This error happend after an upgrade from version 8.6.0 (and below) to version 8.6.1 (or above), for users who use the self regulation feature in expert mode.
+In this mode, they was a setting `stabilization_threshold` to write in your `configuration.yaml`. This setting is not used anymore since many years and was removed.
+You need to remove it from your `configuration.yaml`.

--- a/documentation/fr/troubleshooting.md
+++ b/documentation/fr/troubleshooting.md
@@ -19,6 +19,7 @@
   - [VTherm ne suit pas les changements de consigne faits directement depuis le sous-jacents (`over_climate`)](#vtherm-ne-suit-pas-les-changements-de-consigne-faits-directement-depuis-le-sous-jacents-over_climate)
   - [VTherm passe tout seul en mode 'clim' ou en mode 'chauffage'](#vtherm-passe-tout-seul-en-mode-clim-ou-en-mode-chauffage)
   - [La détection de fenêtre ouverte n'empêche pas le changement de preset](#la-détection-de-fenêtre-ouverte-nempêche-pas-le-changement-de-preset)
+  - [Erreur stabilization_threshold is an invalid option](#erreur-stabilization_threshold-is-an-invalid-option)
 
 
 ## Utilisation d'un Heatzy
@@ -245,3 +246,9 @@ Exemple :
 2. **Ouverture de la fenêtre et attente** : preset reste sur Confort, **la température de consigne passe sur 10°** (hors gel). Cet état peut paraitre incohérent car la température de consigne n'est pas en accord avec le preset affiché,
 3. **Changement de preset en Boost** (par l'utilisateur ou par le Scheduler) : le preset change pour Boost mais la température de consigne reste à 10° (hors gel). Cet état peut aussi paraitre incohérent,
 4. **Fermeture de la fenêtre** : le preset reste sur Boost, la température de consigne passe sur 21° (Boost). L'incohérence a disparue et le changement de preset de l'utilisateur est bien appliqué.
+
+## Erreur stabilization_threshold is an invalid option
+
+Cette erreur apparait lors de la mise à jour de la version 8.6.0 ou précédente vers la version 8.6.1 ou ultérieur, pour les utilisateurs utilisant l'auto regulation
+en mode expert. Dans le mode expert, il y avait un paramètre `stabilization_threshold` à mettre dans le fichier `configuration.yaml`. Ce paramètre n'est plus utilisé
+depuis plusieurs années et a été retiré. Il vous faut le retirer de votre fichier `configuration.yaml`.


### PR DESCRIPTION
Fixes #1666
Add a troubleshoot to remove the deprecated setting.