### PR TITLE
Add missing de/cs/pl  translations for new  auto-tpi documentation.

### DIFF
--- a/README-cs.md
+++ b/README-cs.md
@@ -38,9 +38,9 @@ Versatile Thermostat UI Card (K dispozici na [Github](https://github.com/jmcolli
 > Tyto anomálie mohou naznačovat otevřené okno, vadný radiátor nebo externí zdroj tepla. Funkce odesílá události, které lze použít ke spuštění automatizací (oznámení, výstrahy atd.). Více informací [zde](documentation/cs/feature-heating-failure-detection.md).
 
 ## Release 8.4
-> 1. added auto TPI (experimental). This new feature allows automatically calculating the best coefficients for the TPI algorithm. More information [here](./auto_tpi_internal_doc.md)
-> 2. added a temperature synchronization function for a device controlled in `over_climate` mode. Depending on your device's capabilities, _VTherm_ can control an offset calibration entity or directly an external temperature entity. More information [here](documentation/en/feature-sync_device_temp.md),
-> 3. added a feature named "timed preset" which aims to select a preset for a certain duration and come back to the previous preset after the expiration of the delay. The new feature is totally described [here](documentation/cs/feature-timed-preset.md).
+> 1. added auto TPI (experimental). This new feature allows automatically calculating the best coefficients for the TPI algorithm. More information [zde](documentation/cs/feature-autotpi.md)
+> 2. added a temperature synchronization function for a device controlled in `over_climate` mode. Depending on your device's capabilities, _VTherm_ can control an offset calibration entity or directly an external temperature entity. More information [zde](documentation/cs/feature-sync_device_temp.md),
+> 3. added a feature named "timed preset" which aims to select a preset for a certain duration and come back to the previous preset after the expiration of the delay. The new feature is totally described [zde](documentation/cs/feature-timed-preset.md).
 
 ## Release 8.3
 1. Addition of a configurable delay before activating the central boiler.
@@ -100,15 +100,17 @@ Dokumentace je nyní rozdělena do několika stránek pro snadnější čtení a
 17. [Pokročilé aspekty, bezpečnostní režim](documentation/cs/feature-advanced.md)
 18. [Samoregulace](documentation/cs/self-regulation.md)
 19. [Lock / Unlock](documentation/en/feature-lock.md)
-20. [Temperature synchronisation](documentation/en/feature-sync_device_temp.md)
-21. [Timed preset](documentation/en/feature-timed-preset.md)
-22. [Příklady ladění](documentation/cs/tuning-examples.md)
-23. [Algoritmy](documentation/cs/algorithms.md)
-24. [Zámek / Odemknutí](documentation/cs/feature-lock.md)
-25. [Referenční dokumentace](documentation/cs/reference.md)
-26. [Řešení problémů](documentation/cs/troubleshooting.md)
-27. [Poznámky k verzím](documentation/cs/releases.md)
-28. [Detekce poruchy vytápění](documentation/cs/feature-heating-failure-detection.md)
+20. [Učení Auto TPI](documentation/cs/feature-autotpi.md)
+21. [Technická dokumentace Auto TPI](documentation/cs/feature-autotpi-technical.md)
+22. [Temperature synchronisation](documentation/en/feature-sync_device_temp.md)
+23. [Timed preset](documentation/en/feature-timed-preset.md)
+24. [Příklady ladění](documentation/cs/tuning-examples.md)
+25. [Algoritmy](documentation/cs/algorithms.md)
+26. [Zámek / Odemknutí](documentation/cs/feature-lock.md)
+27. [Referenční dokumentace](documentation/cs/reference.md)
+28. [Řešení problémů](documentation/cs/troubleshooting.md)
+29. [Poznámky k verzím](documentation/cs/releases.md)
+30. [Detekce poruchy vytápění](documentation/cs/feature-heating-failure-detection.md)
 
 # Některé výsledky
 

--- a/README-de.md
+++ b/README-de.md
@@ -38,7 +38,7 @@ Versatile Thermostat UI Card (Verfügbar auf [Github](https://github.com/jmcolli
 > Diese Anomalien können auf ein offenes Fenster, einen defekten Heizkörper oder eine externe Wärmequelle hinweisen. Die Funktion sendet Ereignisse, die zum Auslösen von Automatisierungen (Benachrichtigungen, Warnungen usw.) verwendet werden können. Weitere Informationen [hier](documentation/de/feature-heating-failure-detection.md).
 
 ## Release 8.4
-1. Hinzufügen der automatischen TPI-Funktion (experimental). Diese neue Funktion dient dazu, automatisch die besten Koeffizienten für den TPI-Algorithmus zu berechnen. Weitere Informationen gibt es [hier](./auto_tpi_internal_doc.md).
+1. Hinzufügen der automatischen TPI-Funktion (experimental). Diese neue Funktion dient dazu, automatisch die besten Koeffizienten für den TPI-Algorithmus zu berechnen. Weitere Informationen gibt es [hier](documentation/en/feature-autotpi.md).
 2. added a temperature synchronization function for a device controlled in `over_climate` mode. Depending on your device's capabilities, _VTherm_ can control an offset calibration entity or directly an external temperature entity. More information [here](documentation/de/feature-sync_device_temp.md)
 3. added a feature named "timed preset" which aims to select a preset for a certain duration and come back to the previous preset after the expiration of the delay. The new feature is totally described [here](documentation/de/feature-timed-preset.md).
 

--- a/README-fr.md
+++ b/README-fr.md
@@ -38,7 +38,7 @@ Le composant Versatile Thermostat UI Card (Disponible sur [Github](https://githu
 > Ces anomalies peuvent indiquer une fenêtre ouverte, un radiateur défaillant ou une source de chaleur externe. La fonctionnalité envoie des événements qui peuvent être utilisés pour déclencher des automatisations (notifications, alertes, etc.). Plus d'informations [ici](documentation/fr/feature-heating-failure-detection.md).
 
 ## Release 8.4
-> 1. ajout de l'auto TPI (expérimental). Cette nouvelle fonction permet de calculer automatiquement les meilleurs coefficients pour l'algorithme du TPI. Plus d'informations [ici](./auto_tpi_internal_doc.md)
+> 1. ajout de l'auto TPI (expérimental). Cette nouvelle fonction permet de calculer automatiquement les meilleurs coefficients pour l'algorithme du TPI. Plus d'informations [ici](documentation/fr/feature-autotpi.md)
 > 2. ajout d'une fonction de synchronisation des températures d'un équipement piloté en mode `over_climate`. Suivant, les fonctionnalités de votre équipement, _VTherm_ peut contrôler une entité de calibrage de l'offset ou directement une entité de température externe. Plus d'informations [ici](documentation/fr/feature-sync_device_temp.md)
 > 3. ajout d'une fonction nommée preset temporisé permettant de sélectionner un preset pendant un temps donné et revenir au précédent une fois le délai expiré. La fonction est décrite [ici](documentation/fr/feature-timed-preset.md).
 

--- a/README-pl.md
+++ b/README-pl.md
@@ -38,8 +38,8 @@ Karta integracji VTherm UI (dostępna na [Github](https://github.com/jmcollin78/
 > Anomalie te mogą wskazywać na otwarte okno, uszkodzony grzejnik lub zewnętrzne źródło ciepła. Funkcja wysyła zdarzenia, które mogą być używane do wyzwalania automatyzacji (powiadomienia, alerty itp.). Więcej informacji [tutaj](documentation/pl/feature-heating-failure-detection.md).
 >
 
-## Wydanie 8.4
-> 1. Dodanie eksperymentalnej funkcji automatyzacji algorytmu TPI. Ta nowa funkcja pozwala na automatyczne obliczanie najlepszych współczynników dla algorytmu TPI. Więcej informacji znajdziesz [tutaj _(chwilowo tylko w jęz. francuskim)_](./auto_tpi_internal_doc.md).
+## Wydanie 8.42.
+> 1. Dodanie eksperymentalnej funkcji automatyzacji algorytmu TPI. Ta nowa funkcja pozwala na automatyczne obliczanie najlepszych współczynników dla algorytmu TPI. Więcej informacji znajdziesz [tutaj](documentation/pl/feature-autotpi.md).
 > 2. Dodanie funkcji synchronizacji temperatury dla urządzenia sterowanego w trybie `na_klimacie`. W zależności od możliwości urządzenia, _VTherm_ może sterować jednostką kalibracji offsetu lub bezpośrednio zewnętrzną encją temperatury. Więcej informacji znajduje się [tutaj](documentation/pl/feature-sync_device_temp.md).
 > 3. Dodanie funkcji _**presetu czasowego**_, która umożliwia wybranie presetu na z góry określony czas i powrót do poprzedniego po upływie wkazanego opóźnienia. Nowa funkcja jest szczegółowo opisana [tutaj](documentation/pl/feature-timed-preset.md).
 >
@@ -101,11 +101,13 @@ Dla wygody Użytkownika, a także w celu dostępu do pomocy kontekstowej podczas
 16. [Sterowanie kotłem centralnym](documentation/pl/feature-central-boiler.md)
 17. [Zaawansowane ustawienia, tryb bezpieczny](documentation/pl/feature-advanced.md)
 18. [Samoregulacja](documentation/pl/self-regulation.md)
-19. [Funkcja blokady dostępu kodem PIN](documentation/pl/feature-lock.md)
-20. [Temperature synchronisation](documentation/pl/feature-sync_device_temp.md)
-21. [Timed preset](documentation/pl/feature-timed-preset.md)
-22. [Algorytmy](documentation/pl/algorithms.md)
-23. [Dokumentacja referencyjna](documentation/pl/reference.md)
+19. [Uczenie Auto TPI](documentation/pl/feature-autotpi.md)
+20. [Dokumentacja techniczna Auto TPI](documentation/pl/feature-autotpi-technical.md)
+21. [Algorytmy](documentation/pl/algorithms.md)
+22. [Funkcja blokady](documentation/pl/feature-lock.md)
+23. [Synchronizacja temperatury](documentation/pl/feature-sync_device_temp.md)
+24. [Preset czasowy](documentation/pl/feature-timed-preset.md)
+25. [Dokumentacja referencyjna](documentation/pl/reference.md)
 24. [Przykłady dostrajania układu](documentation/pl/tuning-examples.md)
 25. [Usuwanie problemów](documentation/pl/troubleshooting.md)
 26. [Informacje o wersjach](documentation/pl/releases.md)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Versatile Thermostat UI Card (Available on [Github](https://github.com/jmcollin7
 > These anomalies may indicate an open window, a faulty radiator, or an external heat source. The feature sends events that can be used to trigger automations (notifications, alerts, etc.). More information [here](documentation/en/feature-heating-failure-detection.md).
 
 ## Release 8.4
-> 1. added auto TPI (experimental). This new feature allows automatically calculating the best coefficients for the TPI algorithm. More information [here](./auto_tpi_internal_doc.md)
+> 1. added auto TPI (experimental). This new feature allows automatically calculating the best coefficients for the TPI algorithm. More information [here](documentation/en/feature-auto_tpi.md)
 > 2. added a temperature synchronization function for a device controlled in `over_climate` mode. Depending on your device's capabilities, _VTherm_ can control an offset calibration entity or directly an external temperature entity. More information [here](documentation/en/feature-sync_device_temp.md),
 > 3. added a feature named "timed preset" which aims to select a preset for a certain duration and come back to the previous preset after the expiration of the delay. The new feature is totally described [here](documentation/en/feature-timed-preset.md).
 

--- a/documentation/cs/feature-autotpi-technical.md
+++ b/documentation/cs/feature-autotpi-technical.md
@@ -1,0 +1,516 @@
+# 🧠 Auto TPI: Podrobný technický průvodce
+
+> [!NOTE]
+> Tento dokument je určen pro pokročilé uživatele, kteří chtějí podrobně porozumět algoritmu Auto TPI. Pro přístupnější úvod viz [Uživatelská příručka Auto TPI](feature-autotpi.md).
+
+---
+
+## Obsah
+
+1. [Algoritmus TPI](#algoritmus-tpi)
+2. [Detailní cyklus učení](#detailní-cyklus-učení)
+3. [Kalibrace tepelné kapacity](#kalibrace-tepelné-kapacity)
+4. [Algoritmy pro výpočet koeficientů](#algoritmy-pro-výpočet-koeficientů)
+5. [Mechanismy automatické korekce](#mechanismy-automatické-korekce)
+6. [Pokročilé parametry a konstanty](#pokročilé-parametry-a-konstanty)
+7. [Služby a API](#služby-a-api)
+8. [Pokročilá diagnostika a řešení problémů](#pokročilá-diagnostika-a-řešení-problémů)
+
+---
+
+## Algoritmus TPI
+
+### Základní princip
+
+Algoritmus **TPI** (Time Proportional & Integral) vypočítává v každém cyklu **procento výkonu**. Toto procento určuje, jak dlouho bude ohřívač během cyklu aktivní (např. 60 % v 10minutovém cyklu = 6 minut vytápění).
+
+### Základní vzorec
+
+```
+Výkon = (Kint × ΔT_vnitřní) + (Kext × ΔT_venkovní)
+```
+
+Kde:
+- **Kint** (`tpi_coef_int`): Vnitřní koeffizient, reaguje na rozdíl od požadované hodnoty
+- **Kext** (`tpi_coef_ext`): Venkovní koeficient, kompenzuje tepelné ztráty
+- **ΔT_vnitřní** = Požadovaná hodnota − Vnitřní teplota
+- **ΔT_venkovní** = Požadovaná hodnota − Venkovní teplota
+
+```mermaid
+graph LR
+    subgraph Vstupy
+        A[Vnitřní teplota]
+        B[Venkovní teplota]
+        C[Požadovaná hodnota]
+    end
+    
+    subgraph Výpočet TPI
+        D["ΔT_int = Požadovaná hodnota - T_int"]
+        E["ΔT_ext = Požadovaná hodnota - T_ext"]
+        F["Výkon = Kint×ΔT_int + Kext×ΔT_ext"]
+    end
+    
+    subgraph Výstup
+        G["Výkon % (0-100%)"]
+        H["Doba ZAP/VYP"]
+    end
+    
+    A --> D
+    C --> D
+    B --> E
+    C --> E
+    D --> F
+    E --> F
+    F --> G
+    G --> H
+```
+
+### Role koeficientů
+
+| Koeficient | Role | Situační učení |
+|-------------|------|-------------------|
+| **Kint** | Řídí **reaktivitu**: čím vyšší je, tím rychleji vytápění reaguje na rozdíly | Během **vzestupu teploty** (rozdíl > 0,05 °C, výkon < 99 %) |
+| **Kext** | Kompenzuje **tepelné ztráty**: čím vyšší je, tím více vytápění předvídá ochlazování | Během **stabilizace** kolem požadované hodnoty (rozdíl < 0,5 °C) |
+
+---
+
+## Detailní cyklus učení
+
+### Přehled toku
+
+```mermaid
+flowchart TD
+    subgraph Inicializace
+        A[Start relace] --> B{Rychlost ohřevu = 0?}
+        B -->|Ano| C[Historická předkalibrace]
+        B -->|Ne| G[Aktivní učení]
+        
+        C --> D{Spolehlivost >= 20%?}
+        D -->|Ano| G
+        D -->|Ne| E[Režim Bootstrap]
+        E -->|3 agresivní cykly| F[Odhadovaná kapacita]
+        F --> G
+    end
+    
+    subgraph "Smyčka učení"
+        G --> H[Start cyklu TPI]
+        H --> I[Snímek počátečního stavu]
+        I --> J[Provést ZAP/VYP vytápění]
+        J --> K[Konec cyklu: Měřit ΔT]
+        K --> L{Platné podmínky?}
+        
+        L -->|Ne| M[Přeskočit učení]
+        L -->|Ano| N{Analyzovat situaci}
+        
+        N -.->|Překmit| O[🔸 Korekce Kext<br/>volitelně]
+        N -.->|Stagnace| P[🔸 Kint Boost<br/>volitelně]
+        N -->|T° stoupá| Q[Učení Kint]
+        N -->|Stabilizace| R[Učení Kext]
+        
+        O -.-> S[Aktualizace koeficientů]
+        P -.-> S
+        Q --> S
+        R --> S
+        M --> H
+        S --> H
+    end
+    
+    subgraph Finalizace
+        S --> T{50 cyklů Kint A Kext?}
+        T -->|Ne| H
+        T -->|Ano| U[Uložit do konfigurace]
+        U --> V[Oznámení o ukončení]
+    end
+    
+    style O fill:#fff3cd,stroke:#ffc107,stroke-width:2px
+    style P fill:#fff3cd,stroke:#ffc107,stroke-width:2px
+```
+
+> [!NOTE]
+> **Žluté boxy s čárkovanými čarami** (🔸) představují **volitelné** korekční mechanismy. Musí být explicitně povoleny prostřednictvím parametrů služby `set_auto_tpi_mode`.
+
+### Podrobnosti o snímku cyklu
+
+Na začátku každého cyklu algoritmus zachytí aktuální stav:
+
+| Zachycená data | Využití |
+|---------------|-------|
+| `last_temp_in` | Vnitřní teplota na začátku cyklu |
+| `last_temp_out` | Venkovní teplota na začátku cyklu |
+| `last_order` | Požadovaná hodnota na začátku cyklu |
+| `last_power` | Vypočtený výkon pro tento cyklus (0,0 až 1,0) |
+| `last_state` | Režim HVAC (vytápění/chlazení) |
+
+Na konci cyklu jsou tyto hodnoty porovnány s aktuálními měřeními pro výpočet postupu.
+
+### Podmínky validace cyklu
+
+Cyklus je pro učení **ignorován**, pokud:
+
+| Podmínka | Důvod |
+|-----------|--------|
+| Výkon = 0 % nebo 100 % | Nasycení: žádné využitelné informace o účinnosti |
+| Požadovaná hodnota změněna | Cíl změněn uprostřed cyklu |
+| Aktivní odpojování zátěže | Vytápění bylo nuceně vypnuto Správcem výkonu |
+| Detekována porucha | Detekována anomálie (neúčinné vytápění) |
+| Centrální kotel VYPNUT | Termostat vyžaduje, ale kotel nereaguje |
+| První cyklus po restartu | Žádná platná referenční data |
+
+---
+
+## Kalibrace tepelné kapacity
+
+### Definice
+
+**Tepelná kapacita** (nebo **rychlost ohřevu**) představuje maximální rychlost vzestupu teploty vašeho systému, vyjádřenou v **°C za hodinu** (°C/h).
+
+Příklad: Kapacita 2,0 °C/h znamená, že váš radiátor dokáže při plném výkonu zvýšit teplotu o 2 °C za jednu hodinu (za ideálních adiabatických podmínek).
+
+### Metody určení
+
+```mermaid
+graph TD
+    A[Rychlost ohřevu = 0?] -->|Ano| B[Předkalibrace]
+    A -->|Ne| C[Použít konfigurovanou hodnotu]
+    
+    B --> D{Historie k dispozici?}
+    D -->|Ano| E[Analýza historie]
+    D -->|Ne| F[Režim Bootstrap]
+    
+    E --> G{Spolehlivost >= 20%?}
+    G -->|Ano| H[Kalibrovaná kapacita]
+    G -->|Ne| F
+    
+    F --> I[3 agresivní cykly Kint=1.0 Kext=0.1]
+    I --> J[Měřit skutečný vzestup]
+    J --> K[Odhadovaná kapacita]
+    
+    H --> L[Učení Kint/Kext]
+    K --> L
+    C --> L
+```
+
+### Předkalibrace pomocí analýzy historie
+
+Služba `auto_tpi_calibrate_capacity` analyzuje historii senzorů:
+
+1. **Získání** dat `temperature_slope` a `power_percent` za 30 dní
+2. **Filtrování**: ponechá pouze body, kde `power >= 95 %`
+3. **Eliminace odlehlých hodnot** pomocí metody IQR (Interquartile Range)
+4. **Výpočet 75. percentilu** sklonů (reprezentativnější než medián)
+5. **Adiabatická korekce**: `Kapacita = P75 + Kext × ΔT`
+6. **Aplikace bezpečnostní rezervy**: standardně 20 %
+
+### Režim Bootstrap
+
+Pokud je historie nedostatečná (spolehlivost < 20 %), systém přejde do **režimu bootstrap**:
+
+- **Agresivní koeficienty**: Kint = 1.0, Kext = 0.1
+- **Trvání**: minimálně 3 cykly
+- **Cíl**: Vyvolat významný vzestup teploty pro měření skutečné kapacity
+- **Bezpečnostní časový limit**: Pokud dojde k selhání po 5 cyklech, výchozí kapacita = 0,3 °C/h (pomalé systémy)
+
+---
+
+## Algoritmy pro výpočet koeficientů
+
+### Učení Kint (Vnitřní koeficient)
+
+Algoritmus upravuje Kint, když teplota **stoupá** k požadované hodnotě.
+
+#### Podrobný vzorec
+
+```mermaid
+flowchart LR
+    subgraph "1. Efektivní kapacita"
+        A["C_eff = C_ref × (1 - Kext × ΔT_ext)"]
+    end
+    
+    subgraph "2. Max. možný vzestup"
+        B["max_rise = C_eff × doba_cyklu × účinnost"]
+    end
+    
+    subgraph "3. Upravený cíl"
+        C["target = min(teplotní_rozdíl, max_rise)"]
+    end
+    
+    subgraph "4. Poměr"
+        D["ratio = (target / skutečný_vzestup) × agresivita"]
+    end
+    
+    subgraph "5. Nové Kint"
+        E["Kint_new = Kint_old × ratio"]
+    end
+    
+    A --> B --> C --> D --> E
+```
+
+#### Použité proměnné
+
+| Proměnná | Popis | Typická hodnota |
+|----------|-------------|---------------|
+| `C_ref` | Kalibrovaná referenční kapacita | 1,5 °C/h |
+| `Kext` | Aktuální venkovní koeficient | 0,02 |
+| `ΔT_ext` | Rozdíl vnitřní/venkovní teploty | 15 °C |
+| `doba_cyklu` | V hodinách | 0,167 (10 min) |
+| `účinnost` | Použité procento výkonu | 0,70 |
+| `agresivita` | Faktory moderování | 0,9 |
+
+### Učení Kext (Venkovní koeficient)
+
+Algoritmus upravuje Kext, když je teplota **blízko požadované hodnoty** (|rozdíl| < 0,5 °C).
+
+#### Vzorec
+
+```
+Korekce = Kint × (vnitřní_rozdíl / venkovní_rozdíl)
+Kext_new = Kext_old + Korekce
+```
+
+- Pokud je vnitřní_rozdíl **záporný** (překmit) → Záporná korekce → **Kext klesá**
+- Pokud je vnitřní_rozdíl **kladný** (nedostatečný ohřev) → Kladná korekce → **Kext stoupá**
+
+### Metody vyhlazování
+
+K vyhlazení nových hodnot jsou k dispozici dvě metody:
+
+#### Vážený průměr (režim "Discovery")
+
+```
+Kint_final = (Kint_old × počet + Kint_new) / (počet + 1)
+```
+
+| Cyklus | Stará váha | Nová váha | Dopad nové hodnoty |
+|-------|------------|------------|------------------|
+| 1 | 1 | 1 | 50 % |
+| 10 | 10 | 1 | 9 % |
+| 50 | 50 | 1 | 2 % |
+
+> Počítadlo je omezeno na 50 pro zachování minimální reaktivity.
+
+#### EWMA (režim "Fine Tuning")
+
+```
+Kint_final = (1 - α) × Kint_old + α × Kint_new
+α(n) = α₀ / (1 + decay_rate × n)
+```
+
+| Parametr | Výchozí | Popis |
+|-----------|---------|-------------|
+| `α₀` (počáteční alfa) | 0,08 | Počáteční váha nových hodnot |
+| `decay_rate` | 0,12 | Rychlost poklesu alfa |
+
+---
+
+## Mechanismy automatické korekce
+
+### Korekce překmitu (Kext Deboost)
+
+> **Aktivace**: Parametr `allow_kext_compensation_on_overshoot` ve službě `set_auto_tpi_mode`
+
+Detekuje a koriguje stav, kdy teplota **překročí požadovanou hodnotu**, aniž by klesala zpět.
+
+```mermaid
+flowchart TD
+    A{T° > Požadovaná hodn. + 0,2 °C?} -->|Ano| B{Výkon > 5%?}
+    B -->|Ano| C{T° neklesá?}
+    C -->|Ano| D[Korekce Kext]
+    
+    A -->|Ne| E[Žádná korekce]
+    B -->|Ne| E
+    C -->|Ne| E
+    
+    D --> F["redukce = překmit × Kint / ΔT_ext"]
+    F --> G["Kext_cíl = max(0,001, Kext - redukce)"]
+    G --> H[Aplikovat s alfa boost ×2]
+```
+
+### Korekce stagnace (Kint Boost)
+
+> **Aktivierung**: Parametr `allow_kint_boost_on_stagnation` ve službě `set_auto_tpi_mode`
+
+Detekuje a koriguje stav, kdy teplota **stagnuje** navzdory významnému rozdílu.
+
+```mermaid
+flowchart TD
+    A{Rozdíl > 0,5 °C?} -->|Ano| B{Postup < 0,02 °C?}
+    B -->|Ano| C{Výkon < 99%?}
+    C -->|Ano| D{Po sobě jdoucí boosty < 5?}
+    D -->|Ano| E[Kint Boost]
+    
+    A -->|Ne| F[Žádná korekce]
+    B -->|Ne| F
+    C -->|Ne| F
+    D -->|Ne| G[Upozornění na poddimenzované vytápění]
+    
+    E --> H["boost = 8% × min(rozdíl/0.3, 2.0)"]
+    H --> I["Kint_cíl = Kint × (1 + boost)"]
+```
+
+---
+
+## Pokročilé parametry a konstanty
+
+### Interní konstanty (nekonfigurovatelné)
+
+| Konstanta | Hodnota | Popis |
+|----------|-------|-------------|
+| `MIN_KINT` | 0,01 | Spodní hranice Kint pro zachování reaktivity |
+| `OVERSHOOT_THRESHOLD` | 0,2 °C | Práh překmitu pro spuštění korekce |
+| `OVERSHOOT_POWER_THRESHOLD` | 5 % | Minimální výkon pro považování překmitu za chybu Kext |
+| `OVERSHOOT_CORRECTION_BOOST` | 2,0 | Násobitel alfa během korekce |
+| `NATURAL_RECOVERY_POWER_THRESHOLD` | 20 % | Max. výkon pro přeskočení učení v přirozené obnově |
+| `INSUFFICIENT_RISE_GAP_THRESHOLD` | 0,5 °C | Min. rozdíl pro spuštění Kint boostu |
+| `MAX_CONSECUTIVE_KINT_BOOSTS` | 5 | Limit před upozorněním na poddimenzování |
+| `MIN_PRE_BOOTSTRAP_CALIBRATION_RELIABILITY` | 20 % | Min. spolehlivost pro přeskočení bootstrapu |
+
+### Konfigurovatelné parametry
+
+| Parametr | Typ | Výchozí | Rozsah |
+|-----------|------|---------|-------|
+| **Agresivita** | Posuvník | 1.0 | 0.5 - 1.0 |
+| **Doba ohřevu** | Minuty | 5 | 1 - 30 |
+| **Doba ochlazování** | Minuty | 7 | 1 - 60 |
+| **Rychlost ohřevu** | °C/h | 0 (auto) | 0 - 5.0 |
+| **Počáteční váha** (Discovery) | Celé číslo | 1 | 1 - 50 |
+| **Alpha** (Fine Tuning) | Float | 0.08 | 0.01 - 0.3 |
+| **Rychlost poklesu** | Float | 0.12 | 0.0 - 0.5 |
+
+---
+
+## Služby a API
+
+### `versatile_thermostat.set_auto_tpi_mode`
+
+Ovládá spuštění/zastavení učení.
+
+```yaml
+service: versatile_thermostat.set_auto_tpi_mode
+target:
+  entity_id: climate.my_thermostat
+data:
+  auto_tpi_mode: true                    # true = start, false = stop
+  reinitialise: true                     # true = úplný reset, false = pokračovat
+  allow_kint_boost_on_stagnation: false  # Boost Kint při stagnaci
+  allow_kext_compensation_on_overshoot: false  # Korekce Kext při překmitu
+```
+
+### `versatile_thermostat.auto_tpi_calibrate_capacity`
+
+Kalibruje tepelnou kapacitu z historie.
+
+```yaml
+service: versatile_thermostat.auto_tpi_calibrate_capacity
+target:
+  entity_id: climate.my_thermostat
+data:
+  start_date: "2024-01-01T00:00:00+00:00"  # Volitelné
+  end_date: "2024-02-01T00:00:00+00:00"    # Volitelné
+  min_power_threshold: 95                   # Min % výkonu
+  capacity_safety_margin: 20                # % bezpečnostní rezervy
+  save_to_config: true                      # Uložit do konfigurace
+```
+
+**Návratové hodnoty služby**:
+
+| Klíč | Popis |
+|-----|-------------|
+| `max_capacity` | Vypočtená hrubá kapacita (°C/h) |
+| `recommended_capacity` | Kapacita po rezervě (°C/h) |
+| `reliability` | Index spolehlivosti (%) |
+| `samples_used` | Počet použitých vzorků |
+| `outliers_removed` | Počet odstraněných odlehlých hodnot |
+
+---
+
+## Pokročilá diagnostika a řešení problémů
+
+### Diagnostický senzor
+
+Entita: `sensor.<name>_auto_tpi_learning_state`
+
+| Atribut | Popis |
+|-----------|-------------|
+| `active` | Učení probíhá |
+| `heating_cycles_count` | Celkový počet sledovaných cyklů |
+| `coeff_int_cycles` | Validované cykly Kint |
+| `coeff_ext_cycles` | Validované cykly Kext |
+| `model_confidence` | Spolehlivost 0.0 - 1.0 |
+| `calculated_coef_int` | Aktuální Kint |
+| `calculated_coef_ext` | Aktuální Kext |
+| `last_learning_status` | Důvod posledního cyklu |
+| `capacity_heat_status` | `learning` nebo `learned` |
+| `capacity_heat_value` | Aktuální kapacita (°C/h) |
+
+### Společné stavy učení
+
+| Stav | Význam | Doporučená akce |
+|--------|---------|------------------|
+| `learned_indoor_heat` | Kint úspěšně aktualizováno | Normální |
+| `learned_outdoor_heat` | Kext úspěšně aktualizováno | Normální |
+| `power_out_of_range` | Výkon na 0 % nebo 100 % | Počkejte na nenasycený cyklus |
+| `real_rise_too_small` | Vzestup < 0,01 °C | Zkontrolujte senzor nebo dobu cyklu |
+| `setpoint_changed_during_cycle` | Požadovaná hodnota změněna | Neměňte požadovanou hodnotu |
+| `no_capacity_defined` | Žádná kalibrovaná kapacita | Počkejte na kalibraci/bootstrap |
+| `corrected_kext_overshoot` | Aplikována korekce překmitu | Normální, pokud je Kext příliš vysoký |
+| `corrected_kint_insufficient_rise` | Aplikován boost Kint | Normální, pokud je Kint příliš nízký |
+| `max_kint_boosts_reached` | 5 po sobě jdoucích boostů | **Poddimenzované vytápění** |
+
+### Diagnostický rozhodovací strom
+
+```mermaid
+flowchart TD
+    A[Detekován problém] --> B{Kint nebo Kext?}
+    
+    B -->|Kint příliš nízký| C[T° stoupá pomalu]
+    C --> D{Po 10 cyklech?}
+    D -->|Ano| E[Zkontrolujte doby ohřevu/chlazení]
+    D -->|Ne| F[Počkejte na konvergenci]
+    
+    B -->|Kint příliš vysoký| G[Oscilace T°]
+    G --> H[Snižte agresivitu]
+    
+    B -->|Kext příliš nízký| I[T° klesá pod požadovanou hodn.]
+    I --> J[Zkontrolujte venkovní senzor T°]
+    
+    B -->|Kext příliš vysoký| K[Přetrvávající překmit]
+    K --> L[Povolit allow_kext_compensation]
+    
+    A --> M{Žádné učení?}
+    M -->|power_out_of_range| N[Nasycené vytápění]
+    N --> O[Počkejte na příznivé podmínky]
+    M -->|no_capacity_defined| P[Žádná kalibrace]
+    P --> Q[Zkontrolujte historii nebo vnuťte hodnotu]
+```
+
+### Soubor perzistence
+
+**Umístění**: `.storage/versatile_thermostat_{unique_id}_auto_tpi_v2.json`
+
+Tento soubor obsahuje kompletní stav učení a obnovuje se při restartu Home Assistant. Lze jej smazat pro vynucení úplného resetu (nedoporučuje se).
+
+---
+
+## Přílohy
+
+### Doporučené referenční hodnoty
+
+| Typ vytápění | Doba ohřevu | Doba chladnutí | Typická kapacita |
+|--------------|--------------|--------------|------------------|
+| Elektrický konvektor | 2-5 min | 3-7 min | 2,0-3,0 °C/h |
+| Akumulační radiátor | 5-10 min | 10-20 min | 1,0-2,0 °C/h |
+| Podlahové vytápění | 15-30 min | 30-60 min | 0,3-0,8 °C/h |
+| Centrální kotel | 5-15 min | 10-30 min | 1,0-2,5 °C/h |
+
+### Kompletní matematické vzorce
+
+**Efektivní kapacita**:
+$$C_{eff} = C_{ref} \times (1 - K_{ext} \times \Delta T_{ext})$$
+
+**Adaptivní Alpha (EWMA)**:
+$$\alpha(n) = \frac{\alpha_0}{1 + k \times n}$$
+
+**Spolehlivost kalibrace**:
+$$reliability = 100 \times \min\left(\frac{samples}{20}, 1\right) \times \max\left(0, 1 - \frac{CV}{2}\right)$$
+
+Kde CV = variační koeficient (směrodatná odchylka / průměr)

--- a/documentation/cs/feature-autotpi.md
+++ b/documentation/cs/feature-autotpi.md
@@ -1,0 +1,160 @@
+# 🧠 Auto TPI: Automatické učení
+
+> [!NOTE]
+> Tato funkce je primárně určena pro systémy vytápění typu **Switch** (On/Off), jako jsou elektrické radiátory, kotle, podlahové vytápění nebo peletová kamna. Přizpůsobení pro termostatické radiátorové ventily (TRV) zůstává problematické kvůli jejich nelinearitě.
+
+**Auto TPI** umožňuje vašemu termostatu, aby se sám naučil tepelné charakteristiky vaší místnosti. Automaticky upravuje koeficienty $K_{int}$ (vnitřní setrvačnost) a $K_{ext}$ (vnější izolace), aby dosáhl a udržel vaši požadovanou teplotu s optimální přesností.
+
+> [!TIP]
+> **Pro pokročilé uživatele**: Detailní technická dokumentace vysvětlující algoritmy, matematické vzorce a vnitřní mechanismy je k dispozici zde: [Technická dokumentace Auto TPI](feature-autotpi-technical.md).
+
+---
+
+## 🔄 Cyklus relace
+
+Auto TPI pracuje prostřednictvím **jednorázových učebních relací**. Během relace systém dynamicky analyzuje reakci vaší místnosti: nejprve vyhodnotí skutečný výkon vašeho vytápění, poté upraví Kint a Kext v průběhu minimálně 50 TPI cyklů na každý koeficient.
+
+```mermaid
+graph LR
+    %% Flat Design Palette
+    classDef startEnd fill:#f1f8e9,stroke:#558b2f,stroke-width:2px,color:#33691e
+    classDef decision fill:#e3f2fd,stroke:#1565c0,stroke-width:2px,color:#0d47a1
+    classDef process fill:#eceff1,stroke:#455a64,stroke-width:1px,color:#263238
+    classDef bootstrap fill:#fff9c4,stroke:#fbc02d,stroke-width:2px,color:#f57f17
+
+    A([Start relace]) --> B{Sazba = 0?}
+    
+    B -- "Ano" --> C[Kalibrace]
+    B -- "Ne" --> D["Učení (min 50 cyklů)"]
+    
+    C --> E{Dostatečná\nhistorie?}
+    E -- "Ano" --> D
+    E -- "Ne" --> F[Bootstrap]
+    F -->|3 cykly| D
+    
+    D --> G{Relace ukončena?}
+    G -- "Ne" --> D
+    G -- "Ano" --> H([Relace dokončena])
+
+    class A,H startEnd
+    class B,E,G decision
+    class C,D process
+    class F bootstrap
+```
+
+1.  **Inicializace**: Pokud je **Rychlost ohřevu** (Heat Rate) 0, systém se nejprve pokusí o **Kalibraci** analýzou vašich historických dat o teplotě, sklonu a výkonu (přes službu `calibrate_capacity`).
+2.  **Režim Bootstrap**: Pokud historie není dostatečně spolehlivá pro odhad rychlosti ohřevu, systém přejde do režimu **Bootstrap**. Provede 3 intenzivní topné cykly, aby určil topný výkon vašeho radiátoru.
+3.  **Aktivní učení**: Jakmile je rychlost ohřevu známa, systém zpřesňuje koeficienty TPI v každém cyklu. Tato fáze trvá **minimálně 50 cyklů** na každý koeficient, aby byla zajištěna jejich stabilita.
+4.  **Ukládání**: Na konci relace (přibližně 48 hodin) se naučené koeficienty **a** konečná rychlost ohřevu automaticky uloží do vaší trvalé konfigurace.
+
+### Kdy se upravují Kint a Kext?
+
+Systém se učí oba koeficienty v různých situacích:
+
+| Koeficient | Situační učení | Vysvětlení |
+| :--- | :--- | :--- |
+| **Kint** (vnitřní setrvačnost) | Během **vzestupu teploty**, když je odchylka od požadované hodnoty významná (> 0,05 °C) a vytápění není nasycené (100 %). | Kint řídí citlivost vytápění. Upravuje se, když systém potřebuje "dohnat" požadovanou hodnotu. |
+| **Kext** (vnější izolace) | Během **stabilizace kolem požadované hodnoty**, když je odchylka malá (< 1 °C). | Kext kompenzuje tepelné ztráty směrem ven. Upravuje se, když systém udržuje teplotu. |
+
+> [!TIP]
+> Proto je důležité během učení vytvářet rozmanité topné cykly: vzestup teploty umožňuje nastavení Kint a stabilizace umožňuje nastavení Kext.
+
+> [!NOTE]
+> **Nasycené cykly**: Cykly s výkonem **0 %** nebo **100 %** jsou pro výpočet koeficientů Kint a Kext **ignorovány** (protože neposkytují žádné využitelné informace o tepelné odezvě). Cykly na 100 % se však používají k nastavení **rychlosti ohřevu**.
+
+---
+
+## 🚀 Spuštění učení
+
+Jakmile je funkce **Auto TPI** povolena a nakonfigurována pro váš termostat, učení se nespustí automaticky. Musíte jej spustit ručně:
+
+1.  **Přes vyhrazenou kartu (doporučeno)**: Použijte tlačítko "Play" na kartě [Auto TPI Learning Card](https://github.com/KipK/auto-tpi-learning-card).
+2.  **Přes službu "Set Auto TPI Mode"**: Zavolejte tuto službu (`set_auto_tpi_mode`) z vývojářských nástrojů. Tato služba spouští nebo zastavuje relaci Auto TPI.
+
+---
+
+## ⚙️ Standardní konfigurace
+
+Při povolení Auto TPI jsou k dispozici následující parametry:
+
+| Parametr | Popis |
+| :--- | :--- |
+| **Typ učení** | **Discovery** (pro počáteční učení) nebo **Fine Tuning** (pro doladění stávajícího nastavení). |
+| **Agresivita** | Redukční faktor koeficientu (1.0 = 100 %). Snižte tuto hodnotu (např. 0.8), pokud pozorujete časté překmity teploty. |
+| **Doba ohřevu** | Čas potřebný k tomu, aby vaše zařízení dosáhlo plného výkonu (např. 5 min pro elektrický radiátor). |
+| **Doba ochlazování** | Čas potřebný k ochlazení po vypnutí (např. 7 min pro elektrický radiátor). |
+| **Rychlost ohřevu** | Kapacita vzestupu teploty (°C/hodinu). Ponechte na **0**, aby ji systém vypočítal automaticky pomocí kalibrace nebo bootstrapu. |
+
+---
+
+## 🛠️ Pokročilá konfigurace
+
+Pokud zaškrtnete "Povolit pokročilé parametry", získáte přístup k jemnému nastavení algoritmů.
+
+### Metoda "Discovery" (Vážený průměr)
+Používá se pro rychlou stabilizaci nového systému.
+-   **Počáteční váha** (1 až 50): Definuje důležitost aktuálních koeficientů ve srovnání s novými zjištěními.
+    -   Při **1**: Nově vypočtené koeficienty téměř úplně nahradí ty staré. Učení je rychlé, ale citlivé na rušení.
+    -   Při **50**: Staré koeficienty mají mnohem větší váhu. Učení je velmi pomalé, ale velmi stabilní.
+    -   **Tip**: Pro počáteční učení ponechte na 1. Pokud chcete pokračovat v přerušeném učení při zachování určitého pokroku, použijte střední hodnotu (např. 25).
+
+### Metoda "Fine Tuning" (EWMA)
+Používá se pro hladkou a velmi přesnou adaptaci.
+-   **Alpha**: Vyhlazovací faktor. Čím vyšší je, tím rychleji systém reaguje na nedávné změny.
+-   **Rychlost poklesu (Decay Rate)**: Umožňuje postupně snižovat rychlost učení pro stabilizaci na nejlepších nalezených hodnotách.
+
+---
+
+## 💡 Best Practices
+
+### Vyhněte se vnějším vlivům
+Během učební relace (zejména v prvních několika hodinách) se snažte vyhnout:
+-   Přímému slunečnímu záření na teplotní senzor.
+-   Používání sekundárního zdroje tepla (krb, kamna).
+-   Masivnímu průvanu (otevřené dveře).
+Tyto faktory zkreslují vnímání izolace vaší místnosti systémem.
+
+### Vyhněte se extrémním podmínkám
+
+> [!CAUTION]
+> **Nespouštějte učení, pokud jsou vaše ohřívače nasycené** (neustále 100 % výkonu). K tomu obvykle dochází během výjimečných mrazů, kdy vytápění již nemůže dosáhnout požadované hodnoty. V těchto podmínkách se systém nemůže správně učit, protože nemá žádnou rezervu pro úpravu výkonu. Na spuštění učební relace počkejte na mírnější počasí.
+
+### Ideální průběh relace "Discovery"
+
+> [!TIP]
+> **Konkrétní příklad**: Pokud je vaše obvyklá požadovaná teplota **18 °C**, dočasně ji snižte na **15 °C** a počkejte, až se místnost stabilizuje. Poté restartujte učení a nastavte požadovanou teplotu zpět na **18 °C**. Tím vznikne rozdíl 3 °C, který systém bude sledovat pro své učení.
+
+1.  **Příprava**: Snižte požadovanou teplotu alespoň o 3 °C pod vaši obvyklou teplotu. Nechte místnost vychladnout a stabilizovat na této nové teplotě.
+2.  **Spuštění**: Aktivujte učení a **nastavte požadovanou teplotu zpět na její obvyklou hodnotu**. Systém bude sledovat vzestup teploty.
+3.  **Stabilizace**: Nechte systém několik hodin stabilizovat teplotu kolem požadované hodnoty.
+4.  **Stimulace**: Jakmile se koeficienty přestanou výrazně měnit, vyvolejte nový topný cyklus snížením požadované teploty o 2 °C a následným zvýšením zpět.
+5.  **Stabilizace**: Nechte systém několik hodin stabilizovat teplotu kolem požadované hodnoty.
+6.  **Dokončení**: Pokud učení ještě není dokončeno, nechte systém běžet až do konce při obnovení vašich běžných zvyklostí. Auto TPI se samo zastaví, jakmile se koeficienty po minimálně 50 cyklech u každého stabilizují.
+
+> [!NOTE]
+> **O překmitu (overshoot)**: Překmit při prvním vzestupu teploty je **normální** a dokonce prospěšný! Poskytuje cenná data pro učení. Systém je využije k upřesnění koeficientů. Pokud však překmity **přetrvávají nebo se zhoršují** i po několika cyklech, může to znamenat problém v konfiguraci Auto TPI (nesprávné časy ohřevu/chlazení, příliš vysoká agresivita) nebo problém v samotné konfiguraci VTherm.
+
+### Ideální průběh relace "Fine Tuning"
+1.  **Stabilita**: Dodržujte své obvyklé topné návyky a vyhněte se pouze výjimečným rušivým vlivům (dlouho otevřená okna, pomocné vytápění).
+2.  **Pozorování**: Nechte systém pozorovat mikrozměny a upravovat koeficienty v průběhu 50 cyklů.
+3.  **Přeorientování**: Pokud si všimnete, že se koeficienty výrazně mění nebo se zhoršuje komfort, je lepší restartovat kompletní relaci v režimu **Discovery**.
+---
+
+## 📊 Vizuální monitorování
+
+Pro sledování vývoje učení v reálném čase se důrazně doporučuje nainstalovat kartu **Auto TPI Learning Card**.
+
+### Instalace přes HACS
+
+[![Otevřete svou instanci Home Assistant a otevřete repozitář v Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=KipK&repository=auto-tpi-learning-card&category=plugin)
+
+Nebo ručně přidejte vlastní repozitář: [https://github.com/KipK/auto-tpi-learning-card](https://github.com/KipK/auto-tpi-learning-card)
+
+### Funkce karty
+
+![Auto TPI Card Preview](https://github.com/KipK/auto-tpi-learning-card/blob/main/assets/card.png?raw=true)
+
+-   📈 Progres kalibrace a učení v reálném čase
+-   🔢 Vypočítávané koeficienty `Kint`, `Kext` a rychlost ohřevu
+-   ▶️ Ovládací tlačítko pro spuštění/zastavení relace
+-   🔧 Možnosti resetování relace, povolení Kint Boost nebo Kext Deboost

--- a/documentation/de/feature-autotpi-technical.md
+++ b/documentation/de/feature-autotpi-technical.md
@@ -1,0 +1,516 @@
+# 🧠 Auto TPI: Detaillierter technischer Leitfaden
+
+> [!NOTE]
+> Dieses Dokument richtet sich an fortgeschrittene Benutzer, die den Auto-TPI-Algorithmus im Detail verstehen möchten. Eine zugänglichere Einführung finden Sie im [Auto TPI Benutzerleitfaden](feature-autotpi.md).
+
+---
+
+## Inhaltsverzeichnis
+
+1. [Der TPI-Algorithmus](#der-tpi-algorithmus)
+2. [Detaillierter Lernzyklus](#detaillierter-lernzyklus)
+3. [Kalibrierung der thermischen Kapazität](#kalibrierung-der-thermischen-kapazität)
+4. [Algorithmen zur Koeffizientenberechnung](#algorithmen-zur-koeffizientenberechnung)
+5. [Automatische Korrekturmechanismen](#automatische-korrekturmechanismen)
+6. [Erweiterte Parameter und Konstanten](#erweiterte-parameter-und-konstanten)
+7. [Dienste und API](#dienste-und-api)
+8. [Erweiterte Diagnose und Fehlerbehebung](#erweiterte-diagnose-und-fehlerbehebung)
+
+---
+
+## Der TPI-Algorithmus
+
+### Grundlegendes Prinzip
+
+Der **TPI**-Algorithmus (Time Proportional & Integral) berechnet bei jedem Zyklus einen **Leistungsprozentsatz**. Dieser Prozentsatz bestimmt, wie lange die Heizung während des Zyklus aktiv ist (z. B. 60 % bei einem 10-Minuten-Zyklus = 6 Minuten Heizen).
+
+### Basiskonzept
+
+```
+Leistung = (Kint × ΔT_innen) + (Kext × ΔT_außen)
+```
+
+Wobei:
+- **Kint** (`tpi_coef_int`): Innenkoeffizient, reagiert auf die Differenz zum Sollwert
+- **Kext** (`tpi_coef_ext`): Außenkoeffizient, kompensiert thermische Verluste
+- **ΔT_innen** = Sollwert − Innentemperatur
+- **ΔT_außen** = Sollwert − Außentemperatur
+
+```mermaid
+graph LR
+    subgraph Eingaben
+        A[Innentemperatur]
+        B[Außentemperatur]
+        C[Sollwert]
+    end
+    
+    subgraph TPI-Berechnung
+        D["ΔT_int = Sollwert - T_int"]
+        E["ΔT_ext = Sollwert - T_ext"]
+        F["Leistung = Kint×ΔT_int + Kext×ΔT_ext"]
+    end
+    
+    subgraph Ausgabe
+        G["Leistung % (0-100%)"]
+        H["AN/AUS-Zeit"]
+    end
+    
+    A --> D
+    C --> D
+    B --> E
+    C --> E
+    D --> F
+    E --> F
+    F --> G
+    G --> H
+```
+
+### Rolle der Koeffizienten
+
+| Koeffizient | Rolle | Lern-Situation |
+|-------------|-------|-------------------|
+| **Kint** | Steuert die **Reaktivität**: Je höher er ist, desto schneller reagiert die Heizung auf Abweichungen | Während des **Temperaturanstiegs** (Abweichung > 0,05°C, Leistung < 99%) |
+| **Kext** | Kompensiert **thermische Verluste**: Je höher er ist, desto mehr antizipiert die Heizung die Abkühlung | Während der **Stabilisierung** um den Sollwert (Abweichung < 0,5°C) |
+
+---
+
+## Detaillierter Lernzyklus
+
+### Ablauf-Übersicht
+
+```mermaid
+flowchart TD
+    subgraph Initialisierung
+        A[Sitzung starten] --> B{Heizrate = 0?}
+        B -->|Ja| C[Historische Vorkalibrierung]
+        B -->|Nein| G[Aktives Lernen]
+        
+        C --> D{Zuverlässigkeit >= 20%?}
+        D -->|Ja| G
+        D -->|Nein| E[Bootstrap-Modus]
+        E -->|3 aggressive Zyklen| F[Geschätzte Kapazität]
+        F --> G
+    end
+    
+    subgraph "Lernschleife"
+        G --> H[TPI-Zyklus starten]
+        H --> I[Anfangszustand erfassen]
+        I --> J[Heizung AN/AUS ausführen]
+        J --> K[Zyklusende: ΔT messen]
+        K --> L{Gültige Bedingungen?}
+        
+        L -->|Nein| M[Lernen überspringen]
+        L -->|Ja| N{Situation analysieren}
+        
+        N -.->|Überschwingen| O[🔸 Kext-Korrektur<br/>optional]
+        N -.->|Stagnation| P[🔸 Kint-Boost<br/>optional]
+        N -->|T° steigt| Q[Kint-Lernen]
+        N -->|Stabilisierung| R[Kext-Lernen]
+        
+        O -.-> S[Koeffizienten aktualisieren]
+        P -.-> S
+        Q --> S
+        R --> S
+        M --> H
+        S --> H
+    end
+    
+    subgraph Finalisierung
+        S --> T{50 Zyklen Kint UND Kext?}
+        T -->|Nein| H
+        T -->|Ja| U[In Konfig speichern]
+        U --> V[End-Benachrichtigung]
+    end
+    
+    style O fill:#fff3cd,stroke:#ffc107,stroke-width:2px
+    style P fill:#fff3cd,stroke:#ffc107,stroke-width:2px
+```
+
+> [!NOTE]
+> **Gelbe Boxen mit gestrichelten Linien** (🔸) stellen **optionale** Korrekturmechanismen dar. Diese müssen explizit über die Parameter des Dienstes `set_auto_tpi_mode` aktiviert werden.
+
+### Details zur Zustandserfassung (Snapshot)
+
+Zu Beginn jedes Zyklus erfasst der Algorithmus den aktuellen Zustand:
+
+| Erfasste Daten | Verwendung |
+|----------------|------------|
+| `last_temp_in` | Innentemperatur zu Zyklusbeginn |
+| `last_temp_out` | Außentemperatur zu Zyklusbeginn |
+| `last_order` | Sollwert zu Zyklusbeginn |
+| `last_power` | Berechnete Leistung für diesen Zyklus (0,0 bis 1,0) |
+| `last_state` | HVAC-Modus (Heizen/Kühlen) |
+
+Am Ende des Zyklus werden diese Werte mit den aktuellen Messungen verglichen, um den Fortschritt zu berechnen.
+
+### Validierungsbedingungen für Zyklen
+
+Ein Zyklus wird für das Lernen **ignoriert**, wenn:
+
+| Bedingung | Grund |
+|-----------|--------|
+| Leistung = 0% oder 100% | Sättigung: Keine verwertbaren Informationen zur Effizienz |
+| Sollwert geändert | Zielwert mitten im Zyklus geändert |
+| Lastabwurf aktiv | Heizung wurde vom Power Manager zwangsweise AUS geschaltet |
+| Fehler erkannt | Anomalie festgestellt (Heizung ohne Wirkung) |
+| Zentralheizkessel AUS | Thermostat fordert an, aber Kessel reagiert nicht |
+| Erster Zyklus nach Neustart | Keine gültigen Referenzdaten |
+
+---
+
+## Kalibrierung der thermischen Kapazität
+
+### Definition
+
+Die **thermische Kapazität** (oder **Heizrate**) repräsentiert die maximale Geschwindigkeit des Temperaturanstiegs Ihres Systems, ausgedrückt in **°C pro Stunde** (°C/h).
+
+Beispiel: Eine Kapazität von 2,0 °C/h bedeutet, dass Ihr Heizkörper die Temperatur unter idealen (adiabatischen) Bedingungen bei voller Leistung in einer Stunde um 2 °C anheben kann.
+
+### Bestimmungsmethoden
+
+```mermaid
+graph TD
+    A[Heizrate = 0?] -->|Ja| B[Vorkalibrierung]
+    A -->|Nein| C[Konfigurierten Wert nutzen]
+    
+    B --> D{Historie verfügbar?}
+    D -->|Ja| E[Historien-Analyse]
+    D -->|Nein| F[Bootstrap-Modus]
+    
+    E --> G{Zuverlässigkeit >= 20%?}
+    G -->|Ja| H[Kalibrierte Kapazität]
+    G -->|No| F
+    
+    F --> I[3 aggressive Zyklen Kint=1.0 Kext=0.1]
+    I --> J[Tatsächlichen Anstieg messen]
+    J --> K[Geschätzte Kapazität]
+    
+    H --> L[Kint/Kext Lernen]
+    K --> L
+    C --> L
+```
+
+### Vorkalibrierung via Historien-Analyse
+
+Der Dienst `auto_tpi_calibrate_capacity` analysiert die Sensorhistorie:
+
+1. **Abruf** der Daten von `temperature_slope` und `power_percent` über 30 Tage
+2. **Filterung**: Behält nur Punkte bei, an denen `power >= 95 %` war
+3. **Ausreißer-Eliminierung** mittels IQR-Methode (Interquartile Range)
+4. **Berechnung des 75. Perzentils** der Steigungen (repräsentativer als der Median)
+5. **Adiabatische Korrektur**: `Kapazität = P75 + Kext × ΔT`
+6. **Anwendung einer Sicherheitsmarge**: standardmäßig 20 %
+
+### Bootstrap-Modus
+
+Wenn die Historie unzureichend ist (Zuverlässigkeit < 20 %), wechselt das System in den **Bootstrap-Modus**:
+
+- **Aggressive Koeffizienten**: Kint = 1.0, Kext = 0.1
+- **Dauer**: mindestens 3 Zyklen
+- **Ziel**: Einen signifikanten Temperaturanstieg auslösen, um die tatsächliche Kapazität zu messen
+- **Sicherheits-Timeout**: Wenn nach 5 Zyklen kein Erfolg eintritt, wird eine Standardkapazität von 0,3 °C/h angenommen (für langsame Systeme)
+
+---
+
+## Algorithmen zur Koeffizientenberechnung
+
+### Kint-Lernen (Innenkoeffizient)
+
+Der Algorithmus passt Kint an, wenn die Temperatur in Richtung des Sollwerts **steigt**.
+
+#### Detaillierte Formel
+
+```mermaid
+flowchart LR
+    subgraph "1. Effektive Kapazität"
+        A["C_eff = C_ref × (1 - Kext × ΔT_ext)"]
+    end
+    
+    subgraph "2. Max. möglicher Anstieg"
+        B["max_rise = C_eff × Zyklusdauer × Effizienz"]
+    end
+    
+    subgraph "3. Angepasstes Ziel"
+        C["target = min(Sollwert-Differenz, max_rise)"]
+    end
+    
+    subgraph "4. Verhältnis"
+        D["ratio = (target / tatsächlicher_Anstieg) × Aggressivität"]
+    end
+    
+    subgraph "5. Neues Kint"
+        E["Kint_neu = Kint_alt × ratio"]
+    end
+    
+    A --> B --> C --> D --> E
+```
+
+#### Verwendete Variablen
+
+| Variable | Beschreibung | Typischer Wert |
+|----------|-------------|---------------|
+| `C_ref` | Kalibrierte Referenzkapazität | 1.5 °C/h |
+| `Kext` | Aktueller Außenkoeffizient | 0.02 |
+| `ΔT_ext` | Differenz Innen-/Außentemp | 15°C |
+| `Zyklusdauer` | In Stunden | 0.167 (10 Min.) |
+| `Effizienz` | Verwendeter Leistungsprozentsatz | 0.70 |
+| `Aggressivität` | Moderationsfaktor | 0.9 |
+
+### Kext-Lernen (Außenkoeffizient)
+
+Der Algorithmus passt Kext an, wenn die Temperatur **nahe am Sollwert** ist (|Abweichung| < 0,5°C).
+
+#### Formel
+
+```
+Korrektur = Kint × (Abweichung_innnen / Abweichung_außen)
+Kext_neu = Kext_alt + Korrektur
+```
+
+- Wenn Abweichung_innen **negativ** (Überschwingen) → Negative Korrektur → **Kext sinkt**
+- Wenn Abweichung_innen **positiv** (Unterschreiten) → Positive Korrektur → **Kext steigt**
+
+### Glättungsmethoden
+
+Es stehen zwei Methoden zur Glättung neuer Werte zur Verfügung:
+
+#### Gewichteter Durchschnitt ("Discovery"-Modus)
+
+```
+Kint_final = (Kint_alt × Zähler + Kint_neu) / (Zähler + 1)
+```
+
+| Zyklus | Altes Gewicht | Neues Gewicht | Einfluss des neuen Wertes |
+|-------|------------|------------|------------------|
+| 1 | 1 | 1 | 50% |
+| 10 | 10 | 1 | 9% |
+| 50 | 50 | 1 | 2% |
+
+> Der Zähler ist bei 50 gedeckelt, um eine minimale Reaktivität zu erhalten.
+
+#### EWMA ("Fine Tuning"-Modus)
+
+```
+Kint_final = (1 - α) × Kint_alt + α × Kint_neu
+α(n) = α₀ / (1 + decay_rate × n)
+```
+
+| Parameter | Standard | Beschreibung |
+|-----------|---------|-------------|
+| `α₀` (initiales Alpha) | 0.08 | Ursprüngliches Gewicht neuer Werte |
+| `decay_rate` | 0.12 | Verringerungsgeschwindigkeit von Alpha |
+
+---
+
+## Automatische Korrekturmechanismen
+
+### Überschwing-Korrektur (Kext Deboost)
+
+> **Aktivierung**: Parameter `allow_kext_compensation_on_overshoot` im Dienst `set_auto_tpi_mode`
+
+Erkennt und korrigiert, wenn die Temperatur den **Sollwert überschreitet**, ohne wieder zu sinken.
+
+```mermaid
+flowchart TD
+    A{T° > Sollwert + 0.2°C?} -->|Ja| B{Leistung > 5%?}
+    B -->|Ja| C{T° sinkt nicht?}
+    C -->|Ja| D[Kext-Korrektur]
+    
+    A -->|Nein| E[Keine Korrektur]
+    B -->|Nein| E
+    C -->|Nein| E
+    
+    D --> F["Reduktion = Überschwingen × Kint / ΔT_außen"]
+    F --> G["Kext_Ziel = max(0.001, Kext - Reduktion)"]
+    G --> H[Anwenden mit Alpha-Boost ×2]
+```
+
+### Stagnations-Korrektur (Kint Boost)
+
+> **Aktivierung**: Parameter `allow_kint_boost_on_stagnation` im Dienst `set_auto_tpi_mode`
+
+Erkennt und korrigiert, wenn die Temperatur trotz signifikantem Bedarf **stagniert**.
+
+```mermaid
+flowchart TD
+    A{Abweichung > 0.5°C?} -->|Ja| B{Fortschritt < 0.02°C?}
+    B -->|Ja| C{Leistung < 99%?}
+    C -->|Ja| D{Konsektutive Boosts < 5?}
+    D -->|Ja| E[Kint-Boost]
+    
+    A -->|No| F[Keine Korrektur]
+    B -->|No| F
+    C -->|No| F
+    D -->|No| G[Alarm: Unterdimensionierte Heizung]
+    
+    E --> H["Boost = 8% × min(Abweichung/0.3, 2.0)"]
+    H --> I["Kint_Ziel = Kint × (1 + Boost)"]
+```
+
+---
+
+## Erweiterte Parameter und Konstanten
+
+### Interne Konstanten (Nicht konfigurierbar)
+
+| Konstante | Wert | Beschreibung |
+|----------|-------|-------------|
+| `MIN_KINT` | 0.01 | Untergrenze für Kint zur Aufrechterhaltung der Reaktivität |
+| `OVERSHOOT_THRESHOLD` | 0.2°C | Schwelle für Überschwingen zur Auslösung der Korrektur |
+| `OVERSHOOT_POWER_THRESHOLD` | 5% | Mindestleistung, um Überschwingen als Kext-Fehler zu werten |
+| `OVERSHOOT_CORRECTION_BOOST` | 2.0 | Alpha-Multiplikator während der Korrektur |
+| `NATURAL_RECOVERY_POWER_THRESHOLD` | 20% | Max Leistung, um Lernen bei natürlicher Erholung zu überspringen |
+| `INSUFFICIENT_RISE_GAP_THRESHOLD` | 0.5°C | Mindestabweichung für Kint-Boost |
+| `MAX_CONSECUTIVE_KINT_BOOSTS` | 5 | Limit vor Alarm wegen Unterdimensionierung |
+| `MIN_PRE_BOOTSTRAP_CALIBRATION_RELIABILITY` | 20% | Mindestzuverlässigkeit zur Umgehung des Bootstrap |
+
+### Konfigurierbare Parameter
+
+| Parameter | Typ | Standard | Bereich |
+|-----------|------|---------|-------|
+| **Aggressiveness** | Slider | 1.0 | 0.5 - 1.0 |
+| **Heating Time** | Minuten | 5 | 1 - 30 |
+| **Cooling Time** | Minuten | 7 | 1 - 60 |
+| **Heating Rate** | °C/h | 0 (auto) | 0 - 5.0 |
+| **Initial Weight** (Discovery) | Ganzzahl | 1 | 1 - 50 |
+| **Alpha** (Fine Tuning) | Float | 0.08 | 0.01 - 0.3 |
+| **Decay Rate** | Float | 0.12 | 0.0 - 0.5 |
+
+---
+
+## Dienste und API
+
+### `versatile_thermostat.set_auto_tpi_mode`
+
+Steuert den Start/Stopp des Lernens.
+
+```yaml
+service: versatile_thermostat.set_auto_tpi_mode
+target:
+  entity_id: climate.mein_thermostat
+data:
+  auto_tpi_mode: true                    # true = Start, false = Stopp
+  reinitialise: true                     # true = Vollständiger Reset, false = Fortsetzen
+  allow_kint_boost_on_stagnation: false  # Kint bei Stagnation boosten
+  allow_kext_compensation_on_overshoot: false  # Kext bei Überschwingen korrigieren
+```
+
+### `versatile_thermostat.auto_tpi_calibrate_capacity`
+
+Kalibriert die thermische Kapazität anhand der Historie.
+
+```yaml
+service: versatile_thermostat.auto_tpi_calibrate_capacity
+target:
+  entity_id: climate.mein_thermostat
+data:
+  start_date: "2024-01-01T00:00:00+00:00"  # Optional
+  end_date: "2024-02-01T00:00:00+00:00"    # Optional
+  min_power_threshold: 95                   # Min. Leistung in %
+  capacity_safety_margin: 20                # Sicherheitsmarge in %
+  save_to_config: true                      # In Konfig speichern
+```
+
+**Rückgabewerte des Dienstes**:
+
+| Schlüssel | Beschreibung |
+|-----|-------------|
+| `max_capacity` | Berechnete Bruttokapazität (°C/h) |
+| `recommended_capacity` | Kapazität nach Marge (°C/h) |
+| `reliability` | Zuverlässigkeitsindex (%) |
+| `samples_used` | Anzahl verwendeter Proben |
+| `outliers_removed` | Anzahl entfernter Ausreißer |
+
+---
+
+## Erweiterte Diagnose und Fehlerbehebung
+
+### Diagnose-Sensor
+
+Entität: `sensor.<Name>_auto_tpi_learning_state`
+
+| Attribut | Beschreibung |
+|-----------|-------------|
+| `active` | Lernen läuft |
+| `heating_cycles_count` | Gesamtzahl beobachteter Zyklen |
+| `coeff_int_cycles` | Validierte Kint-Zyklen |
+| `coeff_ext_cycles` | Validierte Kext-Zyklen |
+| `model_confidence` | Vertrauen 0.0 - 1.0 |
+| `calculated_coef_int` | Aktuelles Kint |
+| `calculated_coef_ext` | Aktuelles Kext |
+| `last_learning_status` | Status des letzten Zyklus |
+| `capacity_heat_status` | `learning` oder `learned` |
+| `capacity_heat_value` | Aktuelle Kapazität (°C/h) |
+
+### Häufige Lernstatus-Meldungen
+
+| Status | Bedeutung | Empfohlene Aktion |
+|--------|---------|------------------|
+| `learned_indoor_heat` | Kint erfolgreich aktualisiert | Normal |
+| `learned_outdoor_heat` | Kext erfolgreich aktualisiert | Normal |
+| `power_out_of_range` | Leistung bei 0 % oder 100 % | Auf nicht-gesättigten Zyklus warten |
+| `real_rise_too_small` | Anstieg < 0,01 °C | Sensor oder Zyklusdauer prüfen |
+| `setpoint_changed_during_cycle` | Sollwert geändert | Sollwert während des Zyklus nicht verändern |
+| `no_capacity_defined` | Keine kalibrierte Kapazität | Auf Kalibrierung/Bootstrap warten |
+| `corrected_kext_overshoot` | Überschwing-Korrektur angewandt | Normal, falls Kext zu hoch |
+| `corrected_kint_insufficient_rise` | Kint-Boost angewandt | Normal, falls Kint zu niedrig |
+| `max_kint_boosts_reached` | 5 konsekutive Boosts | **Heizung unterdimensioniert** |
+
+### Diagnose-Entscheidungsbaum
+
+```mermaid
+flowchart TD
+    A[Problem erkannt] --> B{Kint oder Kext?}
+    
+    B -->|Kint zu niedrig| C[T° steigt zu langsam]
+    C --> D{Nach 10 Zyklen?}
+    D -->|Ja| E[Heiz-/Kühlzeiten prüfen]
+    D -->|Nein| F[Konvergenz abwarten]
+    
+    B -->|Kint zu hoch| G[T°-Oszillationen]
+    G --> H[Aggressivität reduzieren]
+    
+    B -->|Kext zu niedrig| I[T° fällt unter Sollwert]
+    I --> J[Außensensor prüfen]
+    
+    B -->|Kext zu hoch| K[Anhaltendes Überschwingen]
+    K --> L[allow_kext_compensation aktivieren]
+    
+    A --> M{Kein Lernen?}
+    M -->|power_out_of_range| N[Gesättigte Heizung]
+    N --> O[Günstige Bedingungen abwarten]
+    M -->|no_capacity_defined| P[Keine Kalibrierung]
+    P --> Q[Historie prüfen oder Wert erzwingen]
+```
+
+### Persistenzdatei
+
+**Speicherort**: `.storage/versatile_thermostat_{unique_id}_auto_tpi_v2.json`
+
+Diese Datei enthält den kompletten Lernzustand und wird bei einem Neustart von Home Assistant wiederhergestellt. Sie kann gelöscht werden, um einen vollständigen Reset zu erzwingen (nicht empfohlen).
+
+---
+
+## Anhänge
+
+### Empfohlene Referenzwerte
+
+| Heizungstyp | Aufheizzeit | Abkühlzeit | Typische Kapazität |
+|--------------|--------------|--------------|------------------|
+| Elektrokonvektor | 2-5 Min. | 3-7 Min. | 2.0-3.0 °C/h |
+| Speicherheizung | 5-10 Min. | 10-20 Min. | 1.0-2.0 °C/h |
+| Fußbodenheizung | 15-30 Min. | 30-60 Min. | 0.3-0.8 °C/h |
+| Zentralheizkessel | 5-15 Min. | 10-30 Min. | 1.0-2.5 °C/h |
+
+### Vollständige mathematische Formeln
+
+**Effektive Kapazität**:
+$$C_{eff} = C_{ref} \times (1 - K_{ext} \times \Delta T_{ext})$$
+
+**Adaptives Alpha (EWMA)**:
+$$\alpha(n) = \frac{\alpha_0}{1 + k \times n}$$
+
+**Zuverlässigkeit der Kalibrierung**:
+$$reliability = 100 \times \min\left(\frac{samples}{20}, 1\right) \times \max\left(0, 1 - \frac{CV}{2}\right)$$
+
+Wobei CV = Variationskoeffizient (Standardabweichung / Mittelwert)

--- a/documentation/de/feature-autotpi.md
+++ b/documentation/de/feature-autotpi.md
@@ -1,442 +1,160 @@
-# Auto-TPI-Funktion
+# 🧠 Auto TPI: Automatisches Lernen
 
+> [!NOTE]
+> Dieses Feature ist primär für **Schalt**-Heizsysteme (An/Aus) konzipiert, wie z.B. Elektroheizkörper, Heizkessel, Fußbodenheizungen oder Pelletöfen. Die Anpassung für thermostatische Heizkörperventile (TRV) bleibt aufgrund deren Nichtlinearität problematisch.
 
-## Einleitung
+**Auto TPI** ermöglicht es Ihrem Thermostat, die thermischen Eigenschaften Ihres Raumes selbstständig zu erlernen. Es passt automatisch die Koeffizienten $K_{int}$ (Interne Trägheit) und $K_{ext}$ (Externe Isolierung) an, um Ihren Sollwert mit optimaler Präzision zu erreichen und zu halten.
 
-Die Funktion **Auto TPI** (oder Selbstlernfunktion) ist eine wichtige Neuerung des Versatile Thermostat. Damit kann der Thermostat seine Regelungskoeffizienten (Kp und Ki) **automatisch** anpassen, indem er das Temperaturverhalten des Raums analysiert.
+> [!TIP]
+> **Für fortgeschrittene Benutzer**: Eine detaillierte technische Dokumentation, die die Algorithmen, mathematischen Formeln und internen Mechanismen erklärt, finden Sie hier: [Auto TPI Technische Dokumentation](feature-autotpi-technical.md).
 
-Im TPI-Modus (Time Proportional & Integral) berechnet der Thermostat einen Öffnungsprozentsatz oder eine Heizzeit anhand der Abweichung zwischen der Solltemperatur und der Innentemperatur (`Kp`) sowie des Einflusses der Außentemperatur (`Ki`).
+---
 
-Die richtigen Koeffizienten (`tpi_coef_int` und `tpi_coef_ext`) zu finden, ist oft komplex und erfordert zahlreiche Versuche. **Das übernimmt Auto TPI.**
+## 🔄 Sitzungszyklus
 
-## Voraussetzungen
+Auto TPI arbeitet in **punktuellen Lern-Sitzungen**. Während einer Sitzung analysiert das System dynamisch die Reaktion Ihres Raumes: Zuerst wird die tatsächliche Leistung Ihrer Heizung bewertet, dann werden Kint und Kext über mindestens 50 TPI-Zyklen pro Koeffizient angepasst.
 
-Damit Auto TPI effizient funktioniert:
-1.  **Zuverlässiger Temperatursensor**: Der Sensor darf nicht direkt von der Wärmequelle beeinflusst werden (nicht beim Heizkörper anbringen!).
-2.  **Außentemperatursensor**: Eine genaue Messung der Außentemperatur ist unerlässlich.
-3.  **TPI-Modus aktiviert**: Diese Funktion ist nur verfügbar, wenn Sie den TPI-Algorithmus verwenden (Thermostat auf Schalter, Ventil oder Klima im TPI-Modus).
-4.  **Korrekte Leistungseinstellung**: Stellen Sie die Parameter für die Aufheizzeit korrekt ein (siehe unten).
-5.  **Optimaler Start (wichtig)**: Damit der Lernvorgang effektiv startet, wird empfohlen, ihn zu aktivieren, wenn die Abweichung zwischen der aktuellen Temperatur und dem Sollwert erheblich ist (**2 °C** sind ausreichend).
-*   *Tipp*: Kühlen Sie den Raum, aktivieren Sie den Lernvorgang und stellen Sie dann den Komfort-Sollwert wieder ein.
+```mermaid
+graph LR
+    %% Flat Design Palette
+    classDef startEnd fill:#f1f8e9,stroke:#558b2f,stroke-width:2px,color:#33691e
+    classDef decision fill:#e3f2fd,stroke:#1565c0,stroke-width:2px,color:#0d47a1
+    classDef process fill:#eceff1,stroke:#455a64,stroke-width:1px,color:#263238
+    classDef bootstrap fill:#fff9c4,stroke:#fbc02d,stroke-width:2px,color:#f57f17
 
-## Konfiguration
+    A([Sitzungsstart]) --> B{Rate = 0?}
+    
+    B -- "Ja" --> C[Kalibrierung]
+    B -- "Nein" --> D["Lernen (min 50 Zyklen)"]
+    
+    C --> E{Genug\nHistorie?}
+    E -- "Ja" --> D
+    E -- "Nein" --> F[Bootstrap]
+    F -->|3 Zyklen| D
+    
+    D --> G{Sitzung beendet?}
+    G -- "Nein" --> D
+    G -- "Ja" --> H([Sitzung komplett])
 
-Die Konfiguration von Auto TPI ist in den TPI-Konfigurationsablauf für **jeden einzelnen Thermostat** integriert.
-
-> **Hinweis**: Der Auto-TPI-Lernvorgang kann nicht über die zentrale Konfiguration eingerichtet werden, da jeder Thermostat einen eigenen Lernvorgang benötigt.
-
-1.  Gehen Sie zur Konfiguration des Versatile Thermostat (**Konfigurieren**).
-2.  Wählen Sie **TPI-Einstellungen**.
-3.  **Wichtig**: Sie müssen die Option **Zentrale TPI-Konfiguration verwenden** deaktivieren, um auf die lokalen Einstellungen zugreifen zu können.
-4.  Aktivieren Sie auf dem nächsten Bildschirm (TPI-Attribute) ganz unten das **Auto-TPI-Lernen aktivieren**.
-
-Sobald diese Option aktiviert ist, wird ein spezieller Konfigurationsassistent in mehreren Schritten angezeigt:
-
-### Schritt 1: Allgemein
-
-*   **Auto-TPI aktivieren**: Ermöglicht das Aktivieren oder Deaktivieren des Lernvorgangs.
-*   **Benachrichtigung**: Wenn diese Option aktiviert ist, wird **nur** dann eine Benachrichtigung gesendet, wenn der Lernvorgang als abgeschlossen gilt (50 Zyklen pro Koeffizient).
-*   **Konfiguration aktualisieren**: Wenn diese Option aktiviert ist, werden die erlernten TPI-Koeffizienten **automatisch** in der Konfiguration des Thermostats gespeichert, aber **nur wenn der Lernvorgang als abgeschlossen gilt**. Wenn diese Option deaktiviert ist, werden die erlernten Koeffizienten für die aktuelle TPI-Regelung verwendet, aber nicht in der Konfiguration gespeichert.
-* **Kontinuierliches Lernen** (`auto_tpi_continuous_learning`): Wenn diese Option aktiviert ist, wird das Lernen auch nach Abschluss der ersten 50 Zyklen unbegrenzt fortgesetzt. Dadurch kann sich der Thermostat kontinuierlich an allmähliche Veränderungen der thermischen Umgebung anpassen (z. B. saisonale Veränderungen, Alterung des Hauses). Wenn diese Option aktiviert ist, werden die gelernten Parameter am Ende jedes Zyklus in der Konfiguration gespeichert (sofern **Konfigurationsaktualisierung** ebenfalls aktiviert ist), sobald das Modell als „stabil” gilt (z. B. nach den ersten 50 Zyklen).
-    *   **Fehlerrobustheit**: Im kontinuierlichen Modus stoppen aufeinanderfolgende Fehler das Lernen nicht. Das System ignoriert fehlerhafte Zyklen und setzt seine Anpassung fort.
-    *   **Erkennung von Betriebsänderungen**: Wenn das kontinuierliche Lernen aktiviert ist, überwacht das System die letzten Lernfehler. Wird eine **systematische Verzerrung** festgestellt (z. B. aufgrund eines Wechsels der Jahreszeit, der Isolierung oder des Heizsystems), wird die Lernrate (Alpha) **vorübergehend erhöht** (auf bis zum Dreifachen des Basiswerts, begrenzt auf 15 %), um die Anpassung zu beschleunigen. Dank dieser Funktion kann sich der Thermostat schnell und ohne manuelles Eingreifen an neue Temperaturbedingungen anpassen.
-*   **Externen Koeffizienten beibehalten** (`auto_tpi_keep_ext_learning`): Wenn diese Option aktiviert ist, wird der externe Koeffizient (`Kext`) auch nach Erreichen von 50 Zyklen weiter gelernt, solange der interne Koeffizient (`Kint`) noch nicht stabil ist.
-**Hinweis:** Die Beibehaltung der Konfiguration erfolgt nur, wenn beide Koeffizienten stabil sind.
-*   **Aufheiz-/Abkühlzeit**: Legen Sie die Trägheit Ihres Kühlers fest ([siehe Thermische Konfiguration](#kritische-thermische-konfiguration)).
-*   **Obergrenze für den Innenkoeffizienten**: Sicherheitsgrenzen für den Innenkoeffizienten (`max 3,0`). **Hinweis**: Bei einer Änderung dieses Grenzwerts im Konfigurationsfluss wird der neue Wert **sofort** auf die gelernten Koeffizienten angewendet, wenn diese über dem neuen Grenzwert liegen (was ein Neuladen der Integration erfordert, was nach dem Speichern einer Änderung über die Optionen der Fall ist).
-
-*   **Heizrate** (`auto_tpi_heating_rate`): Zielwert für die Temperaturanstiegsrate in °C/h. ([siehe Konfiguration der Raten](#configuration-des-taux-de-chauffe) )\n*   **Aggressivität** (`auto_tpi_aggressiveness`): Prozentualer Anteil der erlernten Wärmekapazität, der verwendet werden soll (50-100 %, Standardwert 90 %). Niedrigere Werte führen zu konservativeren Koeffizienten, wodurch das Risiko einer Überschreitung des Sollwerts verringert wird.
-
-    *Hinweis: Es ist nicht unbedingt erforderlich, die maximale Heizrate zu verwenden. Je nach Dimensionierung der Heizung können Sie durchaus einen niedrigeren Wert verwenden, **was sogar sehr empfehlenswert ist**.
-    Je näher Sie an der maximalen Kapazität liegen, desto höher ist der beim Lernen ermittelte Kint-Koeffizient.*
-
-    *Sobald Ihre Kapazität durch den dafür vorgesehenen Dienst definiert oder manuell geschätzt wurde, sollten Sie  einen angemessenen Heizgrad verwenden.
-   **Das Wichtigste ist, dass Sie nicht über das hinausgehen, was Ihr Heizkörper in diesem Raum leisten kann.**
-    Beispiel: Ihre gemessene adiabatische Kapazität beträgt 1,5 °C/h, 1 °C/h ist eine Standardkonstante, deren Verwendung sinnvoll ist.*
-
-### Schritt 2: Methode
-
-Wählen Sie den Lernalgorithmus:
-*   **Durchschnitt (Average)**: Einfacher gewichteter Durchschnitt. Ideal für schnelles und einmaliges Lernen (leicht zurückzusetzen).
-*   **EMA (Exponential Moving Average)**: Exponentieller gleitender Durchschnitt. Sehr empfehlenswert für kontinuierliches Lernen und Feinabstimmung, da er aktuelle Werte bevorzugt.
-
-### Schritt 3: Verfahrenseinstellungen
-
-Konfigurieren Sie die spezifischen Parameter für die gewählte Methode:
-*   **Durchschnitt**: Anfangsgewichtung.
-*   **EMA**: Anfangs-Alpha und Abklingrate (Decay).
-
-
-### Thermische Konfiguration (kritisch)
-
-Der Algorithmus muss die Reaktionsfähigkeit Ihres Heizungssystems verstehen.
-
-#### `heater_heating_time` (Thermische Reaktionszeit)
-Dies ist die Gesamtzeit, die das System benötigt, um eine messbare Wirkung auf die Raumtemperatur zu erzielen.
-
-Sie umfasst:
-*  Die Aufheizzeit des Heizkörpers (materielle Trägheit).
-*  Die Zeit, die die Wärme benötigt, um sich im Raum bis zum Sensor auszubreiten.
-
-**Empfohlene Werte:**
-
-| Heizungstyp                                            | Empfohlener Wert |
-|--------------------------------------------------------|------------------|
-| Elektroheizkörper (Konvektor), Nahsensor               | 2-5 min          |
-| Speicherheizung (Ölbad, Gusseisen), Nahsensor          | 5-10 min         |
-| Fußbodenheizung oder großer Raum mit entferntem Sensor | 10-20 min        |
-
-> Ein falscher Wert kann die Berechnung der Effizienz verfälschen und das Lernen verhindern.
-
-#### `heater_cooling_time` (Kühlzeit des Heizkörpers)
-Zeit, die der Heizkörper benötigt, um nach dem Ausschalten abzukühlen. Wird verwendet, um über den `cold_factor` zu schätzen, ob der Heizkörper zu Beginn eines Zyklus „warm” oder „kalt” ist. Der `cold_factor` ermöglicht es, die Trägheit des Heizkörpers zu korrigieren, und dient als **Filter**: Wenn die Aufheizzeit im Vergleich zur geschätzten Aufwärmzeit zu kurz ist, wird das Lernen für diesen Zyklus ignoriert (um Störungen zu vermeiden).
-
-### Automatisches Lernen der Wärmekapazität ⚡
-
-Die Wärmekapazität (Temperaturanstiegsrate in °C/h) wird nun während des anfänglichen Lernvorgangs dank **Bootstrap** **automatisch gelernt**.
-
-#### Wie funktioniert das?
-
-Das System startet mit **aggressiven TPI-Koeffizienten** für die ersten drei Zyklen, um einen deutlichen Temperaturanstieg zu bewirken und die tatsächliche Leistung Ihrer Heizung zu messen. Anschließend wechselt es automatisch in den normalen TPI-Modus.
-
-#### Die 2 Startstrategien
-
-1. **Automatikmodus (empfohlen)** ✅:
-   - Lassen Sie `auto_tpi_heating_rate` auf **0** (Standard)
-   - Das System erkennt automatisch, dass die Kapazität unbekannt ist
-   - Es führt 3 Zyklen mit **aggressiven TPI-Koeffizienten** (200,0/5,0) durch, um einen Temperaturanstieg zu bewirken und die Kapazität zu messen
-   - **Dies ist der empfohlene Modus für einen Start ohne Konfiguration**
-
-2. **Manueller Modus**:
-   - Setzen Sie `auto_tpi_heating_rate` auf einen bekannten Wert (z. B. 1,5 °C/h).
-   - Der Bootstrap wird vollständig übersprungen.
-   - Das System startet sofort mit dieser Kapazität im TPI-Modus.
-   - Verwenden Sie diesen Modus, wenn Sie Ihre Kapazität bereits kennen.
-
-#### Konfiguration
-
-In Schritt 1 der Auto-TPI-Konfiguration:
-- **Heizrate** (`auto_tpi_heating_rate`): Lassen Sie den Wert auf **0**, um den automatischen Bootstrap zu aktivieren
-
-> 💡 **Tipp**: Für einen optimalen Start des Bootstraps aktivieren Sie das Lernen, wenn die Abweichung zwischen der aktuellen Temperatur und dem Sollwert mindestens 2 °C beträgt.
-
-#### Kalibrierdienst (optional)
-
-Wenn Sie dennoch die Kapazität anhand der Historie schätzen möchten, ohne auf das Bootstrap zu warten:
-
-```yaml
-service: versatile_thermostat.auto_tpi_calibrate_capacity
-target:
-  entity_id: climate.my_thermostat
-data:
-  save_to_config: true
+    class A,H startEnd
+    class B,E,G decision
+    class C,D process
+    class F bootstrap
 ```
 
-Dieser Dienst analysiert den Verlauf und schätzt die Kapazität, indem er die Momente identifiziert, in denen die Heizung mit voller Leistung läuft.
-
-## Funktionsweise
-
-Auto TPI arbeitet zyklisch:
-
-1.  **Beobachtung**: Bei jedem Zyklus (z. B. alle 10 Minuten) misst der Thermostat (der sich im Modus „HEAT” befindet) die Temperatur zu Beginn und am Ende sowie die verbrauchte Leistung.
-2.  **Validierung**: Es wird überprüft, ob der Zyklus für das Lernen gültig ist:
-    *   Das Lernen basiert auf dem Modus `HEAT` des Thermostats, unabhängig vom aktuellen Status des Wärmesenders (`heating`/`idle`).
-    *   Die Leistung war nicht ausgelastet (zwischen 0 % und 100 % ausgeschlossen).
-    *   Die Temperaturabweichung ist signifikant.
-    *   Das System ist stabil (keine aufeinanderfolgenden Fehler).
-    *   Der Zyklus wurde nicht durch eine Leistungsreduzierung (Power Shedding) oder das Öffnen eines Fensters unterbrochen.
-    *   **Fehler erkannt**: Der Lernvorgang wird unterbrochen, wenn eine Anomalie bei der Heizung oder Klimatisierung erkannt wird (z. B. Temperatur steigt trotz Heizung nicht an), um das Einlernen falscher Koeffizienten zu vermeiden.
-    * **Zentralheizungskessel**: Wenn der Thermostat von einem Zentralheizungskessel abhängig ist, wird der Lernvorgang unterbrochen, wenn der Kessel nicht aktiviert ist (auch wenn der Thermostat eine Anforderung sendet).
-3.  **Berechnung (Lernen)**:
-    *   **Fall 1: Interner Koeffizient**. Wenn sich die Temperatur deutlich in die richtige Richtung entwickelt hat (> 0,05 °C), berechnet er das Verhältnis zwischen der tatsächlichen Entwicklung **(über den gesamten Zyklus, einschließlich Trägheit)** und der erwarteten theoretischen Entwicklung (korrigiert durch die kalibrierte Kapazität). Es passt `CoeffInt` an, um die Abweichung zu verringern.
-    *   **Fall 2: Außenkoeffizient**. Wenn das interne Lernen nicht möglich war und die Temperaturabweichung signifikant ist (> 0,1 °C), passt es `CoeffExt` an, um die Verluste auszugleichen.
-        *   **Wichtig**: Das Lernen des Außenkoeffizienten wird **blockiert**, wenn die Temperaturabweichung zu groß ist (> 0,5 °C). Dadurch wird sichergestellt, dass `Kext` (der die Verluste im Gleichgewicht darstellt) nicht durch Probleme mit der Temperaturanstiegsdynamik (die unter `Kint` fallen) verfälscht wird.
-    *   **Fall 3: Schnelle Korrekturen (Boost/Deboost)**. Parallel dazu überwacht das System kritische Anomalien:
-        *   **Boost Kint**: Wenn die Temperatur trotz Heizbedarf stagniert, wird der Innenkoeffizient erhöht. (Optional über `allow_kint_boost_on_stagnation`)
-        *   **Deboost Kext**: Wenn die Temperatur den Sollwert überschreitet und nicht wieder sinkt, wird der Außenkoeffizient reduziert. (Optional über `allow_kext_compensation_on_overshoot`)
-        * Diese Korrekturen werden anhand der Zuverlässigkeit des Modells gewichtet: Je mehr Daten (Lernzyklen) das System hat, desto moderater sind die Korrekturen, um eine Destabilisierung eines zuverlässigen Modells zu vermeiden.*
-4.  **Aktualisierung**: Die neuen Koeffizienten werden geglättet und für den nächsten Zyklus gespeichert.
-
-### Aktivierungssicherheit
-Um unbeabsichtigte Aktivierungen zu vermeiden:
-1. Der Dienst `set_auto_tpi_mode` lehnt die Aktivierung des Lernmodus ab, wenn "Auto-TPI-Lernmodus aktivieren" in der Konfiguration des Thermostats nicht aktiviert ist.
-2. Sollte das Kontrollkästchen in der Konfiguration deaktiviert werden, während der Lernmodus aktiv war, wird dieser beim Neuladen der Integration automatisch beendet.
-
-## Attribute und Sensoren
-
-Ein spezieller Sensor `sensor.<Thermostatname>_auto_tpi_learning_state` ermöglicht die Verfolgung des Lernstatus.
-
-**Verfügbare Attribute:**
-
-*   `active`: Das Lernen ist aktiviert.
-*   `heating_cycles_count`: Gesamtzahl der beobachteten Zyklen.
-*   `coeff_int_cycles`: Anzahl der Anpassungen des internen Koeffizienten.
-*   `coeff_ext_cycles`: Anzahl der Anpassungen des Außenkoeffizienten.
-*   `model_confidence`: Vertrauensindex (0,0 bis 1,0) für die Qualität der Einstellungen. Begrenzt auf 100 % nach 50 Zyklen für jeden Koeffizienten (auch wenn das Lernen fortgesetzt wird).
-*   `last_learning_status`: Aktueller Status des Lernvorgangs oder Grund für das letzte Ergebnis. Lebenszykluswerte: `learning_started` (neues Lernen), `learning_resumed` (Wiederaufnahme nach Pause), `learning_stopped` (unterbrochen). Beispiele für Lernergebnisse: `learned_indoor_heat`, `power_out_of_range`.
-*   `calculated_coef_int` / `calculated_coef_ext`: Aktuelle Werte der Koeffizienten.
-*   `learning_start_dt`: Datum und Uhrzeit des Beginns des Lernvorgangs (nützlich für Grafiken).
-*   `allow_kint_boost_on_stagnation`: Gibt an, ob der Kint-Boost bei Stagnation aktiviert ist.
-*   `allow_kext_compensation_on_overshoot`: Gibt an, ob die Kext-Korrektur bei Überschreitung aktiviert ist.
-*   `capacity_heat_status`: Status des Lernens der Wärmekapazität (`learning` oder `learned`).
-*   `capacity_heat_value`: Der Wert der gelernten Wärmekapazität (in °C/h).
-*   `capacity_heat_count`: Die Anzahl der Bootstrap-Zyklen, die zum Lernen der Kapazität durchgeführt wurden.
-
-## Services
-
-### Kalibrierungsdienst (`versatile_thermostat.auto_tpi_calibrate_capacity`)
-
-Dieser Dienst ermöglicht es, die **adiabatische Kapazität** Ihres Systems (`max_capacity` in °C/h) durch Analyse der historischen Sensordaten zu schätzen.
-
-**Prinzip:** Der Dienst nutzt den Verlauf der **Sensoren** `temperature_slope` und `power_percent`, um die Zeitpunkte zu ermitteln, zu denen die Heizung mit voller Leistung lief. Er verwendet das **75. Perzentil** (das näher an der adiabatischen Temperatur liegt als der Median) und wendet eine **Kext-Korrektur** an: `Capacity = P75 + Kext_config × ΔT`.
-
-```yaml
-service: versatile_thermostat.auto_tpi_calibrate_capacity
-target:
-  entity_id: climate.my_thermostat
-data:
-  start_date: "2023-11-01T00:00:00+00:00" # Optional. Standardmäßig 30 Tage vor "end_date".
-  end_date: "2023-12-01T00:00:00+00:00"   # Optional. Standardmäßig jetzt.
-  min_power_threshold: 95          # Optional. Seuil de puissance en % (0-100). Défaut 95.
-  capacity_safety_margin: 20       # Optional. Sicherheitsmarge in % (0-100), die von der berechneten Kapazität abgezogen werden soll. Standardwert 20.
-  save_to_config: true             # Optional. Die empfohlene Kapazität (nach Marge) in der Konfiguration speichern. Standardwert false.
-```
-
-> **Ergebnis**: Der Wert der adiabatischen Kapazität (`max_capacity_heat`) wird in den Attributen des Lernzustandssensors mit dem **empfohlenen Wert** (berechnete Kapazität – Sicherheitsmarge) aktualisiert.
->
-> Der Dienst gibt außerdem die folgenden Informationen zurück, um die Qualität der Kalibrierung zu analysieren:
-> *   **`max_capacity`**: Die geschätzte adiabatische Bruttokapazität (in °C/h).
-> *   **`recommended_capacity`**: Die empfohlene Kapazität nach Anwendung der Sicherheitsmarge (in °C/h). Dieser Wert wird gespeichert.
-> *   **`margin_percent`**: Die angewandte Sicherheitsmarge (in %).
-> *   **`observed_capacity`**: Das 75. Perzentil brutto (vor Kext-Korrektur).
-> *   **`kext_compensation`**: Der angewandte Korrekturwert (Kext × ΔT).
-> *   **`avg_delta_t`**: Der für die Korrektur verwendete durchschnittliche ΔT-Wert.
-> *   **`reliability`**: Zuverlässigkeitsindex (in %) basierend auf der Anzahl der Stichproben und der Varianz.
-> *   **`samples_used`**: Anzahl der nach der Filterung verwendeten Stichproben.
-> *   **`outliers_removed`**: Anzahl der entfernten Ausreißer.
-> *   **`min_power_threshold`**: Verwendeter Leistungsschwellenwert.
-> *   **`period`**: Anzahl der analysierten Tage im Verlauf.
->
-> Die TPI-Koeffizienten (`Kint`/`Kext`) werden dann durch die normale Lernschleife unter Verwendung dieser Fähigkeit als Referenz gelernt oder angepasst.
-
-### Lernen aktivieren/deaktivieren (`versatile_thermostat.set_auto_tpi_mode`)
-
-Mit diesem Service kann das Auto-TPI-Lernen ohne Konfiguration des Thermostats gesteuert werden.
-
-#### Parameter
-
-| Parameter                              | Typ     | Standard | Beschreibung                                              |
-|----------------------------------------|---------|----------|-----------------------------------------------------------|
-| `auto_tpi_mode`                        | boolean | -        | Aktiviert (`true`) oder deaktiviert (`false`)  das Lernen |
-| `reinitialise`                         | boolean | `true`   | Steuert das Zurücksetzen der Daten bei Aktivierung        |
-| `allow_kint_boost_on_stagnation`       | boolean | `false`  | Erlaubt den Boost von Kint bei Temperaturstagnation       |
-| `allow_kext_compensation_on_overshoot` | boolean | `false`  | Erlaubt Kext-Ausgleich bei Überschreitung (Overshoot)     |
-
-#### Verhalten des Parameters `reinitialise`
+1.  **Initialisierung**: Wenn die **Heizrate** (Heat Rate) 0 ist, versucht das System zunächst eine **Kalibrierung**, indem es Ihre historischen Temperatur-, Steigungs- und Leistungsdaten analysiert (über den Dienst `calibrate_capacity`).
+2.  **Bootstrap-Modus**: Wenn die Historie nicht zuverlässig genug ist, um die Heizrate zu schätzen, wechselt das System in den **Bootstrap-Modus**. Es führt 3 intensive Heizzyklen durch, um die Heizkapazität Ihres Heizkörpers zu bestimmen.
+3.  **Aktives Lernen**: Sobald die Heizrate bekannt ist, verfeinert das System die TPI-Koeffizienten bei jedem Zyklus. Diese Phase dauert **mindestens 50 Zyklen** pro Koeffizient, um deren Stabilität zu gewährleisten.
+4.  **Speichern**: Am Ende der Sitzung (ca. 48 Stunden) werden die erlernten Koeffizienten **und** die endgültige Heizrate automatisch in Ihrer permanenten Konfiguration gespeichert.
 
-Der Parameter `reinitialise` bestimmt, wie vorhandene Trainingsdaten bei der Aktivierung behandelt werden:
+### Wann werden Kint und Kext angepasst?
 
-- **`reinitialise: true`** (Standard): Löscht alle Lerndaten (Koeffizienten und Zähler) und beginnt den Lernvorgang von vorne. Die kalibrierten Kapazitäten (`max_capacity_heat`/`cool`) bleiben erhalten.
-- **`reinitialise: false`**: Setzt das Lernen mit den vorhandenen Daten fort, ohne diese zu löschen. Die vorherigen Koeffizienten und Zähler bleiben erhalten und das Lernen wird anhand dieser Werte fortgesetzt.
+Das System erlernt beide Koeffizienten in unterschiedlichen Situationen:
 
-**Anwendungsfall:** Ermöglicht es, das Lernen vorübergehend zu deaktivieren (z. B. während einer Urlaubszeit oder bei Bauarbeiten) und es anschließend wieder zu aktivieren, ohne die bereits erzielten Fortschritte zu verlieren.
+| Koeffizient | Lern-Situation | Erklärung |
+| :--- | :--- | :--- |
+| **Kint** (Interne Trägheit) | Während des **Temperaturanstiegs**, wenn die Abweichung vom Sollwert signifikant ist (> 0,05°C) und die Heizung nicht gesättigt ist (100%). | Kint steuert die Reaktionsfähigkeit der Heizung. Er passt sich an, wenn das System zum Sollwert "aufholen" muss. |
+| **Kext** (Externe Isolierung) | Während der **Stabilisierung um den Sollwert**, wenn die Abweichung gering ist (< 1°C). | Kext kompensiert Wärmeverluste nach außen. Er passt sich an, wenn das System die Temperatur hält. |
 
-#### Beispiele
+> [!TIP]
+> Deshalb ist es wichtig, während des Lernens abwechslungsreiche Heizzyklen zu erzeugen: Der Temperaturanstieg ermöglicht die Kint-Anpassung, und die Stabilisierung ermöglicht die Kext-Anpassung.
 
-**Neuen Lernvorgang starten (vollständiges Zurücksetzen):**
-```yaml
-service: versatile_thermostat.set_auto_tpi_mode
-target:
-  entity_id: climate.mon_thermostat
-data:
-  auto_tpi_mode: true
-  reinitialise: true  # oder weggelassen, weil das der Fehler ist.
-```
+> [!NOTE]
+> **Gesättigte Zyklen**: Zyklen mit **0%** oder **100%** Leistung werden für die Berechnung der Kint- und Kext-Koeffizienten **ignoriert** (da sie keine brauchbaren Informationen über die thermische Reaktion liefern). Zyklen bei 100% werden jedoch zur Anpassung der **Heizrate** verwendet.
 
-**Das Lernen fortsetzen, ohne Daten zu verlieren:**
-```yaml
-service: versatile_thermostat.set_auto_tpi_mode
-target:
-  entity_id: climate.mon_thermostat
-data:
-  auto_tpi_mode: true
-  reinitialise: false
-```
+---
 
-**Das Lernen beenden:**
+## 🚀 Das Lernen starten
 
-Wenn die Lernphase beendet ist:
+Sobald das **Auto TPI**-Feature für Ihren Thermostat aktiviert und konfiguriert ist, startet das Lernen nicht automatisch. Sie müssen es manuell starten:
 
-- Das Lernen ist **deaktiviert**, aber die gelernten Daten bleiben in den Attributen der Entität **auto_tpi_learning_state** **sichtbar**.
-- Die Regelung verwendet die **Konfigurationskoeffizienten** (nicht die gelernten Koeffizienten).
+1.  **Über die dedizierte Karte (Empfohlen)**: Verwenden Sie den "Play"-Button auf der [Auto TPI Learning Card](https://github.com/KipK/auto-tpi-learning-card).
+2.  **Über den Dienst "Set Auto TPI Mode"**: Rufen Sie diesen Dienst (`set_auto_tpi_mode`) aus den Entwicklerwerkzeugen auf. Dieser Dienst startet oder stoppt eine Auto-TPI-Sitzung.
 
+---
 
-## Berechnungsmethode Gewichteter Durchschnitt
+## ⚙️ Standard-Konfiguration
 
-La méthode **Moyenne Pondérée** (Average) est une approche simple et efficace pour l'apprentissage des coefficients TPI. Elle est particulièrement adaptée pour un apprentissage rapide et unique, ou lorsque vous souhaitez réinitialiser facilement les coefficients.
+Bei der Aktivierung von Auto TPI stehen folgende Parameter zur Verfügung:
 
-### Verhalten
+| Parameter | Beschreibung |
+| :--- | :--- |
+| **Learning Type** | **Discovery** (für das erste Lernen) oder **Fine Tuning** (um bestehende Einstellungen zu verfeineren). |
+| **Aggressiveness** | Reduktionsfaktor der Koeffizienten (1.0 = 100%). Reduzieren Sie diesen Wert (z.B. 0.8), wenn Sie häufige Sollwert-Überschreitungen (Overshoots) beobachten. |
+| **Heating Time** | Erforderliche Zeit, bis Ihr Gerät die volle Leistung erreicht (z.B. 5 Min. für einen Elektroheizkörper). |
+| **Cooling Time** | Erforderliche Zeit zum Abkühlen nach dem Abschalten (z.B. 7 Min. für einen Elektroheizkörper). |
+| **Heat Rate** | Temperaturanstiegskapazität (°C/Stunde). Auf **0** lassen, damit das System sie automatisch über Kalibrierung oder Bootstrap berechnet. |
 
-La méthode Moyenne Pondérée calcule une moyenne pondérée entre les coefficients existants et les nouvelles valeurs calculées. Comme la méthode EMA, elle réduit progressivement l'influence des nouveaux cycles au fur et à mesure de l'apprentissage, mais utilise une approche différente.
+---
 
-**Caractéristique clé** : Plus le nombre de cycles augmente, plus le poids du coefficient existant devient important par rapport au nouveau coefficient. Cela signifie que l'influence des nouveaux cycles diminue progressivement au fur et à mesure de l'apprentissage.
+## 🛠️ Erweiterte Konfiguration
 
-### Parameter
+Wenn Sie "Enable advanced parameters" aktivieren, erhalten Sie Zugriff auf die Feinabstimmung der Algorithmen.
 
-| Paramètre | Description | Défaut |
-|-----------|-------------|--------|
-| **Poids initial** (`avg_initial_weight`) | Poids initial donné aux coefficients de configuration au démarrage | 1 |
+### "Discovery"-Methode (Gewichteter Durchschnitt)
+Wird verwendet, um ein neues System schnell zu stabilisieren.
+-   **Initial Weight** (1 bis 50): Definiert die Bedeutung der aktuellen Koeffizienten im Verhältnis zu neuen Entdeckungen.
+    -   Bei **1**: Neu berechnete Koeffizienten ersetzen die alten fast vollständig. Das Lernen ist schnell, aber empfindlich gegenüber Störungen.
+    -   Bei **50**: Alte Koeffizienten haben viel mehr Gewicht. Das Lernen ist sehr langsam, aber sehr stabil.
+    -   **Empfehlung**: Für das erste Lernen auf 1 lassen. Wenn Sie ein unterbrochenes Lernen fortsetzen möchten, während ein Teil des Fortschritts erhalten bleibt, verwenden Sie einen Zwischenwert (z.B. 25).
 
-### Formel
+### "Fine Tuning"-Methode (EWMA)
+Wird für eine sanfte und sehr präzise Anpassung verwendet.
+-   **Alpha** : Glättungsfaktor. Je höher dieser ist, desto schneller reagiert das System auf aktuelle Änderungen.
+-   **Decay Rate** : Ermöglicht es, die Lerngeschwindigkeit schrittweise zu reduzieren, um sich auf den besten gefundenen Werten zu stabilisieren.
 
-```
-avg_coeff = ((old_coeff × weight_old) + coeff_new) / (weight_old + 1)
-```
+---
 
-Où :
-- `old_coeff` est le coefficient actuel
-- `coeff_new` est le nouveau coefficient calculé pour ce cycle
-- `weight_old` est le nombre de cycles d'apprentissage déjà effectués (avec un minimum de 1)
+## 💡 Best Practices
 
-**Exemple d'évolution du poids** :
-- Cycle 1 : weight_old = 1 → nouveau coefficient a un poids de 50%
-- Cycle 10 : weight_old = 10 → nouveau coefficient a un poids de ~9%
-- Cycle 50 : weight_old = 50 → nouveau coefficient a un poids de ~2%
-- Cycle 100+ : weight_old = 50 (plafonné) → nouveau coefficient a encore un poids ~2% pour assurer la réactivité
+### Externe Störungen vermeiden
+Versuchen Sie während einer Lern-Sitzung (besonders in den ersten Stunden) Folgendes zu vermeiden:
+-   Direkte Sonneneinstrahlung auf den Temperatursensor.
+-   Nutzung einer sekundären Wärmequelle (Kamin, Ofen).
+-   Massive Zugluft (offene Türen).
+Diese Faktoren verfälschen die Wahrnehmung des Systems über die Isolierung Ihres Raumes.
 
-### Hauptmerkmale
+### Extreme Bedingungen vermeiden
 
-1. **Simplicité** : La méthode est facile à comprendre
-2. **Réinitialisation facile** : Les coefficients peuvent être facilement réinitialisés en redémarrant l'apprentissage
-3. **Apprentissage progressif** : L'influence des nouveaux cycles diminue au fur et à mesure, stabilisant progressivement les coefficients
-4. **Convergence rapide** : La méthode atteint une stabilité après environ 50 cycles
+> [!CAUTION]
+> **Starten Sie kein Lernen, wenn Ihre Heizkörper gesättigt sind** (ständig 100% Leistung). Dies tritt typischerweise bei außergewöhnlichen Kältewellen auf, wenn die Heizung den Sollwert nicht mehr erreichen kann. Unter diesen Bedingungen kann das System nicht richtig lernen, da es keinen Spielraum zur Leistungsanpassung hat. Warten Sie auf mildere Wetterbedingungen, um eine Lern-Sitzung zu starten.
 
-### Vergleich mit EMA
+### Idealer Ablauf einer "Discovery"-Sitzung
 
-| Aspect | Moyenne Pondérée | EMA |
-|--------|------------------|-----|
-| **Complexité** | Simple | Plus complexe |
-| **Mécanisme de réduction** | Poids basé sur le nombre de cycles | Alpha adaptatif avec décroissance |
-| **Stabilité** | Stable après 50 cycles | Stable après 50 cycles avec décroissance alpha |
-| **Adaptation continue** | Moins adaptée | Plus adaptée (meilleure pour les changements progressifs) |
-| **Réinitialisation** | Très facile | Facile |
+> [!TIP]
+> **Konkretes Beispiel**: Wenn Ihr üblicher Sollwert **18°C** ist, senken Sie ihn vorübergehend auf **15°C** und warten Sie, bis sich der Raum stabilisiert hat. Starten Sie dann das Lernen neu und stellen Sie den Sollwert wieder auf **18°C**. Dadurch entsteht eine Differenz von 3°C, die das System zum Lernen beobachten wird.
 
-### Nutzungsempfehlungen
+1.  **Vorbereitung**: Senken Sie den Sollwert um mindestens 3°C unter Ihre übliche Temperatur. Lassen Sie den Raum abkühlen und sich bei dieser neuen Temperatur stabilisieren.
+2.  **Start**: Aktivieren Sie das Lernen und **stellen Sie den Sollwert wieder auf seinen üblichen Wert**. Das System wird den Temperaturanstieg beobachten.
+3.  **Stabilisierung**: Lassen Sie das System die Temperatur für einige Stunden um den Sollwert stabilisieren.
+4.  **Stimulation**: Sobald sich die Koeffizienten nicht mehr signifikant ändern, lösen Sie einen neuen Heizzyklus aus, indem Sie den Sollwert um 2°C senken und dann wieder anheben.
+5.  **Stabilisierung**: Lassen Sie das System die Temperatur für einige Stunden um den Sollwert stabilisieren.
+6.  **Abschluss**: Wenn das Lernen noch nicht abgeschlossen ist, lassen Sie das System bis zum Ende laufen, während Sie zu Ihren normalen Lebensgewohnheiten zurückkehren. Auto TPI stoppt von selbst, sobald die Koeffizienten nach jeweils mindestens 50 Zyklen stabilisiert sind.
 
-- **Apprentissage initial** : La méthode Moyenne Pondérée est excellente pour un premier apprentissage rapide
-- **Réglages ponctuels** : Idéale lorsque vous souhaitez ajuster les coefficients une seule fois
-- **Environnements stables** : Bien adaptée aux environnements thermiques relativement stables
+> [!NOTE]
+> **Über das Überschwingen (Overshoot)**: Ein Überschwingen beim ersten Temperaturanstieg ist **normal** und sogar vorteilhaft! Es liefert wertvolle Daten für das Lernen. Das System wird diese nutzen, um die Koeffizienten zu verfeinern. Wenn die Überschwingungen jedoch nach mehreren Zyklen **bestehen bleiben oder sich verschlimmern**, kann dies auf ein Problem in der Auto-TPI-Konfiguration (falsche Heiz-/Kühlzeiten, zu hohe Aggressivität) oder ein Problem in der VTherm-Konfiguration selbst hindeuten.
 
-### Beispiel für Lernfortschritte
+### Idealer Ablauf einer "Fine Tuning"-Sitzung
+1.  **Stabilität**: Behalten Sie Ihre gewohnten Heizgewohnheiten bei und vermeiden Sie lediglich außergewöhnliche Störungen (lange geöffnete Fenster, Zusatzheizung).
+2.  **Beobachtung**: Lassen Sie das System Mikrowariationen beobachten und die Koeffizienten über 50 Zyklen anpassen.
+3.  **Neubewertung**: Wenn Sie feststellen, dass die Koeffizienten stark driften oder der Komfort nachlässt, ist es besser, eine komplette Sitzung im **Discovery**-Modus neu zu starten.
+---
 
-| Cycle | Poids ancien | Poids nouveau | Nouveau coefficient | Résultat |
-|-------|--------------|---------------|---------------------|----------|
-| 1 | 1 | 1 | 0.15 | (0.10 × 1 + 0.15 × 1) / 2 = 0.125 |
-| 2 | 2 | 1 | 0.18 | (0.125 × 2 + 0.18 × 1) / 3 = 0.142 |
-| 10 | 10 | 1 | 0.20 | (0.175 × 10 + 0.20 × 1) / 11 = 0.177 |
-| 50 | 50 | 1 | 0.19 | (0.185 × 50 + 0.19 × 1) / 51 = 0.185 |
+## 📊 Visuelle Überwachung
 
-**Note** : Après 50 cycles, le coefficient est considéré comme stable et l'apprentissage s'arrête (sauf si l'apprentissage continu est activé). À ce stade, le nouveau coefficient n'a plus qu'un poids d'environ 2% dans la moyenne.
+Um die Lernentwicklung in Echtzeit zu verfolgen, wird dringend empfohlen, die benutzerdefinierte Karte **Auto TPI Learning Card** zu installieren.
 
-## Adaptive EMA-Berechnungsmethode
+### Installation über HACS
 
-La méthode EMA (Exponential Moving Average) utilise un coefficient **alpha** qui détermine
-l'influence de chaque nouveau cycle sur les coefficients appris.
+[![Öffnen Sie Ihre Home Assistant-Instanz und öffnen Sie ein Repository im Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=KipK&repository=auto-tpi-learning-card&category=plugin)
 
-### Verhalten
+Oder fügen Sie das benutzerdefinierte Repository manuell hinzu: [https://github.com/KipK/auto-tpi-learning-card](https://github.com/KipK/auto-tpi-learning-card)
 
-Au fil des cycles, **alpha décroît progressivement** pour stabiliser l'apprentissage :
+### Kartenfunktionen
 
-| Cycles | Alpha (avec α₀=0.2, k=0.1) | Influence du nouveau cycle |
-|--------|----------------------------|---------------------------|
-| 0 | 0.20 | 20% |
-| 10 | 0.10 | 10% |
-| 50 | 0.033 | 3.3% |
-| 100 | 0.033 | 3.3% (plafonné à 50 cycles) |
+![Auto TPI Card Vorschau](https://github.com/KipK/auto-tpi-learning-card/blob/main/assets/card.png?raw=true)
 
-### Parameter
-
-| Paramètre | Description | Défaut |
-|-----------|-------------|--------|
-| **Alpha initial** (`ema_alpha`) | Influence au démarrage | 0.2 (20%) |
-| **Taux de décroissance** (`ema_decay_rate`) | Vitesse de stabilisation | 0.1 |
-
-### Formel
-
-```
-alpha(n) = alpha_initial / (1 + decay_rate × n)
-```
-
-Où `n` est le nombre de cycles d'apprentissage (plafonné à 50).
-
-### Sonderfälle
-
-- **decay_rate = 0** : Alpha reste fixe (comportement EMA classique)
-- **decay_rate = 1, alpha = 1** : Équivalent à la méthode "Moyenne Pondérée"
-
-### Empfehlungen
-
-| Situation | Alpha (`ema_alpha`) | Taux de Décroissance (`ema_decay_rate`) |
-|---|---|---|
-| **Apprentissage initial** | `0.15` | `0.08` |
-| **Apprentissage fin** | `0.08` | `0.12` |
-| **Apprentissage continu** | `0.05` | `0.02` |
-
-**Explications:**
-
-- **Apprentissage initial:**
-
-  *Alpha:* 0.15 (15% de poids initial)
-
-  *Avec ces paramètres, le système garde en tête principalement les 20 derniers cycles*
-
-  * Cycle 1: α = 0.15 (forte réactivité initiale)
-  * Cycle 10: α = 0.083 (commence à stabiliser)
-  * Cycle 25: α = 0.050 (filtrage accru)
-  * Cycle 50: α = 0.036 (robustesse finale)
-
-
-  *Taux de décroissance:* 0.08
-
-  Décroissance modérée permettant une adaptation rapide aux 10 premiers cycles
-  Balance optimale entre vitesse (éviter stagnation) et stabilité (éviter sur-ajustement)
-
-- **Apprentissage fin**
-
-  *Alpha:* 0.08 (8% de  poids initial)
-
-  *Avec ces paramètres, le système garde en tête principalement les 50 derniers cycles*
-
-  Démarrage conservateur (coefficients déjà bons)
-  Évite les sur-corrections brutales
-
-  * Cycle 1 : α = 0.08
-  * Cycle 25 : α = 0.024
-  * Cycle 50+ : α = 0.013 (plafonné)
-
-
-  *Taux de décroissance:*: 0.12
-
-  Décroissance plus rapide que l'apprentissage initial
-  Converge vers un filtrage très fort (stabilité)
-  Adaptation majoritaire dans les 15 premiers cycles
-
-- **Apprentissage continu**
-  
-  *Alpha* = 0.05 (5% de poids initial)
-
-  *Avec ces paramètres, le système garde en tête principalement les 100 derniers cycles*
-
-  Très conservateur pour éviter dérive
-  Réactivité modérée aux changements graduels
-
-  * Cycle 1 : α = 0.05
-  * Cycle 50 : α = 0.025
-  * Cycle 100+ : α = 0.025 (plafonné)
-
-
-  *Taux de décroissance:* = 0.02
-
-  Décroissance très lente (apprentissage à long terme)
-  Maintient une capacité d'adaptation même après des centaines de cycles
-  Adapté aux variations saisonnières (hiver/été)
+-   📈 Echtzeit-Fortschritt von Kalibrierung und Lernen
+-   🔢 Koeffizienten `Kint`, `Kext` und Heizrate in Berechnung
+-   ▶️ Steuerungs-Button zum Starten/Stoppen der Sitzung
+-   🔧 Optionen zum Zurücksetzen der Sitzung, Aktivieren von Kint Boost oder Kext Deboost

--- a/documentation/pl/feature-autotpi-technical.md
+++ b/documentation/pl/feature-autotpi-technical.md
@@ -1,0 +1,516 @@
+# 🧠 Auto TPI: Pogłębiony przewodnik techniczny
+
+> [!NOTE]
+> Ten dokument jest przeznaczony dla zaawansowanych użytkowników, którzy chcą szczegółowo zrozumieć algorytm Auto TPI. Bardziej przystępne wprowadzenie znajduje się w [Przewodniku użytkownika Auto TPI](feature-autotpi.md).
+
+---
+
+## Spis treści
+
+1. [Algorytm TPI](#algorytm-tpi)
+2. [Szczegółowy cykl uczenia](#szczegółowy-cykl-uczenia)
+3. [Kalibracja wydajności cieplnej](#kalibracja-wydajności-cieplnej)
+4. [Algorytmy obliczania współczynników](#algorytmy-obliczania-współczynników)
+5. [Mechanizmy automatycznej korekty](#mechanizmy-automatycznej-korekty)
+6. [Zaawansowane parametry i stałe](#zaawansowane-parametry-i-stałe)
+7. [Usługi i API](#usługi-i-api)
+8. [Zaawansowana diagnostyka i rozwiązywanie problemów](#zaawansowana-diagnostyka-i-rozwiązywanie-problemów)
+
+---
+
+## Algorytm TPI
+
+### Podstawowa zasada
+
+Algorytm **TPI** (Time Proportional & Integral) oblicza **procent mocy** w każdym cyklu. Procent ten określa, jak długo grzejnik będzie aktywny podczas cyklu (np. 60% w 10-minutowym cyklu = 6 minut grzania).
+
+### Podstawowy wzór
+
+```
+Moc = (Kint × ΔT_wewnętrzna) + (Kext × ΔT_zewnętrzna)
+```
+
+Gdzie:
+- **Kint** (`tpi_coef_int`): Współczynnik wewnętrzny, reaguje na odchylenie od punktu nastawy
+- **Kext** (`tpi_coef_ext`): Współczynnik zewnętrzny, kompensuje straty ciepła
+- **ΔT_wewnętrzna** = Nastawa − Temperatura wewnętrzna
+- **ΔT_zewnętrzna** = Nastawa − Temperatura zewnętrzna
+
+```mermaid
+graph LR
+    subgraph Wejścia
+        A[Temperatura wewnętrzna]
+        B[Temperatura zewnętrzna]
+        C[Nastawa]
+    end
+    
+    subgraph Obliczenia TPI
+        D["ΔT_int = Nastawa - T_int"]
+        E["ΔT_ext = Nastawa - T_ext"]
+        F["Moc = Kint×ΔT_int + Kext×ΔT_ext"]
+    end
+    
+    subgraph Wyjście
+        G["Moc % (0-100%)"]
+        H["Czas WŁ/WYŁ"]
+    end
+    
+    A --> D
+    C --> D
+    B --> E
+    C --> E
+    D --> F
+    E --> F
+    F --> G
+    G --> H
+```
+
+### Rola współczynników
+
+| Współczynnik | Rola | Sytuacja uczenia |
+|-------------|------|-------------------|
+| **Kint** | Kontroluje **reaktywność**: im wyższy, tym szybciej ogrzewanie reaguje na odchylenia | Podczas **wzrostu temperatury** (odchylenie > 0,05°C, moc < 99%) |
+| **Kext** | Kompensuje **straty ciepła**: im wyższy, tym bardziej ogrzewanie przewiduje ochłodzenie | Podczas **stabilizacji** wokół punktu nastawy (odchylenie < 0,5°C) |
+
+---
+
+## Szczegółowy cykl uczenia
+
+### Przegląd przepływu
+
+```mermaid
+flowchart TD
+    subgraph Inicjalizacja
+        A[Start sesji] --> B{Współczynnik grzania = 0?}
+        B -->|Tak| C[Historyczna prekalibracja]
+        B -->|Nie| G[Aktywne uczenie]
+        
+        C --> D{Wiarygodność >= 20%?}
+        D -->|Tak| G
+        D -->|Nie| E[Tryb Bootstrap]
+        E -->|3 agresywne cykle| F[Oszacowana wydajność]
+        F --> G
+    end
+    
+    subgraph "Pętla uczenia"
+        G --> H[Start cyklu TPI]
+        H --> I[Migawka stanu początkowego]
+        I --> J[Wykonaj grzanie WŁ/WYŁ]
+        J --> K[Koniec cyklu: Pomiar ΔT]
+        K --> L{Warunki poprawne?}
+        
+        L -->|Nie| M[Pomiń uczenie]
+        L -->|Tak| N{Analizuj sytuację}
+        
+        N -.->|Przeregulowanie| O[🔸 Korekta Kext<br/>opcjonalnie]
+        N -.->|Stagnacja| P[🔸 Boost Kint<br/>opcjonalnie]
+        N -->|T° Rośnie| Q[Uczenie Kint]
+        N -->|Stabilizacja| R[Uczenie Kext]
+        
+        O -.-> S[Aktualizacja współczynników]
+        P -.-> S
+        Q --> S
+        R --> S
+        M --> H
+        S --> H
+    end
+    
+    subgraph Finalizacja
+        S --> T{50 cykli Kint ORAZ Kext?}
+        T -->|Nie| H
+        T -->|Tak| U[Zapisz w konfiguracji]
+        U --> V[Powiadomienie o zakończeniu]
+    end
+    
+    style O fill:#fff3cd,stroke:#ffc107,stroke-width:2px
+    style P fill:#fff3cd,stroke:#ffc107,stroke-width:2px
+```
+
+> [!NOTE]
+> **Żółte ramki z przerywaną linią** (🔸) reprezentują **opcjonalne** mechanizmy korekcyjne. Muszą być wyraźnie włączone za pomocą parametrów usługi `set_auto_tpi_mode`.
+
+### Szczegóły migawki cyklu
+
+Na początku każdego cyklu algorytm rejestruje bieżący stan:
+
+| Rejestrowane dane | Zastosowanie |
+|---------------|-------|
+| `last_temp_in` | Temperatura wewn. na początku cyklu |
+| `last_temp_out` | Temperatura zewn. na początku cyklu |
+| `last_order` | Nastawa na początku cyklu |
+| `last_power` | Obliczona moc dla tego cyklu (0.0 do 1.0) |
+| `last_state` | Tryb HVAC (grzanie/chłodzenie) |
+
+Na końcu cyklu wartości te są porównywane z aktualnymi pomiarami w celu obliczenia postępu.
+
+### Warunki walidacji cyklu
+
+Cykl jest **ignorowany** w procesie uczenia, jeśli:
+
+| Warunek | Powód |
+|-----------|--------|
+| Moc = 0% lub 100% | Nasycenie: brak użytecznych informacji o wydajności |
+| Nastawa zmieniona | Cel został zmieniony w trakcie cyklu |
+| Aktywne ograniczanie mocy | Ogrzewanie zostało wymuszone na WYŁ przez Power Manager |
+| Wykryto awarię | Wykryto anomalię (brak efektu grzania) |
+| Kocioł centralny WYŁ | Termostat zgłasza zapotrzebowanie, ale kocioł nie reaguje |
+| Pierwszy cykl po restarcie | Brak wiarygodnych danych referencyjnych |
+
+---
+
+## Kalibracja wydajności cieplnej
+
+### Definicja
+
+**Wydajność cieplna** (lub **współczynnik grzania**) reprezentuje maksymalną prędkość wzrostu temperatury systemu, wyrażoną w **°C na godzinę** (°C/h).
+
+Przykład: Wydajność 2,0 °C/h oznacza, że grzejnik może podnieść temperaturę o 2°C w ciągu jednej godziny przy pełnej mocy (w idealnych warunkach adiabatycznych).
+
+### Metody wyznaczania
+
+```mermaid
+graph TD
+    A[Współczynnik grzania = 0?] -->|Tak| B[Prekalibracja]
+    A -->|Nie| C[Użyj wartości skonfigurowanej]
+    
+    B --> D{Historia dostępna?}
+    D -->|Tak| E[Analiza historii]
+    D -->|Nie| F[Tryb Bootstrap]
+    
+    E --> G{Wiarygodność >= 20%?}
+    G -->|Tak| H[Wydajność skalibrowana]
+    G -->|Nie| F
+    
+    F --> I[3 agresywne cykle Kint=1.0 Kext=0.1]
+    I --> J[Pomiar rzeczywistego wzrostu]
+    J --> K[Oszacowana wydajność]
+    
+    H --> L[Uczenie Kint/Kext]
+    K --> L
+    C --> L
+```
+
+### Prekalibracja poprzez analizę historii
+
+Usługa `auto_tpi_calibrate_capacity` analizuje historię czujników:
+
+1. **Pobranie** danych `temperature_slope` i `power_percent` z 30 dni
+2. **Filtrowanie**: zachowanie tylko punktów, gdzie `power >= 95%`
+3. **Eliminacja wartości odstających** za pomocą metody IQR (rozstęp międzykwartylowy)
+4. **Obliczanie 75. percentyla** nachyleń (bardziej reprezentatywny niż mediana)
+5. **Korekta adiabatyczna**: `Wydajność = P75 + Kext × ΔT`
+6. **Zastosowanie marginesu bezpieczeństwa**: domyślnie 20%
+
+### Tryb Bootstrap
+
+Jeśli historia jest niewystarczająca (wiarygodność < 20%), system przechodzi w **tryb bootstrap**:
+
+- **Agresywne współczynniki**: Kint = 1.0, Kext = 0.1
+- **Czas trwania**: minimum 3 cykle
+- **Cel**: Wywołanie znacznego wzrostu temperatury w celu pomiaru rzeczywistej wydajności
+- **Zabezpieczenie czasowe**: Jeśli po 5 cyklach wystąpi błąd, domyślna wydajność = 0,3 °C/h (wolne systemy)
+
+---
+
+## Algorytmy obliczania współczynników
+
+### Uczenie Kint (Współczynnik wewnętrzny)
+
+Algorytm dostosowuje Kint, gdy temperatura **rośnie** w stronę nastawy.
+
+#### Szczegółowy wzór
+
+```mermaid
+flowchart LR
+    subgraph "1. Wydajność efektywna"
+        A["C_eff = C_ref × (1 - Kext × ΔT_ext)"]
+    end
+    
+    subgraph "2. Maks. możliwy wzrost"
+        B["max_rise = C_eff × czas_cyklu × wydajność"]
+    end
+    
+    subgraph "3. Cel skorygowany"
+        C["target = min(odchylenie_nastawy, max_rise)"]
+    end
+    
+    subgraph "4. Proporcja"
+        D["ratio = (target / wzrost_rzeczywisty) × agresywność"]
+    end
+    
+    subgraph "5. Nowy Kint"
+        E["Kint_nowy = Kint_stary × ratio"]
+    end
+    
+    A --> B --> C --> D --> E
+```
+
+#### Użyte zmienne
+
+| Zmienna | Opis | Typowa wartość |
+|----------|-------------|---------------|
+| `C_ref` | Skalibrowana wydajność referencyjna | 1.5 °C/h |
+| `Kext` | Aktualny współczynnik zewnętrzny | 0.02 |
+| `ΔT_ext` | Różnica temp. wewn./zewn. | 15°C |
+| `czas_cyklu` | W godzinach | 0.167 (10 min) |
+| `wydajność` | Użyty procent mocy | 0.70 |
+| `agresywność` | Współczynnik moderacji | 0.9 |
+
+### Uczenie Kext (Współczynnik zewnętrzny)
+
+Algorytm dostosowuje Kext, gdy temperatura jest **bliska nastawy** (|odchylenie| < 0,5°C).
+
+#### Wzór
+
+```
+Korekta = Kint × (odchylenie_wewn / odchylenie_zewn)
+Kext_nowy = Kext_stary + Korekta
+```
+
+- Jeśli odchylenie_wewn **ujemne** (przeregulowanie) → Korekta ujemna → **Kext maleje**
+- Jeśli odchylenie_wewn **dodatnie** (niedoregulowanie) → Korekta dodatnia → **Kext rośnie**
+
+### Metody wygładzania
+
+Dostępne są dwie metody wygładzania nowych wartości:
+
+#### Średnia ważona (tryb „Discovery”)
+
+```
+Kint_finalny = (Kint_stary × licznik + Kint_nowy) / (licznik + 1)
+```
+
+| Cykl | Stara waga | Nowa waga | Wpływ nowej wartości |
+|-------|------------|------------|------------------|
+| 1 | 1 | 1 | 50% |
+| 10 | 10 | 1 | 9% |
+| 50 | 50 | 1 | 2% |
+
+> Licznik jest ograniczony do 50, aby zachować minimalną reaktywność.
+
+#### EWMA (tryb „Fine Tuning”)
+
+```
+Kint_finalny = (1 - α) × Kint_stary + α × Kint_nowy
+α(n) = α₀ / (1 + decay_rate × n)
+```
+
+| Parametr | Domyślny | Opis |
+|-----------|---------|-------------|
+| `α₀` (początkowe alfa) | 0.08 | Początkowa waga nowych wartości |
+| `decay_rate` | 0.12 | Prędkość spadku wartości alfa |
+
+---
+
+## Mechanizmy automatycznej korekty
+
+### Korekta przeregulowania (Kext Deboost)
+
+> **Aktywacja**: parametr `allow_kext_compensation_on_overshoot` w usłudze `set_auto_tpi_mode`
+
+Wykrywa i koryguje sytuację, gdy temperatura **przekracza nastawę** i nie spada.
+
+```mermaid
+flowchart TD
+    A{T° > Nastawa + 0.2°C?} -->|Tak| B{Moc > 5%?}
+    B -->|Tak| C{T° nie spada?}
+    C -->|Tak| D[Korekta Kext]
+    
+    A -->|Nie| E[Brak korekty]
+    B -->|Nie| E
+    C -->|Nie| E
+    
+    D --> F["redukcja = przeregulowanie × Kint / ΔT_zewn"]
+    F --> G["Kext_cel = max(0.001, Kext - redukcja)"]
+    G --> H[Zastosuj z alpha boost ×2]
+```
+
+### Korekta stagnacji (Kint Boost)
+
+> **Aktywacja**: parametr `allow_kint_boost_on_stagnation` w usłudze `set_auto_tpi_mode`
+
+Wykrywa i koryguje sytuację, gdy temperatura **stoi w miejscu** mimo znaczącego odchylenia.
+
+```mermaid
+flowchart TD
+    A{Odchylenie > 0.5°C?} -->|Tak| B{Postęp < 0.02°C?}
+    B -->|Tak| C{Moc < 99%?}
+    C -->|Tak| D{Kolejne boosty < 5?}
+    D -->|Tak| E[Boost Kint]
+    
+    A -->|Nie| F[Brak korekty]
+    B -->|Nie| F
+    C -->|Nie| F
+    D -->|Nie| G[Alert: Niewystarczająca moc ogrzewania]
+    
+    E --> H["boost = 8% × min(odchylenie/0.3, 2.0)"]
+    H --> I["Kint_cel = Kint × (1 + boost)"]
+```
+
+---
+
+## Zaawansowane parametry i stałe
+
+### Stałe wewnętrzne (niekonfigurowalne)
+
+| Stała | Wartość | Opis |
+|----------|-------|-------------|
+| `MIN_KINT` | 0.01 | Dolny limit Kint dla zachowania reaktywności |
+| `OVERSHOOT_THRESHOLD` | 0.2°C | Próg przeregulowania wyzwalający korektę |
+| `OVERSHOOT_POWER_THRESHOLD` | 5% | Min. moc, by uznać przeregulowanie za błąd Kext |
+| `OVERSHOOT_CORRECTION_BOOST` | 2.0 | Mnożnik alfa podczas korekty |
+| `NATURAL_RECOVERY_POWER_THRESHOLD` | 20% | Maks. moc do pominięcia uczenia przy naturalnym powrocie |
+| `INSUFFICIENT_RISE_GAP_THRESHOLD` | 0.5°C | Min. odchylenie wyzwalające boost Kint |
+| `MAX_CONSECUTIVE_KINT_BOOSTS` | 5 | Limit przed alertem o niewystarczającej mocy |
+| `MIN_PRE_BOOTSTRAP_CALIBRATION_RELIABILITY` | 20% | Min. wiarygodność do pominięcia bootstrapu |
+
+### Parametry konfigurowalne
+
+| Parametr | Typ | Domyślny | Zakres |
+|-----------|------|---------|-------|
+| **Agresywność** | Suwak | 1.0 | 0.5 - 1.0 |
+| **Czas nagrzewania** | Minuty | 5 | 1 - 30 |
+| **Czas chłodzenia** | Minuty | 7 | 1 - 60 |
+| **Współczynnik grzania** | °C/h | 0 (auto) | 0 - 5.0 |
+| **Waga początkowa** (Discovery) | Całkowita | 1 | 1 - 50 |
+| **Alpha** (Fine Tuning) | Zmiennoprzec. | 0.08 | 0.01 - 0.3 |
+| **Wsp. zaniku** | Zmiennoprzec. | 0.12 | 0.0 - 0.5 |
+
+---
+
+## Usługi i API
+
+### `versatile_thermostat.set_auto_tpi_mode`
+
+Kontroluje start/stop uczenia.
+
+```yaml
+service: versatile_thermostat.set_auto_tpi_mode
+target:
+  entity_id: climate.my_thermostat
+data:
+  auto_tpi_mode: true                    # true = start, false = stop
+  reinitialise: true                     # true = pełny reset, false = wznowienie
+  allow_kint_boost_on_stagnation: false  # Boost Kint przy stagnacji
+  allow_kext_compensation_on_overshoot: false  # Korekta Kext przy przeregulowaniu
+```
+
+### `versatile_thermostat.auto_tpi_calibrate_capacity`
+
+Kalibruje wydajność cieplną na podstawie historii.
+
+```yaml
+service: versatile_thermostat.auto_tpi_calibrate_capacity
+target:
+  entity_id: climate.my_thermostat
+data:
+  start_date: "2024-01-01T00:00:00+00:00"  # Opcjonalnie
+  end_date: "2024-02-01T00:00:00+00:00"    # Opcjonalnie
+  min_power_threshold: 95                   # Min % mocy
+  capacity_safety_margin: 20                # % marginesu bezpieczeństwa
+  save_to_config: true                      # Zapisz w konfiguracji
+```
+
+**Zwracane wartości usługi**:
+
+| Klucz | Opis |
+|-----|-------------|
+| `max_capacity` | Obliczona wydajność brutto (°C/h) |
+| `recommended_capacity` | Wydajność po uwzględnieniu marginesu (°C/h) |
+| `reliability` | Indeks wiarygodności (%) |
+| `samples_used` | Liczba użytych próbek |
+| `outliers_removed` | Liczba usuniętych wartości odstających |
+
+---
+
+## Zaawansowana diagnostyka i rozwiązywanie problemów
+
+### Czujnik diagnostyczny
+
+Encja: `sensor.<nazwa>_auto_tpi_learning_state`
+
+| Atrybut | Opis |
+|-----------|-------------|
+| `active` | Uczenie w toku |
+| `heating_cycles_count` | Całkowita liczba zaobserwowanych cykli |
+| `coeff_int_cycles` | Zatwierdzone cykle Kint |
+| `coeff_ext_cycles` | Zatwierdzone cykle Kext |
+| `model_confidence` | Wiarygodność 0.0 - 1.0 |
+| `calculated_coef_int` | Bieżący Kint |
+| `calculated_coef_ext` | Bieżący Kext |
+| `last_learning_status` | Powód ostatniego cyklu |
+| `capacity_heat_status` | `learning` lub `learned` |
+| `capacity_heat_value` | Bieżąca wydajność (°C/h) |
+
+### Typowe statusy uczenia
+
+| Status | Znaczenie | Sugerowane działanie |
+|--------|---------|------------------|
+| `learned_indoor_heat` | Kint zaktualizowany pomyślnie | Norma |
+| `learned_outdoor_heat` | Kext zaktualizowany pomyślnie | Norma |
+| `power_out_of_range` | Moc wynosi 0% lub 100% | Czekaj na cykl nienasycony |
+| `real_rise_too_small` | Wzrost < 0,01°C | Sprawdź czujnik lub czas cyklu |
+| `setpoint_changed_during_cycle` | Nastawa zmieniona | Unikaj zmieniania nastawy |
+| `no_capacity_defined` | Brak skalibrowanej wydajności | Czekaj na kalibrację/bootstrap |
+| `corrected_kext_overshoot` | Zastosowano korektę przeregulowania | Norma, jeśli Kext zbyt wysoki |
+| `corrected_kint_insufficient_rise` | Zastosowano boost Kint | Norma, jeśli Kint zbyt niski |
+| `max_kint_boosts_reached` | 5 kolejnych boostów | **Niewystarczająca moc ogrzewania** |
+
+### Diagnostyczne drzewo decyzyjne
+
+```mermaid
+flowchart TD
+    A[Wykryto problem] --> B{Kint czy Kext?}
+    
+    B -->|Kint zbyt niski| C[T° rośnie powoli]
+    C --> D{Po 10 cyklach?}
+    D -->|Tak| E[Sprawdź czasy grzania/chłodzenia]
+    D -->|No| F[Czekaj na konwergencję]
+    
+    B -->|Kint zbyt wysoki| G[Oscylacje T°]
+    G --> H[Zmniejsz agresywność]
+    
+    B -->|Kext zbyt niski| I[T° spada poniżej nastawy]
+    I --> J[Sprawdź zewnętrzny czujnik T°]
+    
+    B -->|Kext zbyt wysoki| K[Utrzymujące się przeregulowanie]
+    K --> L[Włącz allow_kext_compensation]
+    
+    A --> M{Brak uczenia?}
+    M -->|power_out_of_range| N[Nasycone ogrzewanie]
+    N --> O[Czekaj na sprzyjające warunki]
+    M -->|no_capacity_defined| P[Brak kalibracji]
+    P --> Q[Sprawdź historię lub wymuś wartość]
+```
+
+### Plik trwałości
+
+**Lokalizacja**: `.storage/versatile_thermostat_{unique_id}_auto_tpi_v2.json`
+
+Ten plik zawiera kompletny stan uczenia i jest przywracany przy restarcie Home Assistanta. Można go usunąć, aby wymusić pełny reset (niezalecane).
+
+---
+
+## Dodatki
+
+### Zalecane wartości referencyjne
+
+| Typ ogrzewania | Czas nagrzewania | Czas chłodzenia | Typowa wydajność |
+|--------------|--------------|--------------|------------------|
+| Konwektor elektryczny | 2-5 min | 3-7 min | 2.0-3.0 °C/h |
+| Grzejnik akumulacyjny | 5-10 min | 10-20 min | 1.0-2.0 °C/h |
+| Ogrzewanie podłogowe | 15-30 min | 30-60 min | 0.3-0.8 °C/h |
+| Kocioł centralny | 5-15 min | 10-30 min | 1.0-2.5 °C/h |
+
+### Kompletne wzory matematyczne
+
+**Wydajność efektywna**:
+$$C_{eff} = C_{ref} \times (1 - K_{ext} \times \Delta T_{ext})$$
+
+**Adaptacyjne Alfa (EWMA)**:
+$$\alpha(n) = \frac{\alpha_0}{1 + k \times n}$$
+
+**Wiarygodność kalibracji**:
+$$reliability = 100 \times \min\left(\frac{samples}{20}, 1\right) \times \max\left(0, 1 - \frac{CV}{2}\right)$$
+
+Gdzie CV = Współczynnik zmienności (odchylenie standardowe / średnia)


### PR DESCRIPTION
Add missing de/cs/pl  translations for new  auto-tpi documentation. ( de was still the old deprecated one ) 
Fix wrong links in README.

Perhaps thereafter ask to the translator to check them as it's AI translations. 