### PR TITLE
Support temperature attribute and weather sensors

### DIFF
--- a/custom_components/versatile_thermostat/base_thermostat.py
+++ b/custom_components/versatile_thermostat/base_thermostat.py
@@ -531,12 +531,22 @@ class BaseThermostat(ClimateEntity, RestoreEntity, Generic[T]):
                 STATE_UNAVAILABLE,
                 STATE_UNKNOWN,
             ):
-                _LOGGER.debug(
-                    "%s - external temperature sensor have been retrieved: %.1f",
-                    self,
-                    float(ext_temperature_state.state),
-                )
-                await self._async_update_ext_temp(ext_temperature_state)
+                try:
+                    ext_temp = self._extract_temperature_value(
+                        ext_temperature_state, allow_temperature_attribute=True
+                    )
+                    _LOGGER.debug(
+                        "%s - external temperature sensor have been retrieved: %.1f",
+                        self,
+                        ext_temp,
+                    )
+                    await self._async_update_ext_temp(ext_temperature_state)
+                except ValueError:
+                    _LOGGER.debug(
+                        "%s - external temperature sensor have NOT been retrieved "
+                        "cause it doesn't provide a usable temperature",
+                        self,
+                    )
             else:
                 _LOGGER.debug(
                     "%s - external temperature sensor have NOT been retrieved "
@@ -1623,6 +1633,7 @@ class BaseThermostat(ClimateEntity, RestoreEntity, Generic[T]):
             "hvac_mode": self.hvac_mode,
             "preset_mode": self.preset_mode,
             "ema_temp": self._ema_temp,
+            "ext_current_temperature_entity_id": self._ext_temp_sensor_entity_id,
             "specific_states": {
                 "is_on": self.is_on,
                 "last_central_mode": self.last_central_mode,
@@ -1768,7 +1779,8 @@ class BaseThermostat(ClimateEntity, RestoreEntity, Generic[T]):
         if new_state is None or new_state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
             return
 
-        await self._async_update_ext_temp(new_state)
+        if not await self._async_update_ext_temp(new_state):
+            return
         self.recalculate()
 
         # Potentially it generates a safety event
@@ -1782,9 +1794,7 @@ class BaseThermostat(ClimateEntity, RestoreEntity, Generic[T]):
     async def _async_update_temp(self, state: State):
         """Update thermostat with latest state from sensor."""
         try:
-            cur_temp = float(state.state)
-            if math.isnan(cur_temp) or math.isinf(cur_temp):
-                raise ValueError(f"Sensor has illegal state {state.state}")
+            cur_temp = self._extract_temperature_value(state)
             self._cur_temp = cur_temp
 
             self._last_temperature_measure = self.get_state_date_or_now(state)
@@ -1813,9 +1823,9 @@ class BaseThermostat(ClimateEntity, RestoreEntity, Generic[T]):
     async def _async_update_ext_temp(self, state: State):
         """Update thermostat with latest state from sensor."""
         try:
-            cur_ext_temp = float(state.state)
-            if math.isnan(cur_ext_temp) or math.isinf(cur_ext_temp):
-                raise ValueError(f"Sensor has illegal state {state.state}")
+            cur_ext_temp = self._extract_temperature_value(
+                state, allow_temperature_attribute=True
+            )
             self._cur_ext_temp = cur_ext_temp
             self._last_ext_temperature_measure = self.get_state_date_or_now(state)
 
@@ -1829,8 +1839,36 @@ class BaseThermostat(ClimateEntity, RestoreEntity, Generic[T]):
             # try to restart if we were in safety mode
             # if self._safety_manager.is_safety_detected:
             #     await self._safety_manager.refresh_state()
+            return True
         except ValueError as ex:
             _LOGGER.error("Unable to update external temperature from sensor: %s", ex)
+            return False
+
+    def _extract_temperature_value(
+        self, state: State, allow_temperature_attribute: bool = False
+    ) -> float:
+        """Extract a finite temperature from state or (optionally) from attributes."""
+        values_to_try = [state.state]
+        if allow_temperature_attribute:
+            values_to_try.append(state.attributes.get(ATTR_TEMPERATURE))
+
+        for value in values_to_try:
+            if value in (None, STATE_UNKNOWN, STATE_UNAVAILABLE):
+                continue
+
+            try:
+                temperature = float(value)
+            except (ValueError, TypeError):
+                continue
+
+            if math.isnan(temperature) or math.isinf(temperature):
+                raise ValueError(f"Sensor has illegal state {value}")
+            return temperature
+
+        raise ValueError(
+            f"No usable temperature value in state={state.state} "
+            f"attr_temperature={state.attributes.get(ATTR_TEMPERATURE)}"
+        )
 
     ##
     ## Services (actions)

--- a/custom_components/versatile_thermostat/config_schema.py
+++ b/custom_components/versatile_thermostat/config_schema.py
@@ -12,6 +12,7 @@ from homeassistant.components.input_boolean import (
 )
 
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.components.weather import DOMAIN as WEATHER_DOMAIN
 from homeassistant.components.input_number import (
     DOMAIN as INPUT_NUMBER_DOMAIN,
 )
@@ -110,7 +111,9 @@ STEP_CENTRAL_FEATURES_DATA_SCHEMA = vol.Schema(  # pylint: disable=invalid-name
 STEP_CENTRAL_MAIN_DATA_SCHEMA = vol.Schema(  # pylint: disable=invalid-name
     {
         vol.Required(CONF_EXTERNAL_TEMP_SENSOR): selector.EntitySelector(
-            selector.EntitySelectorConfig(domain=[SENSOR_DOMAIN, INPUT_NUMBER_DOMAIN]),
+            selector.EntitySelectorConfig(
+                domain=[SENSOR_DOMAIN, INPUT_NUMBER_DOMAIN, WEATHER_DOMAIN]
+            ),
         ),
         vol.Required(CONF_TEMP_MIN, default=7): vol.Coerce(float),
         vol.Required(CONF_TEMP_MAX, default=35): vol.Coerce(float),
@@ -122,7 +125,9 @@ STEP_CENTRAL_MAIN_DATA_SCHEMA = vol.Schema(  # pylint: disable=invalid-name
 STEP_CENTRAL_SPEC_MAIN_DATA_SCHEMA = vol.Schema(  # pylint: disable=invalid-name
     {
         vol.Required(CONF_EXTERNAL_TEMP_SENSOR): selector.EntitySelector(
-            selector.EntitySelectorConfig(domain=[SENSOR_DOMAIN, INPUT_NUMBER_DOMAIN]),
+            selector.EntitySelectorConfig(
+                domain=[SENSOR_DOMAIN, INPUT_NUMBER_DOMAIN, WEATHER_DOMAIN]
+            ),
         ),
         vol.Required(CONF_TEMP_MIN, default=7): vol.Coerce(float),
         vol.Required(CONF_TEMP_MAX, default=35): vol.Coerce(float),


### PR DESCRIPTION
Make external temperature handling more robust and allow weather entities as external sensors.

- auto_tpi_manager.py: import ATTR_TEMPERATURE and prefer reading temperature from either the entity state or the temperature attribute when computing outdoor temperature (skip unknown/unavailable and non-numeric values).
- base_thermostat.py: introduce _extract_temperature_value to centrally extract a finite temperature from state or attributes (optionally allowing the temperature attribute). Use this helper in _async_update_temp and _async_update_ext_temp (ext update now returns bool). Add ext_current_temperature_entity_id to the restored state. Improve logging when external sensor does not provide a usable temperature.
- config_schema.py: include the weather domain in the external temperature entity selector so weather entities can be chosen as external temp sensors.

These changes improve resilience to sensors that expose temperature in attributes and expand supported entity types for external temperature.