### PR TITLE
remove useless double calculation of on_time_sec/off_time_sec in thermostat_switch

### DIFF
--- a/custom_components/versatile_thermostat/prop_handler_tpi.py
+++ b/custom_components/versatile_thermostat/prop_handler_tpi.py
@@ -331,6 +331,8 @@ class TPIHandler:
         # Stop here if we are off
         if t.vtherm_hvac_mode == VThermHvacMode_OFF:
             _LOGGER.debug("%s - End of cycle (HVAC_MODE_OFF)", t)
+            t._on_time_sec = 0
+            t._off_time_sec = int(t.cycle_min * 60)
             if t.is_device_active:
                 await t.async_underlying_entity_turn_off()
         else:
@@ -349,6 +351,10 @@ class TPIHandler:
                     realized_percent = on_time_sec / (t.cycle_min * 60)
                     if t.prop_algorithm and hasattr(t.prop_algorithm, "update_realized_power"):
                         t.prop_algorithm.update_realized_power(realized_percent)
+
+            # Store on/off times on thermostat for sensors and attributes
+            t._on_time_sec = on_time_sec
+            t._off_time_sec = off_time_sec
 
             for under in t.underlyings:
                 await under.start_cycle(

--- a/custom_components/versatile_thermostat/thermostat_prop.py
+++ b/custom_components/versatile_thermostat/thermostat_prop.py
@@ -129,6 +129,9 @@ class ThermostatProp(BaseThermostat[T], Generic[T]):
         """Finish the initialization of the thermostat."""
         super().post_init(config_entry)
 
+        # Initialize off_time to full cycle duration (on_percent=0 at startup)
+        self._off_time_sec = int(self._cycle_min * 60)
+
         # Initialize the proportional function from config
         # This allows selecting the correct handler (TPI, or other prop algorithms)
         self._proportional_function = self._entry_infos.get(CONF_PROP_FUNCTION)

--- a/custom_components/versatile_thermostat/thermostat_switch.py
+++ b/custom_components/versatile_thermostat/thermostat_switch.py
@@ -23,7 +23,6 @@ from .const import (
 )
 
 from .commons import write_event_log
-from .timing_utils import calculate_cycle_times
 
 from .base_thermostat import BaseThermostat, ConfigData
 from .thermostat_prop import ThermostatProp
@@ -132,15 +131,9 @@ class ThermostatOverSwitch(ThermostatProp[UnderlyingSwitch]):
             "power_percent": self.power_percent,
         }
 
-        # Calculate on/off times for attributes (generic for any proportional algo on switch)
-        on_time_sec, off_time_sec, _ = calculate_cycle_times(
-            self.safe_on_percent,
-            self._cycle_min,
-            self._minimal_activation_delay,
-            self._minimal_deactivation_delay
-        )
-        self._on_time_sec = on_time_sec
-        self._off_time_sec = off_time_sec
+        # Use pre-calculated on/off times from handler's control_heating
+        on_time_sec = self._on_time_sec
+        off_time_sec = self._off_time_sec
 
         # Underlying specific attributes
         vtherm_over_switch_attr = {


### PR DESCRIPTION
from yesterday night discussion.

Use real previously calculated on/off_time_sec sent to base_thermostat
set off_time_sec to cycle time when OFF for sensor logic.