### PR TITLE
fix(multi-switch): fix cycle timing for 2nd+ underlying switches

### DIFF
--- a/tests/test_multiple_switch.py
+++ b/tests/test_multiple_switch.py
@@ -289,7 +289,7 @@ async def test_multiple_switchs(
         assert entity.window_state is STATE_UNAVAILABLE
 
         event_timestamp = now - timedelta(minutes=4)
-        await send_temperature_change_event(entity, 15, event_timestamp)
+        await send_temperature_change_event(entity, 18.5, event_timestamp)
 
         # Checks that all climates are off
         assert entity.is_device_active is False  # pylint: disable=protected-access
@@ -313,7 +313,7 @@ async def test_multiple_switchs(
         "custom_components.versatile_thermostat.underlyings.UnderlyingSwitch.call_later",
         return_value=None,
     ) as mock_call_later:
-        await send_ext_temperature_change_event(entity, 5, event_timestamp)
+        await send_ext_temperature_change_event(entity, 15, event_timestamp)
 
         # No special event
         assert mock_send_event.call_count == 0

--- a/tests/test_power.py
+++ b/tests/test_power.py
@@ -615,7 +615,7 @@ async def test_power_management_energy_over_switch(hass: HomeAssistant, skip_has
         assert entity.power_manager.device_power == 100.0
 
         assert mock_send_event.call_count == 2
-        assert mock_heater_on.call_count == 1
+        assert mock_heater_on.call_count == 2  # both switches turn on immediately at 100%
         assert mock_heater_off.call_count == 0
 
     with patch(


### PR DESCRIPTION
Adaptive staggering delay: `effective_delay`
Ensures each switch can complete its full on_time within the cycle. At 100% power (off_time=0), all switches now turn on immediately instead of waiting for the full stagger delay.

Moved block;
```
        self._on_time_sec = on_time_sec
        self._off_time_sec = off_time_sec
        self._hvac_mode = hvac_mode
```
after `if self._async_cancel_cycle is not None:`

timing values should be changed when we actually start a new cycle

fix #1750 