### PR TITLE
feat: Ajouter 3 modes d'anticipation au TPI (Classique, TPI+D, Intelligent Bang-Coast)

### DIFF
--- a/custom_components/versatile_thermostat/bang_coast_manager.py
+++ b/custom_components/versatile_thermostat/bang_coast_manager.py
@@ -1,0 +1,440 @@
+"""Bang-Coast Manager for intelligent anticipation mode.
+
+This module implements a state machine with three phases:
+- BANG: Full power (on_percent=1.0) for large temperature gaps
+- COAST: Zero power (on_percent=0) while thermal inertia carries temperature toward target
+- MAINTAIN: TPI + D-term for small gaps and fine regulation
+
+Learning: After each COAST phase, the system learns an inertia coefficient
+that predicts how much temperature will rise after cutoff, based on the
+current slope. This naturally adapts to the number of open valves on a
+central boiler system.
+"""
+
+import logging
+from dataclasses import dataclass, asdict
+from enum import Enum
+from datetime import datetime
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.storage import Store
+from homeassistant.util import dt as dt_util
+
+from .const import (
+    BANG_COAST_MIN_SLOPE_FOR_LEARNING,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+STORAGE_VERSION = 1
+STORAGE_KEY_PREFIX = "versatile_thermostat.bang_coast"
+# Maximum duration of COAST phase (seconds) before forced return to MAINTAIN
+MAX_COAST_DURATION_SEC = 1800  # 30 minutes
+
+
+class BangCoastPhase(Enum):
+    """The three phases of the Bang-Coast state machine."""
+
+    BANG = "bang"
+    COAST = "coast"
+    MAINTAIN = "maintain"
+
+
+@dataclass
+class BangCoastLearningData:
+    """Persistent learning data for Bang-Coast algorithm."""
+
+    # Learned inertia coefficient (hours). Predicts coast rise as coeff * slope.
+    learned_inertia_coeff: float = 0.4
+    # Number of completed BANG-COAST cycles observed
+    cycle_count: int = 0
+    # Average coast rise in degrees (diagnostic)
+    avg_coast_rise: float = 0.0
+    # Average BANG phase duration in seconds (diagnostic)
+    avg_bang_duration: float = 0.0
+
+    def to_dict(self) -> dict:
+        """Convert to dict for persistence."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "BangCoastLearningData":
+        """Create from persisted dict."""
+        return cls(
+            learned_inertia_coeff=data.get("learned_inertia_coeff", 0.4),
+            cycle_count=data.get("cycle_count", 0),
+            avg_coast_rise=data.get("avg_coast_rise", 0.0),
+            avg_bang_duration=data.get("avg_bang_duration", 0.0),
+        )
+
+
+class BangCoastManager:
+    """Manages the Bang-Coast state machine and inertia learning.
+
+    Args:
+        hass: Home Assistant instance
+        unique_id: Unique identifier for this thermostat (used for storage key)
+        name: Display name for logging
+        bang_activation_threshold: Temperature gap (°C) to trigger BANG phase
+        initial_inertia_coeff: Initial inertia coefficient before learning (hours)
+        learning_alpha: EMA learning rate (0-1)
+    """
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        unique_id: str,
+        name: str,
+        bang_activation_threshold: float = 1.0,
+        initial_inertia_coeff: float = 0.4,
+        learning_alpha: float = 0.3,
+    ) -> None:
+        """Initialize the Bang-Coast Manager."""
+        self._hass = hass
+        self._unique_id = unique_id
+        self._name = name
+        self._bang_activation_threshold = bang_activation_threshold
+        self._initial_inertia_coeff = initial_inertia_coeff
+        self._learning_alpha = learning_alpha
+
+        # Persistence
+        storage_key = f"{STORAGE_KEY_PREFIX}.{unique_id.replace('.', '_')}"
+        self._store = Store(hass, STORAGE_VERSION, storage_key)
+        self._data = BangCoastLearningData(
+            learned_inertia_coeff=initial_inertia_coeff
+        )
+
+        # State machine
+        self._phase = BangCoastPhase.MAINTAIN
+        self._bang_start_time: datetime | None = None
+        self._coast_start_time: datetime | None = None
+        self._coast_start_temp: float | None = None
+        self._coast_peak_temp: float | None = None
+        self._slope_at_cutoff: float | None = None
+
+        _LOGGER.debug(
+            "%s - BangCoastManager created: threshold=%.1f, initial_coeff=%.2f, alpha=%.2f",
+            self._name,
+            bang_activation_threshold,
+            initial_inertia_coeff,
+            learning_alpha,
+        )
+
+    @property
+    def current_phase(self) -> BangCoastPhase:
+        """Return the current phase of the state machine."""
+        return self._phase
+
+    @property
+    def learned_inertia_coeff(self) -> float:
+        """Return the current learned inertia coefficient."""
+        return self._data.learned_inertia_coeff
+
+    @property
+    def learning_data(self) -> BangCoastLearningData:
+        """Return the learning data for diagnostics."""
+        return self._data
+
+    def reset_to_maintain(self) -> None:
+        """Reset the state machine to MAINTAIN phase.
+
+        Call this when the thermostat is turned off (HVAC_OFF) to ensure
+        the state machine doesn't carry stale BANG/COAST state across
+        off/on transitions.
+        """
+        if self._phase != BangCoastPhase.MAINTAIN:
+            _LOGGER.info(
+                "%s - BangCoast: Resetting from %s to MAINTAIN (thermostat off or mode change).",
+                self._name,
+                self._phase.value,
+            )
+        self._phase = BangCoastPhase.MAINTAIN
+        self._bang_start_time = None
+        self._coast_start_time = None
+        self._coast_start_temp = None
+        self._coast_peak_temp = None
+        self._slope_at_cutoff = None
+
+    def process(
+        self,
+        target_temp: float,
+        current_temp: float,
+        slope: float | None,
+        base_on_percent: float,
+        coef_d: float,
+    ) -> float:
+        """Process one TPI cycle and return the final on_percent.
+
+        This method manages the state machine transitions and returns:
+        - 1.0 during BANG phase (full power)
+        - 0.0 during COAST phase (zero power, coasting on inertia)
+        - TPI-D value during MAINTAIN phase (base_on_percent - coef_d * slope)
+
+        Args:
+            target_temp: Target temperature
+            current_temp: Current room temperature
+            slope: Temperature slope in °C/h (positive = rising)
+            base_on_percent: TPI-calculated on_percent (P-only, for reference)
+            coef_d: Derivative coefficient for D-term
+
+        Returns:
+            final_on_percent: The on_percent to send to the valve [0, 1]
+        """
+        # Safety: if temperature data is unavailable, return base_on_percent unchanged
+        if target_temp is None or current_temp is None:
+            _LOGGER.debug(
+                "%s - BangCoast: target or current temp is None, skipping state machine.",
+                self._name,
+            )
+            return max(0.0, min(1.0, base_on_percent))
+
+        delta_t = target_temp - current_temp
+        safe_slope = slope if slope is not None else 0.0
+
+        # --- State transitions ---
+        if self._phase == BangCoastPhase.MAINTAIN:
+            self._process_maintain(delta_t, target_temp, current_temp, safe_slope)
+        elif self._phase == BangCoastPhase.BANG:
+            self._process_bang(target_temp, current_temp, safe_slope)
+        elif self._phase == BangCoastPhase.COAST:
+            self._process_coast(delta_t, target_temp, current_temp, safe_slope)
+
+        # --- Compute output based on current phase ---
+        if self._phase == BangCoastPhase.BANG:
+            final_on_percent = 1.0
+        elif self._phase == BangCoastPhase.COAST:
+            final_on_percent = 0.0
+        else:
+            # MAINTAIN: apply TPI + D-term
+            d_correction = coef_d * safe_slope if safe_slope > 0 else 0.0
+            final_on_percent = base_on_percent - d_correction
+            final_on_percent = max(0.0, min(1.0, final_on_percent))
+
+        _LOGGER.debug(
+            "%s - BangCoast: phase=%s, delta_T=%.2f, slope=%.2f, base=%.2f, final=%.2f, coeff=%.3f",
+            self._name,
+            self._phase.value,
+            delta_t,
+            safe_slope,
+            base_on_percent,
+            final_on_percent,
+            self._data.learned_inertia_coeff,
+        )
+
+        return final_on_percent
+
+    def _process_maintain(
+        self,
+        delta_t: float,
+        target_temp: float,
+        current_temp: float,
+        slope: float,
+    ) -> None:
+        """Process transitions from MAINTAIN phase."""
+        if delta_t > self._bang_activation_threshold:
+            self._enter_bang(current_temp)
+
+    def _process_bang(
+        self,
+        target_temp: float,
+        current_temp: float,
+        slope: float,
+    ) -> None:
+        """Process transitions from BANG phase.
+
+        Transition to COAST when predicted final temperature reaches target:
+        current_temp + learned_inertia_coeff * slope >= target_temp
+        """
+        if slope <= 0:
+            # Temperature not rising yet during BANG - stay in BANG
+            return
+
+        predicted_coast_rise = self._data.learned_inertia_coeff * slope
+        predicted_final_temp = current_temp + predicted_coast_rise
+
+        if predicted_final_temp >= target_temp:
+            self._enter_coast(current_temp, slope)
+
+    def _process_coast(
+        self,
+        delta_t: float,
+        target_temp: float,
+        current_temp: float,
+        slope: float,
+    ) -> None:
+        """Process transitions from COAST phase.
+
+        Track peak temperature and transition to MAINTAIN when:
+        - slope becomes negative (peak reached, temperature starts falling)
+        Safety: return to BANG if temperature drops too much.
+        """
+        # Track peak temperature during coast
+        if self._coast_peak_temp is None or current_temp > self._coast_peak_temp:
+            self._coast_peak_temp = current_temp
+
+        # Transition: peak reached (temperature starts falling)
+        if slope < 0:
+            self._end_coast_and_learn(target_temp)
+            return
+
+        # Safety: timeout to avoid getting stuck in COAST (e.g., slope stays at 0)
+        if self._coast_start_time is not None:
+            coast_elapsed = (dt_util.utcnow() - self._coast_start_time).total_seconds()
+            if coast_elapsed > MAX_COAST_DURATION_SEC:
+                _LOGGER.warning(
+                    "%s - BangCoast: COAST timeout after %ds. Forcing return to MAINTAIN.",
+                    self._name,
+                    int(coast_elapsed),
+                )
+                self._end_coast_and_learn(target_temp)
+                return
+
+        # Safety: if temperature dropped too much, go back to BANG
+        if delta_t > self._bang_activation_threshold:
+            _LOGGER.warning(
+                "%s - BangCoast: Safety trigger during COAST. delta_T=%.2f > threshold=%.1f. Returning to BANG.",
+                self._name,
+                delta_t,
+                self._bang_activation_threshold,
+            )
+            self._enter_bang(current_temp)
+
+    def _enter_bang(self, current_temp: float) -> None:
+        """Transition to BANG phase."""
+        self._phase = BangCoastPhase.BANG
+        self._bang_start_time = dt_util.utcnow()
+        self._coast_start_time = None
+        self._coast_start_temp = None
+        self._coast_peak_temp = None
+        self._slope_at_cutoff = None
+
+        _LOGGER.info(
+            "%s - BangCoast: Entering BANG phase at %.1f°C",
+            self._name,
+            current_temp,
+        )
+
+    def _enter_coast(self, current_temp: float, slope: float) -> None:
+        """Transition to COAST phase."""
+        self._phase = BangCoastPhase.COAST
+        self._coast_start_time = dt_util.utcnow()
+        self._coast_start_temp = current_temp
+        self._coast_peak_temp = current_temp
+        self._slope_at_cutoff = slope
+
+        _LOGGER.info(
+            "%s - BangCoast: Entering COAST phase at %.1f°C (slope=%.2f°C/h, predicted_rise=%.2f°C)",
+            self._name,
+            current_temp,
+            slope,
+            self._data.learned_inertia_coeff * slope,
+        )
+
+    def _end_coast_and_learn(self, target_temp: float) -> None:
+        """End COAST phase and learn from the experience."""
+        self._phase = BangCoastPhase.MAINTAIN
+
+        # Calculate BANG duration for diagnostics
+        bang_duration = 0.0
+        if self._bang_start_time is not None:
+            bang_duration = (dt_util.utcnow() - self._bang_start_time).total_seconds()
+
+        # Learn from COAST phase
+        if (
+            self._coast_start_temp is not None
+            and self._coast_peak_temp is not None
+            and self._slope_at_cutoff is not None
+            and self._slope_at_cutoff >= BANG_COAST_MIN_SLOPE_FOR_LEARNING
+        ):
+            actual_coast_rise = self._coast_peak_temp - self._coast_start_temp
+            observed_coeff = actual_coast_rise / self._slope_at_cutoff
+
+            # EMA update
+            old_coeff = self._data.learned_inertia_coeff
+            self._data.learned_inertia_coeff = (
+                (1 - self._learning_alpha) * old_coeff
+                + self._learning_alpha * observed_coeff
+            )
+            # Clamp to reasonable range (0.01 to 2.0 hours)
+            self._data.learned_inertia_coeff = max(
+                0.01, min(2.0, self._data.learned_inertia_coeff)
+            )
+
+            # Update diagnostics
+            self._data.cycle_count += 1
+            n = self._data.cycle_count
+            self._data.avg_coast_rise = (
+                (self._data.avg_coast_rise * (n - 1) + actual_coast_rise) / n
+            )
+            self._data.avg_bang_duration = (
+                (self._data.avg_bang_duration * (n - 1) + bang_duration) / n
+            )
+
+            overshoot = self._coast_peak_temp - target_temp
+
+            _LOGGER.info(
+                "%s - BangCoast: Learning from COAST. "
+                "coast_rise=%.2f°C, slope_at_cutoff=%.2f°C/h, "
+                "observed_coeff=%.3fh, new_coeff=%.3fh (was %.3fh), "
+                "overshoot=%.2f°C, cycles=%d",
+                self._name,
+                actual_coast_rise,
+                self._slope_at_cutoff,
+                observed_coeff,
+                self._data.learned_inertia_coeff,
+                old_coeff,
+                overshoot,
+                self._data.cycle_count,
+            )
+        else:
+            reason = "slope too low" if (
+                self._slope_at_cutoff is not None
+                and self._slope_at_cutoff < BANG_COAST_MIN_SLOPE_FOR_LEARNING
+            ) else "incomplete data"
+            _LOGGER.debug(
+                "%s - BangCoast: Skipping learning (%s). Entering MAINTAIN.",
+                self._name,
+                reason,
+            )
+
+        # Reset transient state
+        self._bang_start_time = None
+        self._coast_start_time = None
+        self._coast_start_temp = None
+        self._coast_peak_temp = None
+        self._slope_at_cutoff = None
+
+    async def async_load_data(self) -> None:
+        """Load persisted learning data."""
+        data = await self._store.async_load()
+        if data:
+            self._data = BangCoastLearningData.from_dict(data)
+            _LOGGER.info(
+                "%s - BangCoast: Data loaded. coeff=%.3fh, cycles=%d",
+                self._name,
+                self._data.learned_inertia_coeff,
+                self._data.cycle_count,
+            )
+        else:
+            self._data = BangCoastLearningData(
+                learned_inertia_coeff=self._initial_inertia_coeff
+            )
+            _LOGGER.info(
+                "%s - BangCoast: No persisted data. Using initial coeff=%.3fh",
+                self._name,
+                self._initial_inertia_coeff,
+            )
+
+    async def async_save_data(self) -> None:
+        """Save learning data to persistent storage."""
+        await self._store.async_save(self._data.to_dict())
+
+    def get_state_for_attributes(self) -> dict:
+        """Return state data for HA entity attributes (diagnostics)."""
+        return {
+            "bang_coast_phase": self._phase.value,
+            "bang_coast_inertia_coeff": round(self._data.learned_inertia_coeff, 3),
+            "bang_coast_cycle_count": self._data.cycle_count,
+            "bang_coast_avg_coast_rise": round(self._data.avg_coast_rise, 2),
+            "bang_coast_avg_bang_duration": round(self._data.avg_bang_duration, 0),
+        }

--- a/custom_components/versatile_thermostat/config_schema.py
+++ b/custom_components/versatile_thermostat/config_schema.py
@@ -279,6 +279,28 @@ STEP_CENTRAL_TPI_DATA_SCHEMA = vol.Schema(  # pylint: disable=invalid-name
                 min=-10.0, max=10.0, step=0.1, mode=selector.NumberSelectorMode.BOX
             )
         ),
+        vol.Optional(CONF_ANTICIPATION_MODE, default=CONF_ANTICIPATION_NONE): selector.SelectSelector(
+            selector.SelectSelectorConfig(
+                options=CONF_ANTICIPATION_MODES,
+                translation_key="anticipation_mode",
+                mode="dropdown",
+            )
+        ),
+        vol.Optional(CONF_ANTICIPATION_COEF_D, default=0.1): selector.NumberSelector(
+            selector.NumberSelectorConfig(
+                min=0.0, max=1.0, step=0.01, mode=selector.NumberSelectorMode.BOX
+            )
+        ),
+        vol.Optional(CONF_BANG_ACTIVATION_THRESHOLD, default=1.0): selector.NumberSelector(
+            selector.NumberSelectorConfig(
+                min=0.5, max=5.0, step=0.1, mode=selector.NumberSelectorMode.BOX
+            )
+        ),
+        vol.Optional(CONF_BANG_INITIAL_INERTIA_COEFF, default=0.4): selector.NumberSelector(
+            selector.NumberSelectorConfig(
+                min=0.05, max=2.0, step=0.05, mode=selector.NumberSelectorMode.BOX
+            )
+        ),
         vol.Optional(CONF_AUTO_TPI_MODE, default=False): cv.boolean,
     }
 )
@@ -307,6 +329,28 @@ STEP_CENTRAL_TPI_DATA_SCHEMA_CENTRAL = vol.Schema(  # pylint: disable=invalid-na
         vol.Optional(CONF_TPI_THRESHOLD_HIGH, default=0): selector.NumberSelector(
             selector.NumberSelectorConfig(
                 min=-10.0, max=10.0, step=0.1, mode=selector.NumberSelectorMode.BOX
+            )
+        ),
+        vol.Optional(CONF_ANTICIPATION_MODE, default=CONF_ANTICIPATION_NONE): selector.SelectSelector(
+            selector.SelectSelectorConfig(
+                options=CONF_ANTICIPATION_MODES,
+                translation_key="anticipation_mode",
+                mode="dropdown",
+            )
+        ),
+        vol.Optional(CONF_ANTICIPATION_COEF_D, default=0.1): selector.NumberSelector(
+            selector.NumberSelectorConfig(
+                min=0.0, max=1.0, step=0.01, mode=selector.NumberSelectorMode.BOX
+            )
+        ),
+        vol.Optional(CONF_BANG_ACTIVATION_THRESHOLD, default=1.0): selector.NumberSelector(
+            selector.NumberSelectorConfig(
+                min=0.5, max=5.0, step=0.1, mode=selector.NumberSelectorMode.BOX
+            )
+        ),
+        vol.Optional(CONF_BANG_INITIAL_INERTIA_COEFF, default=0.4): selector.NumberSelector(
+            selector.NumberSelectorConfig(
+                min=0.05, max=2.0, step=0.05, mode=selector.NumberSelectorMode.BOX
             )
         ),
     }

--- a/custom_components/versatile_thermostat/const.py
+++ b/custom_components/versatile_thermostat/const.py
@@ -77,6 +77,26 @@ CONF_TPI_COEF_INT = "tpi_coef_int"
 CONF_TPI_COEF_EXT = "tpi_coef_ext"
 CONF_TPI_THRESHOLD_LOW = "tpi_threshold_low"
 CONF_TPI_THRESHOLD_HIGH = "tpi_threshold_high"
+
+# Anticipation modes
+CONF_ANTICIPATION_MODE = "anticipation_mode"
+CONF_ANTICIPATION_NONE = "anticipation_none"
+CONF_ANTICIPATION_D_TERM = "anticipation_d_term"
+CONF_ANTICIPATION_SMART = "anticipation_smart"
+CONF_ANTICIPATION_MODES = [
+    CONF_ANTICIPATION_NONE,
+    CONF_ANTICIPATION_D_TERM,
+    CONF_ANTICIPATION_SMART,
+]
+
+# Derivative term parameter (used by TPI+D and Smart mode MAINTAIN phase)
+CONF_ANTICIPATION_COEF_D = "anticipation_coef_d"
+
+# Bang-Coast parameters (Smart mode only)
+CONF_BANG_ACTIVATION_THRESHOLD = "bang_activation_threshold"
+CONF_BANG_INITIAL_INERTIA_COEFF = "bang_initial_inertia_coeff"
+# Minimum slope for learning safety (avoid division by near-zero)
+BANG_COAST_MIN_SLOPE_FOR_LEARNING = 0.2
 CONF_PRESENCE_SENSOR = "presence_sensor_entity_id"
 CONF_PRESET_POWER = "power_temp"
 CONF_MINIMAL_ACTIVATION_DELAY = "minimal_activation_delay"

--- a/custom_components/versatile_thermostat/thermostat_prop.py
+++ b/custom_components/versatile_thermostat/thermostat_prop.py
@@ -95,6 +95,15 @@ class ThermostatProp(BaseThermostat[T], Generic[T]):
         """
         return self.on_percent
 
+    @property
+    def base_on_percent(self) -> float:
+        """Return the base on_percent before anticipation post-processing.
+        This is the pure TPI (P-only) value, used by Auto TPI Learning.
+        """
+        if self._prop_algorithm and hasattr(self._prop_algorithm, "base_on_percent"):
+            return self._prop_algorithm.base_on_percent
+        return self.on_percent
+
     def set_safety(self, default_on_percent: float):
         """Set a default value for on_percent (used for safety mode)"""
         _LOGGER.info("%s - Set safety to ON with default_on_percent=%s", self, default_on_percent)

--- a/custom_components/versatile_thermostat/translations/en.json
+++ b/custom_components/versatile_thermostat/translations/en.json
@@ -140,7 +140,11 @@
           "use_tpi_central_config": "Use central TPI configuration",
           "minimal_activation_delay": "Minimum activation delay",
           "minimal_deactivation_delay": "Minimum deactivation delay",
-          "auto_tpi_mode": "Enable Auto TPI Learning"
+          "auto_tpi_mode": "Enable Auto TPI Learning",
+          "anticipation_mode": "Anticipation mode",
+          "anticipation_coef_d": "Derivative coefficient (D)",
+          "bang_activation_threshold": "Bang activation threshold (°)",
+          "bang_initial_inertia_coeff": "Initial inertia coefficient (h)"
         },
         "data_description": {
           "tpi_coef_int": "Coefficient to use for internal temperature delta",
@@ -150,7 +154,11 @@
           "use_tpi_central_config": "Check to use the central TPI configuration. Uncheck to use a specific TPI configuration for this VTherm",
           "minimal_activation_delay": "Delay in seconds under which the equipment will not be activated",
           "minimal_deactivation_delay": "Delay in seconds under which the equipment will be kept active",
-          "auto_tpi_mode": "TPI learning session are started manually, read the doc first."
+          "auto_tpi_mode": "TPI learning session are started manually, read the doc first.",
+          "anticipation_mode": "Classic = standard TPI. TPI+D = proportional braking based on temperature slope. Smart = heats at 100% then learned cutoff based on thermal inertia.",
+          "anticipation_coef_d": "Reduction of on_percent per °/h of slope. Used by TPI+D and Smart modes.",
+          "bang_activation_threshold": "Temperature gap (°) above which 100% heating is triggered (Smart mode only).",
+          "bang_initial_inertia_coeff": "Initial thermal inertia coefficient in hours. Refined automatically through learning (Smart mode)."
         }
       },
       "presets": {
@@ -516,7 +524,11 @@
           "use_tpi_central_config": "Use central TPI configuration",
           "minimal_activation_delay": "Minimum activation delay",
           "minimal_deactivation_delay": "Minimum deactivation delay",
-          "auto_tpi_mode": "Enable Auto TPI Learning"
+          "auto_tpi_mode": "Enable Auto TPI Learning",
+          "anticipation_mode": "Anticipation mode",
+          "anticipation_coef_d": "Derivative coefficient (D)",
+          "bang_activation_threshold": "Bang activation threshold (°)",
+          "bang_initial_inertia_coeff": "Initial inertia coefficient (h)"
         },
         "data_description": {
           "tpi_coef_int": "Coefficient to use for internal temperature delta",
@@ -526,7 +538,11 @@
           "use_tpi_central_config": "Check to use the central TPI configuration. Uncheck to use a specific TPI configuration for this VTherm",
           "minimal_activation_delay": "Delay in seconds under which the equipment will not be activated",
           "minimal_deactivation_delay": "Delay in seconds under which the equipment will be kept active",
-          "auto_tpi_mode": "TPI learning session are started manually, read the doc first."
+          "auto_tpi_mode": "TPI learning session are started manually, read the doc first.",
+          "anticipation_mode": "Classic = standard TPI. TPI+D = proportional braking based on temperature slope. Smart = heats at 100% then learned cutoff based on thermal inertia.",
+          "anticipation_coef_d": "Reduction of on_percent per °/h of slope. Used by TPI+D and Smart modes.",
+          "bang_activation_threshold": "Temperature gap (°) above which 100% heating is triggered (Smart mode only).",
+          "bang_initial_inertia_coeff": "Initial thermal inertia coefficient in hours. Refined automatically through learning (Smart mode)."
         }
       },
       "presets": {
@@ -823,6 +839,13 @@
       "options": {
         "discovery": "Discovery",
         "fine_tuning": "Fine Tuning"
+      }
+    },
+    "anticipation_mode": {
+      "options": {
+        "anticipation_none": "Classic",
+        "anticipation_d_term": "TPI + Derivative (D)",
+        "anticipation_smart": "Smart (Bang-Coast)"
       }
     }
   },

--- a/custom_components/versatile_thermostat/translations/fr.json
+++ b/custom_components/versatile_thermostat/translations/fr.json
@@ -147,7 +147,11 @@
           "minimal_activation_delay": "Délai minimal d'activation",
           "minimal_deactivation_delay": "Délai de désactivation minimal",
           "use_tpi_central_config": "Utiliser la configuration TPI centrale",
-          "auto_tpi_mode": "Activer l'apprentissage Auto TPI"
+          "auto_tpi_mode": "Activer l'apprentissage Auto TPI",
+          "anticipation_mode": "Mode d'anticipation",
+          "anticipation_coef_d": "Coefficient dérivé (D)",
+          "bang_activation_threshold": "Seuil d'activation Bang (°)",
+          "bang_initial_inertia_coeff": "Coefficient d'inertie initial (h)"
         },
         "data_description": {
           "tpi_coef_int": "Coefficient à utiliser pour le delta de température interne",
@@ -157,7 +161,11 @@
           "use_tpi_central_config": "Cochez pour utiliser la configuration TPI centrale. Décochez et saisissez les attributs pour utiliser une configuration TPI spécifique",
           "minimal_activation_delay": "Délai en secondes en-dessous duquel l'équipement ne sera pas activé",
           "minimal_deactivation_delay": "Délai en secondes en-dessous duquel l'équipement se laissé actif",
-          "auto_tpi_mode": "Les sessions d’apprentissage TPI sont démarrées manuellement ; veuillez lire la doc au préalable."
+          "auto_tpi_mode": "Les sessions d’apprentissage TPI sont démarrées manuellement ; veuillez lire la doc au préalable.",
+          "anticipation_mode": "Classique = TPI standard. TPI+D = freinage proportionnel basé sur la pente. Intelligent = chauffe à 100% puis coupure apprise par l’inertie thermique.",
+          "anticipation_coef_d": "Réduction du on_percent par °/h de pente. Utilisé par les modes TPI+D et Intelligent.",
+          "bang_activation_threshold": "Écart de température (°) au-dessus duquel la chauffe à 100% se déclenche (mode Intelligent uniquement).",
+          "bang_initial_inertia_coeff": "Coefficient initial d'inertie thermique en heures. Se raffine par apprentissage (mode Intelligent)."
         }
       },
       "presets": {
@@ -530,7 +538,11 @@
           "minimal_activation_delay": "Délai minimal d'activation",
           "minimal_deactivation_delay": "Délai de désactivation minimal",
           "use_tpi_central_config": "Utiliser la configuration TPI centrale",
-          "auto_tpi_mode": "Activer l'apprentissage Auto TPI"
+          "auto_tpi_mode": "Activer l'apprentissage Auto TPI",
+          "anticipation_mode": "Mode d'anticipation",
+          "anticipation_coef_d": "Coefficient dérivé (D)",
+          "bang_activation_threshold": "Seuil d'activation Bang (°)",
+          "bang_initial_inertia_coeff": "Coefficient d'inertie initial (h)"
         },
         "data_description": {
           "tpi_coef_int": "Coefficient à utiliser pour le delta de température interne",
@@ -540,7 +552,11 @@
           "use_tpi_central_config": "Cochez pour utiliser la configuration TPI centrale. Décochez et saisissez les attributs pour utiliser une configuration TPI spécifique",
           "minimal_activation_delay": "Délai en secondes en-dessous duquel l'équipement ne sera pas activé",
           "minimal_deactivation_delay": "Délai en secondes en-dessous duquel l'équipement sera laissé actif",
-          "auto_tpi_mode": "Les sessions d’apprentissage TPI sont démarrées manuellement ; veuillez lire la doc au préalable."
+          "auto_tpi_mode": "Les sessions d’apprentissage TPI sont démarrées manuellement ; veuillez lire la doc au préalable.",
+          "anticipation_mode": "Classique = TPI standard. TPI+D = freinage proportionnel basé sur la pente. Intelligent = chauffe à 100% puis coupure apprise par l’inertie thermique.",
+          "anticipation_coef_d": "Réduction du on_percent par °/h de pente. Utilisé par les modes TPI+D et Intelligent.",
+          "bang_activation_threshold": "Écart de température (°) au-dessus duquel la chauffe à 100% se déclenche (mode Intelligent uniquement).",
+          "bang_initial_inertia_coeff": "Coefficient initial d'inertie thermique en heures. Se raffine par apprentissage (mode Intelligent)."
         }
       },
       "presets": {
@@ -837,6 +853,13 @@
       "options": {
         "discovery": "Découverte",
         "fine_tuning": "Ajustement fin"
+      }
+    },
+    "anticipation_mode": {
+      "options": {
+        "anticipation_none": "Classique",
+        "anticipation_d_term": "TPI + Dérivé (D)",
+        "anticipation_smart": "Intelligent (Bang-Coast)"
       }
     }
   },


### PR DESCRIPTION
> NOTE : MR en pending le temps de tester en profondeur et de valider (tests en cours de mon côté).

## Contexte et motivation

### Probleme

Sur les installations avec **chaudiere centrale a gaz** et **vannes thermostatiques (TRV)**, l'algorithme TPI standard provoque des **depassements de temperature** (overshoot) significatifs. L'inertie thermique des radiateurs continue de liberer de la chaleur bien apres la fermeture de la vanne, entrainant des depassements de 0.5 a 1.5°C au-dessus de la consigne.

Ce phenomene est amplifie par :
- Le **temps de reponse** des TRV Zigbee (ex: SONOFF TRVZB)
- La **masse thermique** des radiateurs en fonte ou aluminium
- Le **nombre variable de vannes ouvertes** sur le circuit, qui modifie la dynamique de chauffe

### Solution proposee

Ajouter un **selecteur de mode d'anticipation** dans la configuration TPI, offrant 3 strategies :

| Mode | Description | Cas d'usage |
|------|-------------|-------------|
| **Classique** | TPI standard, aucune modification | Comportement actuel par defaut |
| **TPI + Derive (D)** | Freine proportionnellement quand la temperature monte vite | Regulation douce, systemes reactifs |
| **Intelligent (Bang-Coast)** | Chauffe a 100%, coupure anticipee apprise par l'inertie | Efficacite maximale, systemes a forte inertie |

---

## Architecture technique

### Vue d'ensemble du flux de donnees

```
                         config_schema.py
                              |
                    [CONF_ANTICIPATION_MODE]
                    [CONF_ANTICIPATION_COEF_D]
                    [CONF_BANG_ACTIVATION_THRESHOLD]
                    [CONF_BANG_INITIAL_INERTIA_COEFF]
                              |
                              v
                      prop_handler_tpi.py (TPIHandler)
                       /              \
                      v                v
            prop_algo_tpi.py      bang_coast_manager.py
            (TpiAlgorithm)        (BangCoastManager)
                 |                      |
         base_on_percent          effective_on_percent
         (P-only, pour            (valeur finale pour
          Auto TPI Learning)       la vanne)
```

### Separation `base_on_percent` / `effective_on_percent`

Un principe architectural cle : l'Auto TPI Learning doit observer la sortie **pure du TPI (P-only)**, pas la valeur modifiee par l'anticipation. Sinon, le Learning interpreterait les corrections D-term ou Bang-Coast comme des variations de coefficients TPI, ce qui corromprait l'apprentissage.

```
TpiAlgorithm.calculate()
    |
    +-- _base_on_percent  = TPI P-only (coef_int * delta_T + coef_ext * delta_ext)
    |                       --> vers Auto TPI Learning
    |
    +-- _calculated_on_percent = base + D-term (si mode TPI+D)
                                --> vers la vanne (si mode TPI+D)
                                --> vers BangCoastManager comme entree (si mode Intelligent)
```

### Machine a etats Bang-Coast

```
                    delta_T > seuil
         MAINTAIN ──────────────────> BANG (on_percent = 1.0)
            ^                           |
            |                           | predicted_rise >= delta_T
            |                           v
            +───── slope < 0 ───── COAST (on_percent = 0.0)
                  (pic atteint)     [mesure inertie reelle]
                  [apprentissage]   [timeout 30min securite]
```

**Formule de prediction (BANG -> COAST):**
```
predicted_coast_rise = learned_inertia_coeff * slope
Si current_temp + predicted_coast_rise >= target_temp:
    -> transition vers COAST
```

**Formule d'apprentissage (fin de COAST):**
```
actual_coast_rise = coast_peak_temp - coast_start_temp
observed_coeff = actual_coast_rise / slope_at_cutoff
learned_coeff = (1 - alpha) * old_coeff + alpha * observed_coeff
```

- `slope` en °C/h, `coeff` en heures -> `coeff * slope` en °C (dimensionnellement correct)
- L'EMA (alpha=0.3) lisse les observations sur ~10 cycles
- Le coefficient est borne dans [0.01, 2.0] heures
- Apprentissage ignore si slope_at_cutoff < 0.2°C/h (securite division)

### Adaptation au nombre de vannes ouvertes

Le `slope` (pente de temperature) reflete naturellement le nombre de vannes ouvertes :
- **1 vanne ouverte** : slope elevee, inertie elevee -> ratio stable
- **3 vannes ouvertes** : slope plus faible, inertie plus faible -> ratio similaire

Le coefficient appris capture implicitement cette dynamique via le ratio `coast_rise / slope`, qui est relativement stable pour une piece donnee quelle que soit la charge du circuit.

---

## Fichiers modifies

### 1. `const.py` — Nouvelles constantes

**Lignes ajoutees : 81-99** (apres `CONF_TPI_THRESHOLD_HIGH`)

```python
# Anticipation modes
CONF_ANTICIPATION_MODE = "anticipation_mode"
CONF_ANTICIPATION_NONE = "anticipation_none"
CONF_ANTICIPATION_D_TERM = "anticipation_d_term"
CONF_ANTICIPATION_SMART = "anticipation_smart"
CONF_ANTICIPATION_MODES = [
    CONF_ANTICIPATION_NONE,
    CONF_ANTICIPATION_D_TERM,
    CONF_ANTICIPATION_SMART,
]

# Derivative term parameter
CONF_ANTICIPATION_COEF_D = "anticipation_coef_d"

# Bang-Coast parameters
CONF_BANG_ACTIVATION_THRESHOLD = "bang_activation_threshold"
CONF_BANG_INITIAL_INERTIA_COEFF = "bang_initial_inertia_coeff"
BANG_COAST_MIN_SLOPE_FOR_LEARNING = 0.2
```

**Impact** : Aucun — ajout pur, pas de modification de constantes existantes.

---

### 2. `bang_coast_manager.py` — NOUVEAU FICHIER (441 lignes)

Module autonome qui implemente :

| Composant | Role |
|-----------|------|
| `BangCoastPhase` (Enum) | BANG, COAST, MAINTAIN |
| `BangCoastLearningData` (dataclass) | Donnees persistees : `learned_inertia_coeff`, `cycle_count`, `avg_coast_rise`, `avg_bang_duration` |
| `BangCoastManager` (classe) | Machine a etats + apprentissage + persistence |

**Methodes principales :**

| Methode | Description |
|---------|-------------|
| `process()` | Point d'entree par cycle TPI. Gere les transitions et retourne `final_on_percent` |
| `reset_to_maintain()` | Reinitialise la machine (appele sur HVAC_OFF) |
| `_process_maintain()` | Transition MAINTAIN -> BANG si delta_T > seuil |
| `_process_bang()` | Transition BANG -> COAST si prediction >= target |
| `_process_coast()` | Transition COAST -> MAINTAIN quand slope < 0 (pic atteint) |
| `_end_coast_and_learn()` | Calcul de l'apprentissage EMA + reset etat transitoire |
| `async_load_data()` / `async_save_data()` | Persistence via HA `Store` |
| `get_state_for_attributes()` | Diagnostics pour les attributs HA |

**Securites implementees :**
- Garde `None` sur `target_temp` / `current_temp` (retourne `base_on_percent` clampe)
- Timeout COAST de 30 minutes (`MAX_COAST_DURATION_SEC`)
- Retour en BANG si delta_T re-depasse le seuil pendant COAST
- Slope minimum pour l'apprentissage (0.2°C/h)
- Clamping du coefficient appris [0.01, 2.0]

**Pattern architectural** : Suit le meme modele que `auto_tpi_manager.py` et `feature_window_manager.py` — module manager dedie avec persistence `Store`.

---

### 3. `prop_algo_tpi.py` — Modification de `TpiAlgorithm`

**Changements :**

| Element | Modification |
|---------|-------------|
| `__init__()` | +2 parametres : `anticipation_mode`, `anticipation_coef_d` |
| `_base_on_percent` | Nouvel attribut d'instance, sauvegarde la valeur P-only avant post-traitement |
| `calculate()` | Sauvegarde `_base_on_percent` apres le calcul TPI, puis applique le D-term **uniquement si mode = TPI+D** |
| `base_on_percent` (property) | Nouvelle propriete exposant la valeur P-only |
| `anticipation_mode` (property) | Nouvelle propriete |
| `anticipation_coef_d` (property) | Nouvelle propriete |

**Post-traitement D-term (mode TPI+D uniquement) :**

```python
if self._anticipation_mode == CONF_ANTICIPATION_D_TERM and slope > 0 and on_percent > 0:
    d_correction = self._anticipation_coef_d * slope
    self._calculated_on_percent = max(0.0, self._calculated_on_percent - d_correction)
```

**Comportement par mode :**

| Mode | `_base_on_percent` | `_calculated_on_percent` (= `on_percent`) |
|------|-------------------|------------------------------------------|
| Classique | = TPI P-only | = TPI P-only (identique) |
| TPI+D | = TPI P-only | = TPI P-only - D-term |
| Intelligent | = TPI P-only | = TPI P-only (D-term applique par BangCoastManager) |

---

### 4. `thermostat_prop.py` — Nouvelle propriete `base_on_percent`

```python
@property
def base_on_percent(self) -> float:
    """Return the base on_percent before anticipation post-processing."""
    if self._prop_algorithm and hasattr(self._prop_algorithm, "base_on_percent"):
        return self._prop_algorithm.base_on_percent
    return self.on_percent
```

**Role** : Expose la valeur P-only au `TPIHandler` pour qu'il puisse la transmettre au Learning.

---

### 5. `prop_handler_tpi.py` — Orchestration dans `TPIHandler`

C'est le fichier avec le plus de modifications. Changements organises par methode :

#### `__init__()`
- Ajout de `self._bang_coast_manager: BangCoastManager | None`
- Ajout de `self._cached_effective_on_percent: float | None` (cache anti-double-appel)

#### `init_algorithm()`
- Lecture des 4 nouveaux parametres de config
- Passage de `anticipation_mode` et `anticipation_coef_d` a `TpiAlgorithm`
- Instanciation conditionnelle de `BangCoastManager` si mode = Intelligent

#### `async_added_to_hass()`
- Chargement des donnees persistees du BangCoastManager

#### `_get_tpi_data()` (appele par Auto TPI Learning)
- Appelle `bang_coast_manager.process()` pour obtenir `effective_on_percent`
- **Cache le resultat** dans `_cached_effective_on_percent` pour eviter le double appel
- Persiste les donnees d'apprentissage
- Retourne `base_on_percent` (P-only) au Learning

#### `control_heating()` (controle effectif de la vanne)
- **Invalide le cache** en debut de cycle
- **Reset la machine** a MAINTAIN si HVAC = OFF
- Si cache disponible : reutilise le resultat (pas de double `process()`)
- Si cache vide (Learning inactif) : appelle `recalculate()` + `process()` + `save_data()`

#### `update_attributes()`
- Expose les diagnostics BangCoast dans les attributs HA
- Expose le `anticipation_mode` dans la configuration

**Probleme resolu : double appel a `process()`**

Avant le fix, quand Auto TPI Learning ET BangCoast etaient actifs simultanement :
1. `process_cycle()` appelait `_get_tpi_data()` -> `process()` (1er appel)
2. `control_heating()` appelait `process()` directement (2eme appel)

Cela causait **2 transitions d'etat par cycle** au lieu d'1. Le cache `_cached_effective_on_percent` resout ce probleme.

---

### 6. `config_schema.py` — Nouveaux champs de configuration

Ajout dans `STEP_CENTRAL_TPI_DATA_SCHEMA` et `STEP_CENTRAL_TPI_DATA_SCHEMA_CENTRAL` :

| Champ | Type | Defaut | Plage |
|-------|------|--------|-------|
| `anticipation_mode` | SelectSelector (dropdown) | `anticipation_none` | 3 options |
| `anticipation_coef_d` | NumberSelector | 0.1 | [0.0, 1.0] step 0.01 |
| `bang_activation_threshold` | NumberSelector | 1.0 | [0.5, 5.0] step 0.1 |
| `bang_initial_inertia_coeff` | NumberSelector | 0.4 | [0.05, 2.0] step 0.05 |

**Retrocompatibilite** : Tous les champs sont `vol.Optional` avec des valeurs par defaut. Les configurations existantes ne sont pas affectees (`anticipation_mode` = `anticipation_none` = comportement identique a l'actuel).

---

### 7. `translations/fr.json` et `translations/en.json`

Ajout dans les sections `config.step.tpi` et `options.step.tpi` :

**Labels (data) :**
- `anticipation_mode` : "Mode d'anticipation" / "Anticipation mode"
- `anticipation_coef_d` : "Coefficient derive (D)" / "Derivative coefficient (D)"
- `bang_activation_threshold` : "Seuil d'activation Bang (°)" / "Bang activation threshold (°)"
- `bang_initial_inertia_coeff` : "Coefficient d'inertie initial (h)" / "Initial inertia coefficient (h)"

**Descriptions (data_description) :**
- Textes explicatifs detaillant chaque parametre et le mode concerne

**Selector options :**
```json
"anticipation_mode": {
    "options": {
        "anticipation_none": "Classique",
        "anticipation_d_term": "TPI + Derive (D)",
        "anticipation_smart": "Intelligent (Bang-Coast)"
    }
}
```

---

## Scenarios de validation

### Scenario 1 : Mode Classique (regression zero)

| Etape | Attendu |
|-------|---------|
| Configurer `anticipation_mode = anticipation_none` | |
| Cycle TPI | `base_on_percent = on_percent` (identiques) |
| Auto TPI Learning | Recoit la meme valeur qu'avant |
| Pas de BangCoastManager instancie | Pas de `bang_coast_*` dans les attributs |

### Scenario 2 : Mode TPI+D

| Etape | Attendu |
|-------|---------|
| Configurer `anticipation_mode = anticipation_d_term`, `coef_d = 0.1` | |
| Temperature monte (slope = 2.0°C/h), TPI calcule `base = 0.6` | `on_percent = 0.6 - 0.1*2.0 = 0.4` |
| Temperature stable (slope = 0) | `on_percent = base` (pas de correction) |
| Temperature descend (slope < 0) | `on_percent = base` (D-term ignore si slope <= 0) |
| Auto TPI Learning | Recoit `base_on_percent = 0.6` (P-only, sans D-term) |

### Scenario 3 : Mode Intelligent — Cycle complet

| Etape | Phase | on_percent | Attendu |
|-------|-------|-----------|---------|
| T=18°, cible=21° (delta=3.0 > seuil 1.0) | MAINTAIN->BANG | 1.0 | Transition immediate |
| T=19.5°, slope=2.0, coeff=0.4, predict=0.8 | BANG | 1.0 | 19.5+0.8=20.3 < 21 -> reste BANG |
| T=20.2°, slope=2.0, coeff=0.4, predict=0.8 | BANG->COAST | 0.0 | 20.2+0.8=21.0 >= 21 -> coupure |
| T=20.8° (en montee) | COAST | 0.0 | peak_temp = 20.8 |
| T=21.1° (pic), slope devient negatif | COAST->MAINTAIN | TPI+D | Apprentissage: rise=0.9, coeff=0.9/2.0=0.45 |
| Auto TPI Learning | | | Recoit `base_on_percent` (P-only) |

### Scenario 4 : HVAC OFF pendant BANG

| Etape | Attendu |
|-------|---------|
| Phase = BANG, utilisateur eteint le thermostat | |
| `control_heating()` detecte HVAC_OFF | `reset_to_maintain()` appele |
| Utilisateur rallume | Demarre proprement en MAINTAIN |

### Scenario 5 : Temperatures None au demarrage

| Etape | Attendu |
|-------|---------|
| `current_temp = None` (capteur pas encore disponible) | |
| `BangCoastManager.process()` | Retourne `base_on_percent` clampe [0,1] |
| `TpiAlgorithm.calculate()` | `on_percent = 0` (comportement existant) |

### Scenario 6 : Timeout COAST

| Etape | Attendu |
|-------|---------|
| Phase COAST, slope reste a 0 pendant 30min | |
| Timeout `MAX_COAST_DURATION_SEC` atteint | Log WARNING + `_end_coast_and_learn()` |
| Transition forcee vers MAINTAIN | Apprentissage tente avec les donnees disponibles |

---

## Attributs HA exposes (diagnostics)

Quand le mode Intelligent est actif, les attributs suivants sont ajoutes a l'entite thermostat :

### Section `specific_states`

| Attribut | Type | Description |
|----------|------|-------------|
| `bang_coast_phase` | string | Phase actuelle : "bang", "coast", "maintain" |
| `bang_coast_inertia_coeff` | float | Coefficient d'inertie appris (heures) |
| `bang_coast_cycle_count` | int | Nombre de cycles BANG-COAST completes |
| `bang_coast_avg_coast_rise` | float | Montee moyenne en °C pendant COAST |
| `bang_coast_avg_bang_duration` | float | Duree moyenne de la phase BANG (secondes) |

### Section `configuration`

| Attribut | Type | Description |
|----------|------|-------------|
| `anticipation_mode` | string | Mode selectionne |

---

## Persistence

| Donnee | Stockage | Cle |
|--------|----------|-----|
| Coefficient d'inertie appris | HA `Store` (JSON) | `versatile_thermostat.bang_coast.{unique_id}` |
| Compteur de cycles | HA `Store` | idem |
| Moyennes diagnostiques | HA `Store` | idem |

Les donnees sont :
- **Chargees** au demarrage (`async_added_to_hass`)
- **Sauvegardees** a chaque cycle TPI (apres chaque appel a `process()`)
- **Non affectees** par un redemarrage HA (persistence fichier)

---

## Limitations connues (v1)

| Limitation | Impact | Evolution possible |
|------------|--------|-------------------|
| Mode refroidissement (cooling) non supporte par Bang-Coast | BANG jamais declenche si delta_T < 0 | Ajout d'un delta_T inverse pour cooling |
| Coefficient unique pour toutes les conditions | Le coefficient moyen s'adapte via EMA | Apprentissage contextuel (par nb de vannes) |
| Sauvegarde a chaque cycle | Ecriture frequente (faible volume) | Dirty flag pour n'ecrire que si donnees modifiees |
| Pas de borne temporelle pour la phase BANG | Theoriquement infinie si slope = 0 | Ajouter un MAX_BANG_DURATION_SEC |

---

## Checklist de review

- [ ] **Retrocompatibilite** : Mode `anticipation_none` par defaut, aucun impact sur les configs existantes
- [ ] **Pas de modification du config_flow.py** : Le `generic_step` existant gere les nouveaux champs automatiquement
- [ ] **Auto TPI Learning protege** : Recoit `base_on_percent` (P-only), jamais la valeur post-traitee
- [ ] **Double appel process() corrige** : Cache `_cached_effective_on_percent` dans `TPIHandler`
- [ ] **Reset sur HVAC_OFF** : `reset_to_maintain()` previent les etats incoherents
- [ ] **Timeout COAST** : 30min max pour eviter les blocages
- [ ] **Garde None** : Pas de crash si temperatures indisponibles au demarrage
- [ ] **Traductions** : FR et EN completes (config + options + selector)
- [ ] **Tests unitaires** : A ecrire pour `BangCoastManager` (transitions, apprentissage, edge cases)
- [ ] **Tests d'integration** : Valider le flux complet avec Auto TPI Learning actif + mode Smart

---

## Parametres recommandes pour une premiere utilisation

Pour une installation type **chaudiere gaz + TRV SONOFF TRVZB + piece ~15m²** :

| Parametre | Valeur | Raison |
|-----------|--------|--------|
| `anticipation_mode` | `anticipation_smart` | Efficacite maximale |
| `anticipation_coef_d` | `0.1` | Freinage modere en phase MAINTAIN |
| `bang_activation_threshold` | `1.0°C` | Evite le BANG pour les petits ecarts |
| `bang_initial_inertia_coeff` | `0.4h` | Valeur initiale prudente, s'affine en ~10 cycles |
