### PR TITLE
Fix #1767 - `over_switch` cycles on VTherm with multi-switchs don't start immediatly

### DIFF
--- a/custom_components/versatile_thermostat/thermostat_climate.py
+++ b/custom_components/versatile_thermostat/thermostat_climate.py
@@ -233,7 +233,7 @@ class ThermostatOverClimate(BaseThermostat[UnderlyingClimate]):
 
             target_temp = round_to_nearest(new_regulated_temp + offset_temp, regulation_step)
 
-            # The dtemp is the difference between the new target temp and the last sent temperature to the underlying. 
+            # The dtemp is the difference between the new target temp and the last sent temperature to the underlying.
             # If the dtemp is too low, we consider that there is no need to send a new temperature to the underlying because it
             # will not have any effect on the device. This avoid to send too many temperature changes to the underlying.
             dtemp = target_temp - (under.last_sent_temperature if under.last_sent_temperature else 0)
@@ -632,7 +632,7 @@ class ThermostatOverClimate(BaseThermostat[UnderlyingClimate]):
 
         self._attr_extra_state_attributes.update({"vtherm_over_climate": vtherm_over_climate_data})
 
-        _LOGGER.debug("%s - Calling update_custom_attributes: %s", self, self._attr_extra_state_attributes)
+        # _LOGGER.debug("%s - Calling update_custom_attributes: %s", self, self._attr_extra_state_attributes)
 
     @overrides
     def recalculate(self, force=False):

--- a/custom_components/versatile_thermostat/thermostat_climate_valve.py
+++ b/custom_components/versatile_thermostat/thermostat_climate_valve.py
@@ -215,8 +215,8 @@ class ThermostatOverClimateValve(ThermostatProp[UnderlyingClimate], ThermostatOv
             }
         )
 
-        self.async_write_ha_state()
-        _LOGGER.debug("%s - Calling update_custom_attributes: %s", self, self._attr_extra_state_attributes)
+        # self.async_write_ha_state()
+        # _LOGGER.debug("%s - Calling update_custom_attributes: %s", self, self._attr_extra_state_attributes)
 
     @overrides
     def recalculate(self, force=False):

--- a/custom_components/versatile_thermostat/thermostat_switch.py
+++ b/custom_components/versatile_thermostat/thermostat_switch.py
@@ -163,7 +163,7 @@ class ThermostatOverSwitch(ThermostatProp[UnderlyingSwitch]):
         attributes["vtherm_over_switch"] = vtherm_over_switch_attr
         self._attr_extra_state_attributes.update(attributes)
 
-        _LOGGER.debug("%s - Calling update_custom_attributes: %s", self, self._attr_extra_state_attributes)
+        # _LOGGER.debug("%s - Calling update_custom_attributes: %s", self, self._attr_extra_state_attributes)
 
     @overrides
     def incremente_energy(self):

--- a/custom_components/versatile_thermostat/thermostat_valve.py
+++ b/custom_components/versatile_thermostat/thermostat_valve.py
@@ -58,8 +58,6 @@ class ThermostatOverValve(ThermostatProp[UnderlyingValve]):  # pylint: disable=a
         else:
             return self._valve_open_percent
 
-
-
     @overrides
     def post_init(self, config_entry: ConfigData):
         """Initialize the Thermostat"""
@@ -156,7 +154,7 @@ class ThermostatOverValve(ThermostatProp[UnderlyingValve]):  # pylint: disable=a
             }
         )
 
-        _LOGGER.debug("%s - Calling update_custom_attributes: %s", self, self._attr_extra_state_attributes)
+        # _LOGGER.debug("%s - Calling update_custom_attributes: %s", self, self._attr_extra_state_attributes)
 
     @overrides
     def recalculate(self, force=False):

--- a/tests/test_multiple_switch.py
+++ b/tests/test_multiple_switch.py
@@ -91,12 +91,8 @@ async def test_one_switch_cycle(hass: HomeAssistant, skip_send_event, fake_temp_
         assert mock_send_event.call_count == 0
         assert mock_heater_off.call_count == 0
 
-        # The first heater should be on but because call_later is mocked heater_on is not called
-        # assert mock_heater_on.call_count == 1
+        # The first heater should be on bu call_later is mocked.
         assert mock_heater_on.call_count == 0
-        # There is no check if active
-        # don't work with PropertyMock
-        # assert mock_device_active.call_count == 0
 
         # 4 calls dispatched along the cycle
         assert mock_call_later.call_count == 1


### PR DESCRIPTION
Fixes #1767