### PR TITLE
Avoid sending offset updates if new value is equal to current one

### DIFF
--- a/custom_components/versatile_thermostat/thermostat_climate.py
+++ b/custom_components/versatile_thermostat/thermostat_climate.py
@@ -925,7 +925,8 @@ class ThermostatOverClimate(BaseThermostat[UnderlyingClimate]):
                         current_offset,
                         offset,
                     )
-                    await under.send_value_to_number(sync_entity_id, offset)
+                    if offset != current_offset:
+                        await under.send_value_to_number(sync_entity_id, offset)
             elif room_temp is not None:
                 # Send the new temperature directly
                 val = round_to_nearest(room_temp, step_sync_entity)


### PR DESCRIPTION
Hello,
i'm using versatile_thermostat with on/off TRVs.
I see with zigbee2mqtt that versatile_thermostat sends temperature offset updates even if offset is already fine as-is (confirmed reading versatile_thermostat debug logs).
This simple patch avoid pushing new offset to underlying if not needed.