### PR TITLE
Fix translation error. Remove invalid translation placeholder.

### DIFF
--- a/custom_components/versatile_thermostat/translations/cs.json
+++ b/custom_components/versatile_thermostat/translations/cs.json
@@ -95,12 +95,6 @@
       "type": {
         "title": "Propojené entity",
         "description": "Atributy propojených entit",
-        "description_placeholders": {
-          "over_switch_doc": {
-            "text": "dokumentace",
-            "url": "https://github.com/jmcollin78/versatile_thermostat/blob/main/documentation/cs/over-switch.md#configuration"
-          }
-        },
         "data": {
           "underlying_entity_ids": "Zařízení, která mají být řízena",
           "heater_keep_alive": "Interval keep-alive spínače v sekundách",
@@ -428,12 +422,6 @@
       "type": {
         "title": "Entity - {name}",
         "description": "Atributy propojených entit",
-        "description_placeholders": {
-          "over_switch_doc": {
-            "text": "dokumentace",
-            "url": "https://github.com/jmcollin78/versatile_thermostat/blob/main/documentation/cs/over-switch.md#configuration"
-          }
-        },
         "data": {
           "underlying_entity_ids": "Zařízení, která mají být řízena",
           "heater_keep_alive": "Interval keep-alive spínače v sekundách",

--- a/custom_components/versatile_thermostat/translations/fr.json
+++ b/custom_components/versatile_thermostat/translations/fr.json
@@ -98,12 +98,6 @@
       "type": {
         "title": "Entité(s) liée(s)",
         "description": "Attributs de(s) l'entité(s) liée(s)",
-        "description_placeholders": {
-          "over_switch_doc": {
-            "text": "documentation",
-            "url": "https://github.com/jmcollin78/versatile_thermostat/blob/main/documentation/fr/over-switch.md#configuration"
-          }
-        },
         "data": {
           "underlying_entity_ids": "Les équipements à controller",
           "heater_keep_alive": "keep-alive (sec)",
@@ -481,12 +475,6 @@
       "type": {
         "title": "Entité(s) liée(s) - {name}",
         "description": "Attributs de(s) l'entité(s) liée(s)",
-        "description_placeholders": {
-          "over_switch_doc": {
-            "text": "documentation",
-            "url": "https://github.com/jmcollin78/versatile_thermostat/blob/main/documentation/fr/over-switch.md#configuration"
-          }
-        },
         "data": {
           "underlying_entity_ids": "Les équipements à controller",
           "heater_keep_alive": "keep-alive (sec)",

--- a/custom_components/versatile_thermostat/translations/it.json
+++ b/custom_components/versatile_thermostat/translations/it.json
@@ -97,12 +97,6 @@
             "type": {
                 "title": "Entità collegate",
                 "description": "Attributi delle entità collegate",
-                "description_placeholders": {
-                    "over_switch_doc": {
-                        "text": "documentazione",
-                        "url": "https://github.com/jmcollin78/versatile_thermostat/blob/main/documentation/en/over-switch.md#configuration"
-                    }
-                },
                 "data": {
                     "underlying_entity_ids": "Dispositivo(i) da controllare",
                     "heater_keep_alive": "Intervallo di mantenimento della connessione in secondi",
@@ -479,12 +473,6 @@
             "type": {
                 "title": "Carateristiche - {name}",
                 "description": "Attributi delle entità collegate",
-                "description_placeholders": {
-                    "over_switch_doc": {
-                        "text": "documentazione",
-                        "url": "https://github.com/jmcollin78/versatile_thermostat/blob/main/documentation/en/over-switch.md#configuration"
-                    }
-                },
                 "data": {
                     "underlying_entity_ids": "Dispositivo(i) da controllare",
                     "heater_keep_alive": "Intervallo di mantenimento della connessione in secondi",

--- a/custom_components/versatile_thermostat/translations/pl.json
+++ b/custom_components/versatile_thermostat/translations/pl.json
@@ -94,12 +94,6 @@
       "type": {
         "title": "Encje powiązane",
         "description": "Atrybuty encji powiązanych",
-        "description_placeholders": {
-          "over_switch_doc": {
-            "text": "dokumentacja",
-            "url": "https://github.com/jmcollin78/versatile_thermostat/blob/main/documentation/pl/over-switch.md#configuration"
-          }
-        },
         "data": {
           "underlying_entity_ids": "Sterowane urządzenia",
           "heater_keep_alive": "Czas podtrzymania (w sek.)",
@@ -437,12 +431,6 @@
       "type": {
         "title": "Encje - {name}",
         "description": "Atrybuty encji powiązanych",
-        "description_placeholders": {
-          "over_switch_doc": {
-            "text": "dokumentacja",
-            "url": "https://github.com/jmcollin78/versatile_thermostat/blob/main/documentation/pl/over-switch.md#configuration"
-          }
-        },
         "data": {
           "underlying_entity_ids": "Sterowane urządzenie(-a)",
           "heater_keep_alive": "Czas podtrzymania (w sek.)",

--- a/custom_components/versatile_thermostat/translations/ru.json
+++ b/custom_components/versatile_thermostat/translations/ru.json
@@ -93,12 +93,6 @@
       "type": {
         "title": "Связанные сущности",
         "description": "Атрибуты связанных сущностей",
-        "description_placeholders": {
-          "over_switch_doc": {
-            "text": "документация",
-            "url": "https://github.com/jmcollin78/versatile_thermostat/blob/main/documentation/en/over-switch.md#configuration"
-          }
-        },
         "data": {
           "underlying_entity_ids": "Устройство(а) для управления",
           "heater_keep_alive": "Интервал поддержания переключателя (секунды)",


### PR DESCRIPTION
Fixes #1786

Rmove the invalid placeholder on the type step of the config flow. This placeholder is not present in the english translation. This error is only present on other translations.