### PR TITLE
feat: add stuck TRV valve detection and auto-recovery

### DIFF
--- a/custom_components/versatile_thermostat/feature_heating_failure_detection_manager.py
+++ b/custom_components/versatile_thermostat/feature_heating_failure_detection_manager.py
@@ -334,7 +334,7 @@ class FeatureHeatingFailureDetectionManager(BaseFeatureManager):
         """Diagnose the root cause of a failure by checking valve underlyings.
 
         For thermostats with valve underlyings (over_valve or over_climate_valve),
-        compares the commanded state (should_device_be_active) with the real state
+        compares the requested state (should_device_be_active) with the real state
         (is_device_active) to determine if a stuck valve is the cause.
 
         Args:
@@ -369,14 +369,14 @@ class FeatureHeatingFailureDetectionManager(BaseFeatureManager):
                 stuck_valves.append({
                     "entity_id": under.entity_id,
                     "type": "valve_stuck_closed",
-                    "commanded": "open",
+                    "requested": "open",
                     "actual": "closed",
                 })
             elif not should_active and is_active:
                 stuck_valves.append({
                     "entity_id": under.entity_id,
                     "type": "valve_stuck_open",
-                    "commanded": "closed",
+                    "requested": "closed",
                     "actual": "open",
                 })
 

--- a/tests/test_heating_failure_detection.py
+++ b/tests/test_heating_failure_detection.py
@@ -1026,7 +1026,7 @@ async def test_diagnose_root_cause_valve_stuck_closed(hass: HomeAssistant):
     assert result["root_cause_entity_id"] == "number.trv_living_room"
     assert len(result["root_cause_details"]) == 1
     assert result["root_cause_details"][0]["type"] == "valve_stuck_closed"
-    assert result["root_cause_details"][0]["commanded"] == "open"
+    assert result["root_cause_details"][0]["requested"] == "open"
     assert result["root_cause_details"][0]["actual"] == "closed"
 
 
@@ -1052,7 +1052,7 @@ async def test_diagnose_root_cause_valve_stuck_open(hass: HomeAssistant):
     assert result["root_cause_entity_id"] == "number.trv_bedroom"
     assert len(result["root_cause_details"]) == 1
     assert result["root_cause_details"][0]["type"] == "valve_stuck_open"
-    assert result["root_cause_details"][0]["commanded"] == "closed"
+    assert result["root_cause_details"][0]["requested"] == "closed"
     assert result["root_cause_details"][0]["actual"] == "open"
 
 


### PR DESCRIPTION
## Summary

When using `over_climate` thermostats backed by TRV valves (e.g., Zigbee radiator valves), a common real-world issue is the valve **physically getting stuck in the "heating" position** even after the room temperature has exceeded the target. This results in wasted energy, uncomfortable overheating, and no built-in way for the user to know it's happening until they notice the room is too warm.

This PR adds a new optional feature — **Stuck Valve Detection** — that:

1. **Detects** when an underlying TRV reports `hvac_action: heating` while `current_temperature > target_temperature` for a configurable delay (default: 120 seconds)
2. **Automatically cycles** the valve off and back on to attempt to physically unstick it
3. **Limits retries** to a configurable maximum number of cycles (default: 3), after which it fires a Home Assistant event and logs a warning so the user can take manual action
4. **Fires events** (`versatile_thermostat_stuck_valve_event`) for easy integration with HA automations and notifications

### Why this is needed

The existing **Heating Failure Detection** feature covers the opposite scenario (thermostat is heating but temperature is not rising). There is currently **no mechanism** to detect or recover from a valve that remains open when it shouldn't be. Users with multiple TRV-based zones have reported this as a recurring problem, especially with cheaper Zigbee valves that occasionally lose sync with their internal motor position.

## Changes

- **New file:** `feature_stuck_valve_detection_manager.py` — implements the detection logic as a `BaseFeatureManager`, following the same pattern as existing feature managers (heating failure, motion, window, etc.)
- **`const.py`** — new configuration constants and `STUCK_VALVE_EVENT` event type
- **`config_schema.py`** — schema definitions for the new configuration options
- **`config_flow.py`** — new UI step `stuck_valve_detection` with configurable delay and max cycles
- **`thermostat_climate.py`** — registers the manager in `ThermostatOverClimate`
- **`base_thermostat.py`** — calls `refresh_state()` on the stuck valve manager during each update cycle
- **`strings.json`** + **all 9 translation files** (en, it, fr, de, cs, el, pl, ru, sk) — full UI translations for the new feature

## Configuration options

| Option | Default | Description |
|--------|---------|-------------|
| `use_stuck_valve_detection_feature` | `false` | Enable/disable the feature |
| `stuck_valve_detection_delay_sec` | `120` | Seconds to wait before considering a valve stuck |
| `stuck_valve_max_cycles` | `3` | Max off/on cycles before giving up and firing an alert event |

## Test plan

- [ ] Enable the feature on an `over_climate` VTherm with a TRV
- [ ] Simulate a stuck valve (manually set TRV to heating while room temp > target)
- [ ] Verify detection triggers after the configured delay
- [ ] Verify the off/on cycle is performed and logged
- [ ] Verify the event `versatile_thermostat_stuck_valve_event` is fired
- [ ] Verify max cycles limit is respected
- [ ] Verify feature does nothing when disabled
- [ ] Verify feature is ignored on non-`over_climate` thermostats