### PR TITLE
fix(cycle_scheduler): close race window with _is_starting guard, add cycleScheduler.shutdown() to properly cancel timers

### DIFF
--- a/custom_components/versatile_thermostat/base_thermostat.py
+++ b/custom_components/versatile_thermostat/base_thermostat.py
@@ -438,6 +438,11 @@ class BaseThermostat(ClimateEntity, RestoreEntity, Generic[T]):
 
         self.stop_recalculate_later()
 
+        # Cancel scheduler timers so leftover async_call_later handles cannot fire
+        # after the entity has been unloaded (e.g. on cycle duration config change).
+        if self._cycle_scheduler:
+            self._cycle_scheduler.shutdown()
+
         # stop listening for all managers
         for manager in self._managers:
             manager.stop_listening()

--- a/custom_components/versatile_thermostat/cycle_scheduler.py
+++ b/custom_components/versatile_thermostat/cycle_scheduler.py
@@ -452,6 +452,22 @@ class CycleScheduler:
             _from_cycle_end=True,
         )
 
+    def shutdown(self):
+        """Cancel pending timers immediately without firing end-of-cycle callbacks.
+
+        Must be called synchronously when the entity is being removed from HA so
+        that leftover async_call_later handles cannot fire after the new entity
+        (potentially with a different cycle duration) has already started.
+        """
+        if self._tick_unsub:
+            self._tick_unsub()
+            self._tick_unsub = None
+        if self._cycle_end_unsub:
+            self._cycle_end_unsub()
+            self._cycle_end_unsub = None
+        self._is_cancelling = False
+        self._is_starting = False
+
     async def cancel_cycle(self):
         """Cancel the current cycle if one is running."""
         await self._cancel_cycle_impl()


### PR DESCRIPTION
- fix(cycle_scheduler): close race window with _is_starting guard:
 Add _is_starting flag to keep is_cycle_running=True during the window between cancel_cycle() returning and _start_cycle_switch() installing new timers.

Without this guard, a concurrent start_cycle(force=False) could see is_cycle_running=False, create duplicate timers, and leak them — causing cascading premature cycle ends and double energy counting until HA restart.

- fix(cycle_scheduler): cancel timers on entity removal to prevent stale callbacks
 Add CycleScheduler.shutdown() to cancel pending timers synchronously, and call it from BaseThermostat.remove_thermostat() during entity removal.