### PR TITLE
Fix anchor name

### DIFF
--- a/documentation/cs/feature-advanced.md
+++ b/documentation/cs/feature-advanced.md
@@ -11,7 +11,7 @@ Aby se tomu zabránilo, _VTherm_ zajišťuje, že teploměry pravidelně hlásí
 
 Výzva spočívá v tom, že některé teploměry—zejména ty na baterie—posílají aktualizace teploty pouze když se hodnota změní. Je zcela možné nedostávat teplotní aktualizace hodiny, aniž by teploměr selhal. Parametry níže umožňují jemné doladění prahových hodnot pro aktivaci Bezpečnostního režimu.
 
-Pokud má váš teploměr atribut `last seen` indikující čas posledního kontaktu, můžete jej specifikovat v hlavních atributech _VTherm_ pro výrazné snížení falešných aktivací Bezpečnostního režimu. Viz [konfigurace](base-attributes.md#choosing-base-attributes) a [řešení problémů](troubleshooting.md#why-does-my-versatile-thermostat-switch-to-safety-mode).
+Pokud má váš teploměr atribut `last seen` indikující čas posledního kontaktu, můžete jej specifikovat v hlavních atributech _VTherm_ pro výrazné snížení falešných aktivací Bezpečnostního režimu. Viz [konfigurace](base-attributes.md#choosing-base-attributes) a [řešení problémů](troubleshooting.md#why-is-my-versatile-thermostat-going-into-safety-mode).
 
 Pro _VTherm_ typu `over_climate`, které se samo-regulují, je Bezpečnostní režim deaktivován. V tomto případě není žádné nebezpečí, pouze riziko nesprávné teploty.
 

--- a/documentation/de/feature-advanced.md
+++ b/documentation/de/feature-advanced.md
@@ -12,7 +12,7 @@ Um dies zu verhindern, sorgt das _VTherm_ dafür, dass die Thermometer regelmä�
 
 Die Herausforderung besteht darin, dass einige Thermometer - insbesondere batteriebetriebene - nur dann Temperaturaktualisierungen senden, wenn sich der Wert ändert. Es ist durchaus möglich, dass stundenlang keine Temperaturaktualisierungen empfangen werden, ohne dass das Thermometer ausfällt. Die nachstehenden Parameter ermöglichen eine Feinabstimmung der Schwellenwerte für die Aktivierung des Sicherheitsmodus.
 
-Wenn Ihr Thermometer über ein Attribut `Zuletzt gesehen` verfügt, das den Zeitpunkt des letzten Kontakts angibt, können Sie es in den Hauptattributen des _VTherm_ angeben, um falsche Aktivierungen des Sicherheitsmodus stark zu reduzieren. Siehe [Konfiguration](base-attributes.md#choosing-base-attributes) und [Störungsbeseitigung](troubleshooting.md#why-does-my-versatile-thermostat-switch-to-safety-mode).
+Wenn Ihr Thermometer über ein Attribut `Zuletzt gesehen` verfügt, das den Zeitpunkt des letzten Kontakts angibt, können Sie es in den Hauptattributen des _VTherm_ angeben, um falsche Aktivierungen des Sicherheitsmodus stark zu reduzieren. Siehe [Konfiguration](base-attributes.md#choosing-base-attributes) und [Störungsbeseitigung](troubleshooting.md#why-is-my-versatile-thermostat-going-into-safety-mode).
 
 Bei `over_climate`-_VTherms_, die sich selbst regulieren, ist der Sicherheitsmodus deaktiviert. In diesem Fall besteht keine Gefahr, nur das Risiko einer falschen Temperatur.
 

--- a/documentation/en/feature-advanced.md
+++ b/documentation/en/feature-advanced.md
@@ -10,7 +10,7 @@ To prevent this, _VTherm_ ensures that thermometers report values regularly. If 
 
 The challenge lies in that some thermometers—especially battery-operated ones—only send temperature updates when the value changes. It is entirely possible to receive no temperature updates for hours without the thermometer failing. The parameters below allow fine-tuning of the thresholds for activating Safety Mode.
 
-If your thermometer has a `last seen` attribute indicating the last contact time, you can specify it in the _VTherm_'s main attributes to greatly reduce false Safety Mode activations. See [configuration](base-attributes.md#choosing-base-attributes) and [troubleshooting](troubleshooting.md#why-does-my-versatile-thermostat-switch-to-safety-mode).
+If your thermometer has a `last seen` attribute indicating the last contact time, you can specify it in the _VTherm_'s main attributes to greatly reduce false Safety Mode activations. See [configuration](base-attributes.md#choosing-base-attributes) and [troubleshooting](troubleshooting.md#why-is-my-versatile-thermostat-going-into-safety-mode).
 
 For `over_climate` _VTherms_, which self-regulate, Safety Mode is disabled. In this case, there is no danger, only the risk of an incorrect temperature.
 

--- a/documentation/pl/feature-advanced.md
+++ b/documentation/pl/feature-advanced.md
@@ -10,7 +10,7 @@ Aby temu zapobiec, VTherm zapewnia regularne raportowanie wartości odczytywanyc
 
 Problem polega na tym, że niektóre termometry — szczególnie zasilane bateryjnie — wysyłają aktualizacje temperatury tylko wtedy, gdy wartość się zmienia. Zatem całkiem możliwe jest, że przez wiele godzin nie nadejdą żadne aktualizacje temperatury, mimo że termometr działa poprawnie. Poniższe parametry pozwalają na precyzyjne dostrojenie progów aktywacji Trybu Bezpiecznego.
 
-Jeśli Twój termometr posiada atrybut `last seen`, wskazujący czas ostatniego kontaktu, możesz określić go w głównych atrybutach VTherm, aby znacznie ograniczyć fałszywe aktywacje Trybu Bezpiecznego (patrz: [konfiguracja](base-attributes.md#choosing-base-attributes) oraz [rozwiązywanie problemów](troubleshooting.md#why-does-my-versatile-thermostat-switch-to-safety-mode)).
+Jeśli Twój termometr posiada atrybut `last seen`, wskazujący czas ostatniego kontaktu, możesz określić go w głównych atrybutach VTherm, aby znacznie ograniczyć fałszywe aktywacje Trybu Bezpiecznego (patrz: [konfiguracja](base-attributes.md#choosing-base-attributes) oraz [rozwiązywanie problemów](troubleshooting.md#why-is-my-versatile-thermostat-going-into-safety-mode)).
 
 Dla `termostatu na klimacie` z samoregulacją Tryb Bezpieczny jest niedostępny. W takim przypadku nie ma zagrożenia, istnieje jedynie ryzyko błędnej temperatury.
 


### PR DESCRIPTION
Here's the correct URL that I noticed: https://www.versatile-thermostat.org/en/docs/troubleshooting/#why-is-my-versatile-thermostat-going-into-safety-mode