### PR TITLE
fix: hvac_action simulation has missing underlying_target_temperature #1867

### DIFF
--- a/custom_components/versatile_thermostat/underlyings.py
+++ b/custom_components/versatile_thermostat/underlyings.py
@@ -950,7 +950,10 @@ class UnderlyingClimate(UnderlyingEntity):
     @property
     def underlying_target_temperature(self) -> float:
         """Get the target_temperature"""
-        return self.get_underlying_attribute("target_temperature")
+        value = self.get_underlying_attribute("target_temperature")
+        if value is not None:
+            return value
+        return self.get_underlying_attribute("temperature")
 
     @property
     def underlying_current_temperature(self) -> float | None:


### PR DESCRIPTION
# Fix hvac_action simulation (#1867)

In underlyings.py underlying_target_temperature property reads "target_temperature" attribute. This attribute is (sometimes?) called "temperature". The code now also checks "temperature" attribute when the other is not available. More details about this in the related issue

```python
    @property
    def underlying_target_temperature(self) -> float:
        """Get the target_temperature"""
        value = self.get_underlying_attribute("target_temperature")
        if value is not None:
            return value
        return self.get_underlying_attribute("temperature")
```