### PR TITLE
feat #1830: add auto-relock after unlock delay

### DIFF
--- a/custom_components/versatile_thermostat/config_schema.py
+++ b/custom_components/versatile_thermostat/config_schema.py
@@ -467,6 +467,7 @@ STEP_CENTRAL_LOCK_DATA_SCHEMA = vol.Schema(  # pylint: disable=invalid-name
         vol.Optional(CONF_LOCK_CODE): cv.string,
         vol.Optional(CONF_LOCK_USERS, default=True): cv.boolean,
         vol.Optional(CONF_LOCK_AUTOMATIONS, default=True): cv.boolean,
+        vol.Optional(CONF_AUTO_RELOCK_SEC, default=30): vol.Coerce(int),
     }
 )
 

--- a/custom_components/versatile_thermostat/const.py
+++ b/custom_components/versatile_thermostat/const.py
@@ -144,6 +144,7 @@ CONF_FAILURE_DETECTION_ENABLE_TEMPLATE = "failure_detection_enable_template"
 CONF_LOCK_CODE = "lock_code"
 CONF_LOCK_USERS = "lock_users"
 CONF_LOCK_AUTOMATIONS = "lock_automations"
+CONF_AUTO_RELOCK_SEC = "auto_relock_sec"
 
 CONF_VSWITCH_ON_CMD_LIST = "vswitch_on_command"
 CONF_VSWITCH_OFF_CMD_LIST = "vswitch_off_command"

--- a/custom_components/versatile_thermostat/feature_lock_manager.py
+++ b/custom_components/versatile_thermostat/feature_lock_manager.py
@@ -1,13 +1,16 @@
 """ This module manages the lock feature of the Versatile Thermostat integration. """
 import logging
+from datetime import timedelta
 from .log_collector import get_vtherm_logger
 from typing import Any
 
 from homeassistant.core import (
     HomeAssistant,
+    callback,
 )
 
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.event import async_call_later
 
 from .const import *  # pylint: disable=wildcard-import, unused-wildcard-import
 from .commons_type import ConfigData
@@ -26,6 +29,8 @@ class FeatureLockManager(BaseFeatureManager):
         self._lock_automations: bool = True
         self._lock_code: str | None = None
         self._is_locked: bool = False
+        self._auto_relock_sec: int = 30
+        self._cancel_auto_relock = None
 
     @overrides
     def post_init(self, entry_infos: ConfigData):
@@ -33,6 +38,7 @@ class FeatureLockManager(BaseFeatureManager):
         self._lock_users = entry_infos.get(CONF_LOCK_USERS, True)
         self._lock_automations = entry_infos.get(CONF_LOCK_AUTOMATIONS, True)
         self._lock_code = entry_infos.get(CONF_LOCK_CODE)
+        self._auto_relock_sec = int(entry_infos.get(CONF_AUTO_RELOCK_SEC, 30) or 0)
         self._is_configured = self._lock_users or self._lock_automations
 
     @overrides
@@ -85,10 +91,35 @@ class FeatureLockManager(BaseFeatureManager):
     def change_lock_state(self, locked: bool, code: str | None = None) -> None:
         """Set the internal lock state."""
         if self._validate_lock_code(code):
+            if self._cancel_auto_relock:
+                self._cancel_auto_relock()
+                self._cancel_auto_relock = None
             self._is_locked = locked
             _LOGGER.info("%s - Lock state set to %s", self, locked)
+            if not locked and self._auto_relock_sec > 0:
+                self._cancel_auto_relock = async_call_later(
+                    self.hass,
+                    timedelta(seconds=self._auto_relock_sec),
+                    self._do_auto_relock,
+                )
+                _LOGGER.info(
+                    "%s - Auto-relock scheduled in %s seconds",
+                    self,
+                    self._auto_relock_sec,
+                )
             return True
         return False
+
+    @callback
+    def _do_auto_relock(self, _now) -> None:
+        """Callback triggered by the auto-relock timer."""
+        self._cancel_auto_relock = None
+        self._is_locked = True
+        _LOGGER.info(
+            "%s - Auto-relock triggered after %s seconds", self, self._auto_relock_sec
+        )
+        self._vtherm.update_custom_attributes()
+        self._vtherm.async_write_ha_state()
 
     @property
     def has_lock_settings_enabled(self) -> bool:
@@ -110,6 +141,7 @@ class FeatureLockManager(BaseFeatureManager):
                         "is_locked": self._is_locked,
                         "lock_users": self._lock_users,
                         "lock_automations": self._lock_automations,
-                        "lock_code": bool(self._lock_code)
+                        "lock_code": bool(self._lock_code),
+                        "auto_relock_sec": self._auto_relock_sec,
                     }
                 })

--- a/custom_components/versatile_thermostat/strings.json
+++ b/custom_components/versatile_thermostat/strings.json
@@ -47,10 +47,12 @@
           "use_lock_central_config": "Use central lock configuration",
           "lock_code": "Optional pincode (4 digits)",
           "lock_users": "Lock will prevent commands from Users",
-          "lock_automations": "Lock will prevent commands from Automations & integrations (i.e scheduler)"
+          "lock_automations": "Lock will prevent commands from Automations & integrations (i.e scheduler)",
+          "auto_relock_sec": "Auto-relock delay"
         },
         "data_description": {
-          "use_lock_central_config": "Check to use the central lock configuration. Uncheck to use a specific lock configuration for this VTherm"
+          "use_lock_central_config": "Check to use the central lock configuration. Uncheck to use a specific lock configuration for this VTherm",
+          "auto_relock_sec": "Delay in seconds before automatically re-locking after an unlock. Set to 0 to disable auto-relock. Default is 30 seconds."
         }
       },
       "main": {
@@ -150,7 +152,7 @@
           "use_tpi_central_config": "Check to use the central TPI configuration. Uncheck to use a specific TPI configuration for this VTherm",
           "minimal_activation_delay": "Delay in seconds under which the equipment will not be activated",
           "minimal_deactivation_delay": "Delay in seconds under which the equipment will be kept active",
-          "auto_tpi_mode": "Check to enable Auto TPI feature. TPI learning session are manually started, read the doc first."
+          "auto_tpi_mode": "TPI learning session are started manually, read the doc first."
         }
       },
       "presets": {
@@ -287,30 +289,29 @@
       },
       "auto_tpi_configuration": {
         "title": "Auto TPI - Configuration",
-        "description": "General parameters for Auto TPI learning.",
+        "description": "General settings for Auto TPI learning.",
         "data": {
-          "auto_tpi_enable_update_config": "Update configuration",
-          "auto_tpi_enable_notification": "Notifications",
-          "auto_tpi_keep_ext_learning": "Keep external coefficient learning",
-          "auto_tpi_continuous_learning": "Continuous learning",
-          "heater_heating_time": "Heater warm-up time (min)",
-          "heater_cooling_time": "Heater cool-down time (min)",
-          "auto_tpi_max_coef_int": "Max Internal Coefficient",
-          "auto_tpi_heating_rate": "Heating rate ({unit}/h)"
+          "auto_tpi_learning_type": "Learning Type",
+          "heater_heating_time": "Heating time (min)",
+          "heater_cooling_time": "Cooling time (min)",
+          "auto_tpi_heating_rate": "Heating Rate ({unit}/h)",
+          "auto_tpi_aggressiveness": "Aggressiveness",
+          "auto_tpi_enable_advanced_settings": "Enable Advanced Parameters",
+          "auto_tpi_continuous_kext": "Continuous Kext Learning"
         },
         "data_description": {
-          "auto_tpi_enable_update_config": "Automatically update the configuration with learned coefficients",
-          "auto_tpi_enable_notification": "Send a notification when learning is complete",
-          "auto_tpi_keep_ext_learning": "If set, the external coefficient will continue learning even after reaching 50 cycles, as long as the internal coefficient has not reached stability.",
-          "auto_tpi_continuous_learning": "If set, the system will continue calculating and applying new coefficients silently after learning is finished (EMA method recommended).",
+          "auto_tpi_learning_type": "Choose 'Discovery' for initial startup (Weighted Average, weight 1) or 'Fine Tuning' for continuous adjustments (EWMA, Alpha 0.08).",
           "heater_heating_time": "Time to reach full power (minutes)",
-          "heater_cooling_time": "Time to cool down after stop (minutes)\n\n| Type | Heating time | Cooling time |\n| :--- | :--- | :--- |\n| Electric radiator | 5min | 7min |\n| Water radiator | 15min | 20min |\n| Floor heating | 30min | 45min |",
-          "auto_tpi_max_coef_int": "Maximum allowed value for the internal coefficient (Coeff Int)"
+          "heater_cooling_time": "Time to cool down after stop (minutes)\n\n| Type | Heating time | Cooling time |\n| :--- | :--- | :--- |\n| Electric radiator | 5mn | 7mn |\n| Water radiator | 15mn | 20mn |\n| Underfloor heating | 30mn | 45mn |",
+          "auto_tpi_heating_rate": "Radiator temperature rise capacity ({unit} per hour). Leave at 0 for automatic learning (bootstrap).",
+          "auto_tpi_aggressiveness": "Reduction factor for learned coefficients (50-100%). Lower values result in more conservative coefficients and reduce overshoot risk.",
+          "auto_tpi_enable_advanced_settings": "Check to access parameter fine-tuning (Alpha, Decay, Weight).",
+          "auto_tpi_continuous_kext": "Check to enable continuous learning of the external coefficient (Kext) outside of AutoTPI sessions."
         }
       },
       "auto_tpi_avg_settings": {
         "title": "Auto TPI - Weighted Average",
-        "description": "Parameters for the Average method.",
+        "description": "Parameters for Weighted Average method.",
         "data": {
           "auto_tpi_avg_initial_weight": "Initial Weight"
         },
@@ -320,14 +321,16 @@
       },
       "auto_tpi_ema_settings": {
         "title": "Auto TPI - EWMA",
-        "description": "Parameters for the EMA method.\n\nRecommendations:\n| Situation | Alpha (ema_alpha) | Decay Rate (ema_decay_rate) |\n| :--- | :--- | :--- |\n| Initial learning | 0.15 | 0.08 |\n| Fine learning | 0.08 | 0.12 |\n| Continuous learning | 0.05 | 0.02 |",
+        "description": "Parameters for EWMA method.\n\nRecommendations:\n| Situation | Alpha (ema_alpha) | Decay Rate (ema_decay_rate) |\n| :--- | :--- | :--- |\n| Initial Learning | 0.15 | 0.08 |\n| Fine Learning | 0.08 | 0.12 |\n| Continuous Learning | 0.05 | 0.02 |",
         "data": {
           "auto_tpi_ema_alpha": "Alpha",
-          "auto_tpi_ema_decay_rate": "Decay Rate"
+          "auto_tpi_ema_decay_rate": "Decay Rate",
+          "auto_tpi_continuous_kext_alpha": "Continuous Kext Alpha"
         },
         "data_description": {
           "auto_tpi_ema_alpha": "Smoothing factor (0-1). Higher = faster adaptation",
-          "auto_tpi_ema_decay_rate": "Rate at which Alpha decreases over time (stabilization)"
+          "auto_tpi_ema_decay_rate": "Rate at which Alpha decreases over time (stabilization)",
+          "auto_tpi_continuous_kext_alpha": "Smoothing factor for continuous Kext learning (Alpha). Default 0.04 (approx 3-5 days adaptation)."
         }
       },
       "sync_device_internal_temp": {
@@ -374,6 +377,8 @@
       "valve_regulation_nb_entities_incorrect": "The number of valve entities for valve regulation should be equal to the number of underlyings",
       "sync_device_internal_temp_nb_entities_incorrect": "The number of entities for synchronize device internal temperature should be equal to the number of underlyings",
       "min_opening_degrees_format": "A comma separated list of positive integer is expected. Example: 20, 25, 30",
+      "max_opening_degrees_format": "A comma separated list of positive integer between 0 and the max valve opening is expected. Example: 80, 85, 90",
+      "min_max_opening_degrees_inconsistent": "For each underlying device, max_opening_degrees must be strictly greater than min_opening_degrees. Please check your configuration.",
       "vswitch_configuration_incorrect": "The command customization configuration is incorrect. It is required for underlying entities that are not switches, and the format must be service_name[/attribute:value]. More information is available in the README"
     },
     "abort": {
@@ -413,9 +418,6 @@
           "sync_device_internal_temp": "Synchronize device temperature",
           "lock": "Lock",
           "heating_failure_detection": "Heating failure detection",
-          "auto_tpi_configuration": "Auto TPI - Configuration",
-          "auto_tpi_avg_settings": "Auto TPI - Weighted Average",
-          "auto_tpi_ema_settings": "Auto TPI - EWMA",
           "finalize": "All done",
           "configuration_not_complete": "Configuration not complete"
         }
@@ -427,10 +429,12 @@
           "use_lock_central_config": "Use central lock configuration",
           "lock_code": "Optional pincode (4 digits)",
           "lock_users": "Lock will prevent commands from Users",
-          "lock_automations": "Lock will prevent commands from Automations & integrations (i.e scheduler)"
+          "lock_automations": "Lock will prevent commands from Automations & integrations (i.e scheduler)",
+          "auto_relock_sec": "Auto-relock delay"
         },
         "data_description": {
-          "use_lock_central_config": "Check to use the central lock configuration. Uncheck to use a specific lock configuration for this VTherm"
+          "use_lock_central_config": "Check to use the central lock configuration. Uncheck to use a specific lock configuration for this VTherm",
+          "auto_relock_sec": "Delay in seconds before automatically re-locking after an unlock. Set to 0 to disable auto-relock. Default is 30 seconds."
         }
       },
       "main": {
@@ -530,7 +534,7 @@
           "use_tpi_central_config": "Check to use the central TPI configuration. Uncheck to use a specific TPI configuration for this VTherm",
           "minimal_activation_delay": "Delay in seconds under which the equipment will not be activated",
           "minimal_deactivation_delay": "Delay in seconds under which the equipment will be kept active",
-          "auto_tpi_mode": "Check to enable Auto TPI feature. TPI learning session are manually started, read the doc first."
+          "auto_tpi_mode": "TPI learning session are started manually, read the doc first."
         }
       },
       "presets": {
@@ -683,48 +687,48 @@
       },
       "auto_tpi_configuration": {
         "title": "Auto TPI - Configuration - {name}",
-        "description": "General parameters for Auto TPI learning.",
+        "description": "General settings for Auto TPI learning.",
         "data": {
-          "auto_tpi_enable_update_config": "Update configuration",
-          "auto_tpi_enable_notification": "Notifications",
-          "auto_tpi_keep_ext_learning": "Keep external coefficient learning",
-          "auto_tpi_continuous_learning": "Continuous learning",
-          "heater_heating_time": "Heater warm-up time (min)",
-          "heater_cooling_time": "Heater cool-down time (min)",
-          "auto_tpi_max_coef_int": "Max Internal Coefficient",
-          "auto_tpi_heating_rate": "Heating rate (°C/h)",
-          "auto_tpi_cooling_rate": "Cooling rate (°C/h)"
+          "auto_tpi_learning_type": "Learning Type",
+          "auto_tpi_heating_rate": "Heating Rate ({unit}/h)",
+          "heater_heating_time": "Heating time (min)",
+          "heater_cooling_time": "Cooling time (min)",
+          "auto_tpi_aggressiveness": "Aggressiveness",
+          "auto_tpi_enable_advanced_settings": "Enable Advanced Parameters",
+          "auto_tpi_continuous_kext": "Continuous Kext Learning"
         },
         "data_description": {
-          "auto_tpi_enable_update_config": "Automatically update the configuration with learned coefficients",
-          "auto_tpi_enable_notification": "Send a notification when learning is complete",
-          "auto_tpi_keep_ext_learning": "If set, the external coefficient will continue learning even after reaching 50 cycles, as long as the internal coefficient has not reached stability.",
-          "auto_tpi_continuous_learning": "If set, the system will continue calculating and applying new coefficients silently after learning is finished (EMA method recommended).",
+          "auto_tpi_learning_type": "Choose 'Discovery' for initial startup (Weighted Average, weight 1) or 'Fine Tuning' for continuous adjustments (EWMA, Alpha 0.08).",
+          "auto_tpi_heating_rate": "Radiator temperature rise capacity ({unit} per hour). Leave at 0 for automatic learning (bootstrap).",
           "heater_heating_time": "Time to reach full power (minutes)",
-          "heater_cooling_time": "Time to cool down after stop (minutes)",
-          "auto_tpi_max_coef_int": "Maximum allowed value for the internal coefficient (Coeff Int)"
+          "heater_cooling_time": "Time to cool down after stop (minutes)\n\n| Type | Heating time | Cooling time |\n| :--- | :--- | :--- |\n| Electric radiator | 5mn | 7mn |\n| Water radiator | 15mn | 20mn |\n| Underfloor heating | 30mn | 45mn |",
+          "auto_tpi_aggressiveness": "Reduction factor for learned coefficients (50-100%). Lower values result in more conservative coefficients and reduce overshoot risk.",
+          "auto_tpi_enable_advanced_settings": "Check to modify the parameters of the chosen algorithm.",
+          "auto_tpi_continuous_kext": "Check to enable continuous learning of the external coefficient (Kext) outside of AutoTPI sessions."
         }
       },
       "auto_tpi_avg_settings": {
         "title": "Auto TPI - Weighted Average - {name}",
-        "description": "Parameters for the Average method.",
+        "description": "Parameters for Weighted Average method.",
         "data": {
           "auto_tpi_avg_initial_weight": "Initial Weight"
         },
         "data_description": {
-          "auto_tpi_avg_initial_weight": "Weight of the initial/previous value in the average calculation"
+          "auto_tpi_avg_initial_weight": "Initial weight of existing coefficients in the average calculation (1-50 is typical). Higher weight means slower and more stable learning."
         }
       },
       "auto_tpi_ema_settings": {
         "title": "Auto TPI - EWMA - {name}",
-        "description": "Parameters for the EMA method.\n\nRecommendations:\n| Situation | Alpha (ema_alpha) | Decay Rate (ema_decay_rate) |\n| :--- | :--- | :--- |\n| Initial learning | 0.15 | 0.08 |\n| Fine learning | 0.08 | 0.12 |\n| Continuous learning | 0.05 | 0.02 |",
+        "description": "Parameters for EWMA method.\n\nRecommendations:\n| Situation | Alpha (ema_alpha) | Decay Rate (ema_decay_rate) |\n| :--- | :--- | :--- |\n| Strong adjustments | 0.15 | 0.08 |\n| Fine tuning | 0.08 | 0.12 |",
         "data": {
           "auto_tpi_ema_alpha": "Alpha",
-          "auto_tpi_ema_decay_rate": "Decay Rate"
+          "auto_tpi_ema_decay_rate": "Decay Rate",
+          "auto_tpi_continuous_kext_alpha": "Continuous Kext Alpha"
         },
         "data_description": {
           "auto_tpi_ema_alpha": "Smoothing factor (0-1). Higher = faster adaptation",
-          "auto_tpi_ema_decay_rate": "Rate at which Alpha decreases over time (stabilization)"
+          "auto_tpi_ema_decay_rate": "Rate at which Alpha decreases over time (stabilization)",
+          "auto_tpi_continuous_kext_alpha": "Smoothing factor for continuous Kext learning (Alpha). Default 0.04 (approx 3-5 days adaptation)."
         }
       },
       "heating_failure_detection": {
@@ -759,6 +763,8 @@
       "valve_regulation_nb_entities_incorrect": "The number of valve entities for valve regulation should be equal to the number of underlyings",
       "sync_device_internal_temp_nb_entities_incorrect": "The number of entities for synchronize device internal temperature should be equal to the number of underlyings",
       "min_opening_degrees_format": "A comma separated list of positive integer is expected. Example: 20, 25, 30",
+      "max_opening_degrees_format": "A comma separated list of positive integer between 0 and the max value of the valve is expected. Example: 80, 85, 90",
+      "min_max_opening_degrees_inconsistent": "For each underlying device, max_opening_degrees must be strictly greater than min_opening_degrees. Please check your configuration.",
       "vswitch_configuration_incorrect": "The command customization configuration is incorrect. It is required for underlying entities that are not switches, and the format must be service_name[/attribute:value]. More information is available in the README"
     },
     "abort": {
@@ -823,6 +829,12 @@
       "options": {
         "average": "Average",
         "ema": "Exponential Moving Average (EMA)"
+      }
+    },
+    "auto_tpi_learning_type": {
+      "options": {
+        "discovery": "Discovery",
+        "fine_tuning": "Fine Tuning"
       }
     }
   },

--- a/custom_components/versatile_thermostat/translations/cs.json
+++ b/custom_components/versatile_thermostat/translations/cs.json
@@ -44,11 +44,13 @@
           "use_lock_central_config": "Použít centrální konfiguraci zamknutí",
           "lock_code": "Volitelný PIN (4 číslice)",
           "lock_users": "Zamknutí zabrání příkazům uživatelů",
-          "lock_automations": "Zamknutí zabrání příkazům z automatizací a integrací (např. plánovač)"
+          "lock_automations": "Zamknutí zabrání příkazům z automatizací a integrací (např. plánovač)",
+          "auto_relock_sec": "Automatické opětovné zamknutí"
         },
         "data_description": {
           "use_lock_central_config": "Zaškrtněte pro použití centrální konfigurace zamknutí. Odškrtněte pro použití konfigurace zamknutí specifické pro tento VTherm",
-          "lock_code": "PIN kód pro odemknutí termostatu (4 číslice)"
+          "lock_code": "PIN kód pro odemknutí termostatu (4 číslice)",
+          "auto_relock_sec": "Prodleva v sekundách před automatickým opětovným zamknutím po odemknutí. Nastavte 0 pro deaktivaci. Výchozí hodnota je 30 sekund."
         }
       },
       "main": {
@@ -371,11 +373,13 @@
         "data": {
           "use_lock_central_config": "Použít centrální konfiguraci zamknutí",
           "lock_users": "Zamknutí zabrání příkazům uživatelů",
-          "lock_automations": "Zamknutí zabrání příkazům z automatizací a integrací (např. plánovač)"
+          "lock_automations": "Zamknutí zabrání příkazům z automatizací a integrací (např. plánovač)",
+          "auto_relock_sec": "Automatické opětovné zamknutí"
         },
         "data_description": {
           "use_lock_central_config": "Zaškrtněte pro použití centrální konfigurace zamknutí. Odškrtněte pro použití konfigurace zamknutí specifické pro tento VTherm",
-          "lock_code": "PIN kód pro odemknutí termostatu (4 číslice)"
+          "lock_code": "PIN kód pro odemknutí termostatu (4 číslice)",
+          "auto_relock_sec": "Prodleva v sekundách před automatickým opětovným zamknutím po odemknutí. Nastavte 0 pro deaktivaci. Výchozí hodnota je 30 sekund."
         }
       },
       "main": {

--- a/custom_components/versatile_thermostat/translations/de.json
+++ b/custom_components/versatile_thermostat/translations/de.json
@@ -47,10 +47,12 @@
           "use_lock_central_config": "Zentrale Sperrkonfiguration verwenden",
           "lock_code": "Optionaler PIN-Code (4 Ziffern)",
           "lock_users": "Sperre verhindert Benutzerbefehle",
-          "lock_automations": "Sperre verhindert Befehle von Automatisierungen und Integrationen (z.B. Planer)"
+          "lock_automations": "Sperre verhindert Befehle von Automatisierungen und Integrationen (z.B. Planer)",
+          "auto_relock_sec": "Automatische Wiederverriegelung"
         },
         "data_description": {
-          "use_lock_central_config": "Aktivieren für zentrale Sperrkonfiguration. Deaktivieren für sperrspezifische Konfiguration dieses VTherm"
+          "use_lock_central_config": "Aktivieren für zentrale Sperrkonfiguration. Deaktivieren für sperrspezifische Konfiguration dieses VTherm",
+          "auto_relock_sec": "Verzögerung in Sekunden bevor nach dem Entsperren automatisch wieder verriegelt wird. 0 zum Deaktivieren. Standardwert ist 30 Sekunden."
         }
       },
       "main": {
@@ -423,10 +425,12 @@
           "use_lock_central_config": "Zentrale Sperrkonfiguration verwenden",
           "lock_code": "Optionaler PIN (4 Ziffern)",
           "lock_users": "Sperre verhindert Benutzerbefehle",
-          "lock_automations": "Sperre verhindert Befehle von Automatisierungen und Integrationen (z.B. Planer)"
+          "lock_automations": "Sperre verhindert Befehle von Automatisierungen und Integrationen (z.B. Planer)",
+          "auto_relock_sec": "Automatische Wiederverriegelung"
         },
         "data_description": {
-          "use_lock_central_config": "Aktivieren für zentrale Sperrkonfiguration. Deaktivieren für spezifische Sperrkonfiguration dieses VTherm"
+          "use_lock_central_config": "Aktivieren für zentrale Sperrkonfiguration. Deaktivieren für spezifische Sperrkonfiguration dieses VTherm",
+          "auto_relock_sec": "Verzögerung in Sekunden bevor nach dem Entsperren automatisch wieder verriegelt wird. 0 zum Deaktivieren. Standardwert ist 30 Sekunden."
         }
       },
       "main": {
@@ -677,7 +681,7 @@
           "sync_entity_ids": "Entitie-Liste, die zur Synchronisierung der internen Temperatur der zugeordneten Geräte verwendet werden. Es muss eine pro zugeordnetem Gerät vorhanden sein. Wenn es aktiviert ist, muss eine Kalibrierungsentität vorhanden sein, ansonsten eine Temperaturentity. Beides sind Entities vom Typ `number`."
         }
       },
-       "auto_tpi_configuration": {
+      "auto_tpi_configuration": {
         "title": "Auto TPI - Konfiguration - {name}",
         "description": "Allgemeine Parameter für das Auto-TPI-Lernen.",
         "data": {
@@ -811,13 +815,13 @@
         "auto_start_stop_slow": "Langsam",
         "auto_start_stop_medium": "Mittel",
         "auto_start_stop_fast": "Schnell"
-       }
+      }
     },
     "auto_tpi_calculation_method": {
       "options": {
         "average": "Durchschnitt",
         "ema": "Exponentialer gleitender Durchschnitt (EMA)"
-     }
+      }
     },
     "auto_tpi_learning_type": {
       "options": {

--- a/custom_components/versatile_thermostat/translations/en.json
+++ b/custom_components/versatile_thermostat/translations/en.json
@@ -47,10 +47,12 @@
                     "use_lock_central_config": "Use central lock configuration",
                     "lock_code": "Optional pincode (4 digits)",
                     "lock_users": "Lock will prevent commands from Users",
-                    "lock_automations": "Lock will prevent commands from Automations & integrations (i.e scheduler)"
+                    "lock_automations": "Lock will prevent commands from Automations & integrations (i.e scheduler)",
+                    "auto_relock_sec": "Auto-relock delay"
                 },
                 "data_description": {
-                    "use_lock_central_config": "Check to use the central lock configuration. Uncheck to use a specific lock configuration for this VTherm"
+                    "use_lock_central_config": "Check to use the central lock configuration. Uncheck to use a specific lock configuration for this VTherm",
+                    "auto_relock_sec": "Delay in seconds before automatically re-locking after an unlock. Set to 0 to disable auto-relock. Default is 30 seconds."
                 }
             },
             "main": {
@@ -427,10 +429,12 @@
                     "use_lock_central_config": "Use central lock configuration",
                     "lock_code": "Optional pincode (4 digits)",
                     "lock_users": "Lock will prevent commands from Users",
-                    "lock_automations": "Lock will prevent commands from Automations & integrations (i.e scheduler)"
+                    "lock_automations": "Lock will prevent commands from Automations & integrations (i.e scheduler)",
+                    "auto_relock_sec": "Auto-relock delay"
                 },
                 "data_description": {
-                    "use_lock_central_config": "Check to use the central lock configuration. Uncheck to use a specific lock configuration for this VTherm"
+                    "use_lock_central_config": "Check to use the central lock configuration. Uncheck to use a specific lock configuration for this VTherm",
+                    "auto_relock_sec": "Delay in seconds before automatically re-locking after an unlock. Set to 0 to disable auto-relock. Default is 30 seconds."
                 }
             },
             "main": {

--- a/custom_components/versatile_thermostat/translations/fr.json
+++ b/custom_components/versatile_thermostat/translations/fr.json
@@ -47,11 +47,13 @@
           "use_lock_central_config": "Utiliser la configuration de verrouillage centrale",
           "lock_code": "Code PIN optionnel (4 chiffres)",
           "lock_users": "Le verrouillage empêchera les commandes des utilisateurs",
-          "lock_automations": "Le verrouillage empêchera les commandes des automatisations et des intégrations (ex: planificateur)"
+          "lock_automations": "Le verrouillage empêchera les commandes des automatisations et des intégrations (ex: planificateur)",
+          "auto_relock_sec": "Délai de re-verrouillage automatique"
         },
         "data_description": {
           "use_lock_central_config": "Cochez pour utiliser la configuration de verrouillage centrale. Décochez pour utiliser une configuration de verrouillage spécifique pour ce VTherm",
-          "lock_code": "Le code pin pour déverouiller le thermostat (4 digits)"
+          "lock_code": "Le code pin pour déverouiller le thermostat (4 digits)",
+          "auto_relock_sec": "Délai en secondes avant le re-verrouillage automatique après un déverrouillage. Mettre 0 pour désactiver. La valeur par défaut est 30 secondes."
         }
       },
       "main": {
@@ -428,11 +430,13 @@
           "use_lock_central_config": "Utiliser la configuration de verrouillage centrale",
           "lock_code": "Code pin optionel (4 chiffres)",
           "lock_users": "Le verrouillage empêchera les commandes des utilisateurs",
-          "lock_automations": "Le verrouillage empêchera les commandes des automatisations et des intégrations (ex: planificateur)"
+          "lock_automations": "Le verrouillage empêchera les commandes des automatisations et des intégrations (ex: planificateur)",
+          "auto_relock_sec": "Délai de re-verrouillage automatique"
         },
         "data_description": {
           "use_lock_central_config": "Cochez pour utiliser la configuration de verrouillage centrale. Décochez pour utiliser une configuration de verrouillage spécifique pour ce VTherm",
-          "lock_code": "Le code PIN pour déverrouiller le thermostat (4 chiffres)"
+          "lock_code": "Le code PIN pour déverrouiller le thermostat (4 chiffres)",
+          "auto_relock_sec": "Délai en secondes avant le re-verrouillage automatique après un déverrouillage. Mettre 0 pour désactiver. La valeur par défaut est 30 secondes."
         }
       },
       "main": {

--- a/custom_components/versatile_thermostat/translations/pl.json
+++ b/custom_components/versatile_thermostat/translations/pl.json
@@ -44,10 +44,12 @@
           "use_lock_central_config": "Użyj centralnej konfiguracji blokady",
           "lock_code": "Opcjonalny kod PIN (4 cyfry)",
           "lock_users": "Blokada uniemożliwi wykonywanie poleceń użytkowników",
-          "lock_automations": "Blokada uniemożliwi wykonywanie poleceń przez automatyzacje i integracje (np. harmonogram)"
+          "lock_automations": "Blokada uniemożliwi wykonywanie poleceń przez automatyzacje i integracje (np. harmonogram)",
+          "auto_relock_sec": "Automatyczne ponowne zablokowanie"
         },
         "data_description": {
-          "use_lock_central_config": "Zaznacz, aby używać centralnej konfiguracji blokady. Odznacz, aby używać konfiguracji blokady dedykowanej dla tego termostatu VTherm"
+          "use_lock_central_config": "Zaznacz, aby używać centralnej konfiguracji blokady. Odznacz, aby używać konfiguracji blokady dedykowanej dla tego termostatu VTherm",
+          "auto_relock_sec": "Opóźnienie w sekundach przed automatycznym ponownym zablokowaniem po odblokowaniu. Ustaw 0, aby wyłączyć. Domyślna wartość to 30 sekund."
         }
       },
       "main": {
@@ -381,10 +383,12 @@
           "use_lock_central_config": "Użyj centralnej konfiguracji blokady",
           "lock_code": "Opcjonalny kod PIN (4 cyfry)",
           "lock_users": "Blokada uniemożliwi polecenia użytkowników",
-          "lock_automations": "Blokada uniemożliwi polecenia z automatyzacji i integracji (np. harmonogram)"
+          "lock_automations": "Blokada uniemożliwi polecenia z automatyzacji i integracji (np. harmonogram)",
+          "auto_relock_sec": "Automatyczne ponowne zablokowanie"
         },
         "data_description": {
-          "use_lock_central_config": "Zaznacz aby używać centralnej konfiguracji blokady. Odznacz aby używać konfiguracji blokady specyficznej dla tego VTherm"
+          "use_lock_central_config": "Zaznacz aby używać centralnej konfiguracji blokady. Odznacz aby używać konfiguracji blokady specyficznej dla tego VTherm",
+          "auto_relock_sec": "Opóźnienie w sekundach przed automatycznym ponownym zablokowaniem po odblokowaniu. Ustaw 0, aby wyłączyć. Domyślna wartość to 30 sekund."
         }
       },
       "main": {

--- a/documentation/cs/feature-lock.md
+++ b/documentation/cs/feature-lock.md
@@ -15,6 +15,10 @@ Můžete také nakonfigurovat volitelný **Kód zámku**:
 
 - **Kód zámku**: 4-místný číselný PIN (např. "1234"). Pokud je nastaven, tento kód je vyžadován pro zamknutí/odemknutí termostatu. Toto je volitelné a pokud není nakonfigurováno, není vyžadován žádný kód.
 
+Můžete nakonfigurovat zpoždění **automatického opětovného zamknutí**:
+
+- **Zpoždění automatického opětovného zamknutí (sekundy)**: Pokud je nastavena kladná hodnota, termostat se automaticky znovu zamkne po uplynutí zadaného počtu sekund po odemknutí. Nastavte `0` pro deaktivaci automatického opětovného zamknutí. Výchozí hodnota je `30` sekund.
+
 Můžete si také vybrat použití centrální konfigurace pro nastavení zámku.
 
 ## Použití
@@ -46,7 +50,7 @@ data:
 
 Stav zámku je:
 
-- Viditelný v atributech `is_locked`, `lock_users` a `lock_automations` klimatizační entity
+- Viditelný v atributech `is_locked`, `lock_users`, `lock_automations` a `auto_relock_sec` klimatizační entity
 - Zachován při restartu Home Assistant (včetně PIN kódu pokud nastaveno)
 - Pro každý termostat zvlášť (každý termostat má svůj vlastní zámek a volitelný PIN kód)
 

--- a/documentation/de/feature-lock.md
+++ b/documentation/de/feature-lock.md
@@ -15,6 +15,10 @@ Sie können auch einen optionalen **Sperrcode** konfigurieren:
 
 - **Sperrcode**: Ein 4-stelliger numerischer PIN-Code (z. B. "1234"). Wenn gesetzt, ist dieser Code erforderlich, um den Thermostat zu sperren/zu entsperren. Dies ist optional und wenn nicht konfiguriert, ist kein Code erforderlich.
 
+Sie können eine **automatische Wiederverriegelungs**-Verzögerung konfigurieren:
+
+- **Automatische Wiederverriegelungs-Verzögerung (Sekunden)**: Bei einem positiven Wert verriegelt sich der Thermostat nach dem angegebenen Verzögerungszeitraum nach dem Entsperren automatisch wieder. Auf `0` setzen, um die automatische Wiederverriegelung zu deaktivieren. Der Standardwert ist `30` Sekunden.
+
 Sie können auch eine zentrale Konfiguration für die Sperreinstellungen verwenden.
 
 ## Verwendung
@@ -46,7 +50,7 @@ data:
 
 Der Sperrzustand ist:
 
-- Sichtbar in den Attributen `is_locked`, `lock_users` und `lock_automations` der Klimaentität
+- Sichtbar in den Attributen `is_locked`, `lock_users`, `lock_automations` und `auto_relock_sec` der Klimaentität
 - Wird bei Neustarts von Home Assistant beibehalten (einschließlich PIN-Code, falls gesetzt)
 - Pro Thermostat (jeder Thermostat hat seine eigene Sperre und optionalen PIN-Code)
 

--- a/documentation/en/feature-lock.md
+++ b/documentation/en/feature-lock.md
@@ -15,6 +15,10 @@ You can also configure an optional **Lock Code**:
 
 - **Lock Code**: A 4-digit numeric pincode (e.g., "1234"). If set, this code is required to lock/unlock the thermostat. This is optional and if not configured, no code is required.
 
+You can configure an **Auto-Relock** delay:
+
+- **Auto-Relock Delay (seconds)**: When set to a positive value, the thermostat will automatically re-lock after the specified number of seconds following an unlock. Set to `0` to disable auto-relock. The default is `30` seconds.
+
 You can also choose to use a central configuration for the lock settings.
 
 ## Usage
@@ -46,7 +50,7 @@ data:
 
 The lock state is:
 
-- Visible in the `is_locked`, `lock_users`, and `lock_automations` attributes of the climate entity
+- Visible in the `is_locked`, `lock_users`, `lock_automations`, and `auto_relock_sec` attributes of the climate entity
 - Preserved across Home Assistant restarts (including the pincode if set)
 - Per-thermostat (each thermostat has its own lock and optional pincode)
 

--- a/documentation/fr/feature-lock.md
+++ b/documentation/fr/feature-lock.md
@@ -46,7 +46,7 @@ data:
 
 L'état de verrouillage est :
 
-- Visible dans les attributs `is_locked`, `lock_users` et `lock_automations` de l'entité climat.
+- Visible dans les attributs `is_locked`, `lock_users`, `lock_automations` et `auto_relock_sec` de l'entité climat.
 - Conservé lors des redémarrages de Home Assistant (y compris le code PIN si défini).
 - Spécifique à chaque thermostat (chaque thermostat a son propre verrou et code PIN optionnel).
 

--- a/documentation/pl/feature-lock.md
+++ b/documentation/pl/feature-lock.md
@@ -15,6 +15,10 @@ Możesz również skonfigurować opcjonalny **Kod blokady**:
 
 - **Kod blokady**: 4-cyfrowy numeryczny `kod PIN` (np. '1234'). Jeśli kod został ustawiony, wówczas będzie on wymagany do blokowania i odblokowywania termostatu. Jest to opcjonalna funkcjonalność, zatem w przypadku braku jej konfiguracji, żaden kod nie będzie wymagany.
 
+Możesz skonfigurować opóźnienie **automatycznego ponownego zablokowania**:
+
+- **Opóźnienie automatycznego ponownego zablokowania (sekundy)**: Gdy ustawiona jest wartość dodatnia, termostat automatycznie ponownie się zablokuje po upływie określonej liczby sekund po odblokowaniu. Ustaw `0`, aby wyłączyć automatyczne ponowne blokowanie. Domyślna wartość to `30` sekund.
+
 Możesz również wybrać centralną konfigurację dla ustawień blokady.
 
 ## Sposoby użycia
@@ -46,7 +50,7 @@ data:
 
 Stan blokady jest:
 
-- Widoczny w atrybutach `is_locked`, `lock_users` i `lock_automations` encji klimatyzacji (`climate`)
+- Widoczny w atrybutach `is_locked`, `lock_users`, `lock_automations` i `auto_relock_sec` encji klimatyzacji (`climate`)
 - Zachowywany po ponownym uruchomieniu Home Assistanta (w tym kod PIN, jeśli został wcześniej ustawiony)
 - Indywidualny dla każdego termostatu (każdy termostat ma swoją własną blokadę i opcjonalny kod PIN)
 

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -13,6 +13,7 @@ from custom_components.versatile_thermostat.const import (
     CONF_LOCK_USERS,
     CONF_LOCK_AUTOMATIONS,
     CONF_LOCK_CODE,
+    CONF_AUTO_RELOCK_SEC,
     SERVICE_LOCK,
     SERVICE_UNLOCK,
 )
@@ -27,6 +28,7 @@ async def setup_thermostat(
     lock_users: bool,
     lock_automations: bool,
     lock_code: str | None = None,
+    auto_relock_sec: int = 0,
 ):
     """Setup the thermostat with the given lock configuration"""
     entry = MockConfigEntry(
@@ -57,6 +59,7 @@ async def setup_thermostat(
             CONF_LOCK_USERS: lock_users,
             CONF_LOCK_AUTOMATIONS: lock_automations,
             CONF_LOCK_CODE: lock_code,
+            CONF_AUTO_RELOCK_SEC: auto_relock_sec,
         },
     )
 
@@ -270,3 +273,75 @@ async def test_lock_state_persistence(hass: HomeAssistant, skip_hass_states_is_s
     )
     entity.lock_manager.restore_state(old_state)
     assert entity.lock_manager.is_locked is False  # No change on lock state
+
+
+@pytest.mark.parametrize("expected_lingering_tasks", [True])
+@pytest.mark.parametrize("expected_lingering_timers", [True])
+async def test_auto_relock_with_delay(hass: HomeAssistant, skip_hass_states_is_state):
+    """Test that auto-relock triggers after the configured delay when unlocking."""
+    entity = await setup_thermostat(hass, True, True, None, auto_relock_sec=30)
+    assert entity
+    assert entity.lock_manager._auto_relock_sec == 30
+
+    # Lock the thermostat first
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_LOCK,
+        {ATTR_ENTITY_ID: "climate.theoverswitchmockname"},
+        blocking=True,
+    )
+    assert entity.lock_manager.is_locked is True
+
+    cancel_mock = MagicMock()
+    with patch(
+        "custom_components.versatile_thermostat.feature_lock_manager.async_call_later",
+        return_value=cancel_mock,
+    ) as mock_call_later:
+        # Unlock should schedule auto-relock
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_UNLOCK,
+            {ATTR_ENTITY_ID: "climate.theoverswitchmockname"},
+            blocking=True,
+        )
+        assert entity.lock_manager.is_locked is False
+        mock_call_later.assert_called_once()
+
+        # Simulate timer expiration by calling the callback directly
+        callback = mock_call_later.call_args[0][2]
+
+    callback(None)
+    assert entity.lock_manager.is_locked is True
+    assert entity.lock_manager._cancel_auto_relock is None
+
+
+@pytest.mark.parametrize("expected_lingering_tasks", [True])
+@pytest.mark.parametrize("expected_lingering_timers", [True])
+async def test_auto_relock_disabled_with_zero_delay(hass: HomeAssistant, skip_hass_states_is_state):
+    """Test that auto-relock is not scheduled when auto_relock_sec is 0."""
+    entity = await setup_thermostat(hass, True, True, None, auto_relock_sec=0)
+    assert entity
+    assert entity.lock_manager._auto_relock_sec == 0
+
+    # Lock the thermostat first
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_LOCK,
+        {ATTR_ENTITY_ID: "climate.theoverswitchmockname"},
+        blocking=True,
+    )
+    assert entity.lock_manager.is_locked is True
+
+    with patch(
+        "custom_components.versatile_thermostat.feature_lock_manager.async_call_later",
+    ) as mock_call_later:
+        # Unlock should NOT schedule auto-relock when delay is 0
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_UNLOCK,
+            {ATTR_ENTITY_ID: "climate.theoverswitchmockname"},
+            blocking=True,
+        )
+        assert entity.lock_manager.is_locked is False
+        mock_call_later.assert_not_called()
+


### PR DESCRIPTION
Add `auto_relock_sec` parameter to the lock feature. When set to a positive value, the thermostat automatically re-locks after the specified number of seconds following an unlock. Set to 0 to disable. Default is 30 seconds.

- Add CONF_AUTO_RELOCK_SEC constant
- Update STEP_CENTRAL_LOCK_DATA_SCHEMA with new field (default: 30)
- Implement timer in FeatureLockManager using async_call_later + @callback
- Expose auto_relock_sec in entity attributes
- Add unit tests (with delay, with zero delay)
- Update translations EN/FR/CS/DE/PL
- Update feature-lock documentation in all languages