### PR TITLE
Fix naive/aware datetime comparison in fan mode command throttling

### DIFF
--- a/custom_components/versatile_thermostat/underlyings.py
+++ b/custom_components/versatile_thermostat/underlyings.py
@@ -203,7 +203,7 @@ class UnderlyingEntity:
         try:
             response: ServiceResponse = await self._hass.services.async_call(domain, service, service_data, blocking, context, target, return_response)
 
-            self._last_command_sent_datetime = dt_util.utcnow()
+            self._last_command_sent_datetime = self._thermostat.now
             return response
         except Exception as err:
             _LOGGER.error("Error calling service %s.%s: %s. The underlying will not change its state.", domain, service, err)
@@ -739,7 +739,7 @@ class UnderlyingClimate(UnderlyingEntity):
             self._cancel_set_fan_mode_later = None
 
         delay: float = 2.0
-        now = dt_util.utcnow()
+        now = self._thermostat.now
         last_command_sent = self._last_command_sent_datetime
 
         if now > last_command_sent + timedelta(seconds=delay):


### PR DESCRIPTION
This fixes a datetime type mismatch in `underlyings.py`.

`set_fan_mode()` compares the current time against `_last_command_sent_datetime` to rate-limit consecutive commands. In some situations these two values are not the same datetime kind (offset-aware vs offset-naive), which causes Python to raise:

```
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/websocket_api/commands.py", line 279, in handle_call_service
    response = await hass.services.async_call(...)
  File "/usr/src/homeassistant/homeassistant/core.py", line 2817, in async_call
    response_data = await coro
  File "/usr/src/homeassistant/homeassistant/core.py", line 2860, in _execute_service
    return await target(service_call)
  File "/usr/src/homeassistant/homeassistant/helpers/service.py", line 835, in entity_service_call
    single_response = await _handle_entity_call(...)
  File "/usr/src/homeassistant/homeassistant/helpers/service.py", line 907, in _handle_entity_call
    result = await task
  File "/usr/src/homeassistant/homeassistant/components/climate/__init__.py", line 570, in async_handle_set_fan_mode_service
    await self.async_set_fan_mode(fan_mode)
  File "/config/custom_components/versatile_thermostat/thermostat_climate.py", line 1174, in async_set_fan_mode
    await under.set_fan_mode(fan_mode)
  File "/config/custom_components/versatile_thermostat/underlyings.py", line 700, in set_fan_mode
    if self._thermostat.now > self._last_command_sent_datetime + timedelta(seconds=delay):
TypeError: can't compare offset-naive and offset-aware datetimes

```