### PR TITLE
Fix: Do not try to calculate on_pecent if temperature not available

### DIFF
--- a/custom_components/versatile_thermostat/thermostat_climate_valve.py
+++ b/custom_components/versatile_thermostat/thermostat_climate_valve.py
@@ -259,6 +259,9 @@ class ThermostatOverClimateValve(ThermostatProp[UnderlyingClimate], ThermostatOv
             new_valve_percent = 100
         else:
             on_percent = self.safe_on_percent
+            if on_percent is None:
+                # Temperature not yet available; preserve the current valve position.
+                return
             new_valve_percent = round(max(0, min(on_percent, 1)) * 100)
 
             # Issue 533 - don't filter with dtemp if valve should be close. Else it will never close


### PR DESCRIPTION
Fixes Errors after V9.3.0 update Fixes #1902

## Summary

After updating to V9.3.0, users with a VTherm of type `over_climate_valve` observe repeated `TypeError` exceptions in the logs every time the room temperature or outdoor temperature sensor fires an event. The thermostat continues to function after startup, but the errors are logged in bulk at boot time.

---

## Exact Error

```
TypeError: '<' not supported between instances of 'int' and 'NoneType'
```

Full traceback (repeated for every temperature sensor event on every `over_climate_valve` VTherm):

```
File "thermostat_climate.py", line 862, in _async_temperature_changed
    ret = await super()._async_temperature_changed(event)
File "base_thermostat.py", line 1865, in _async_temperature_changed
    self.recalculate()
File "thermostat_climate_valve.py", line 262, in recalculate
    new_valve_percent = round(max(0, min(on_percent, 1)) * 100)
                                     ~~~^^^^^^^^^^^^^^^
TypeError: '<' not supported between instances of 'int' and 'NoneType'
```

---

## Root Cause: Missing `None`-guard in `thermostat_climate_valve.recalculate()`

In [`thermostat_climate_valve.recalculate()`](custom_components/versatile_thermostat/thermostat_climate_valve.py:261):

```python
on_percent = self.safe_on_percent
new_valve_percent = round(max(0, min(on_percent, 1)) * 100)  # ← crashes when on_percent is None
```

The sibling class [`thermostat_valve.py`](custom_components/versatile_thermostat/thermostat_valve.py:210) **already has the correct guard**:

```python
current_on_percent = self.safe_on_percent
if current_on_percent is None:
    # Temperature not yet available; preserve the current valve position.
    return
```

This guard was **never added** to `thermostat_climate_valve.recalculate()`, making it the direct, immediate cause of the crash.
