### PR TITLE
Fix false power shedding on VTherm startup with multiple underlyings

### DIFF
--- a/custom_components/versatile_thermostat/feature_central_power_manager.py
+++ b/custom_components/versatile_thermostat/feature_central_power_manager.py
@@ -50,7 +50,7 @@ class FeatureCentralPowerManager(BaseFeatureManager):
         self._current_max_power: float | None = None
         self._power_temp: float | None = None
         self._cancel_calculate_shedding_call = None
-        self._started_vtherm_total_power: float = 0
+        self._started_vtherm_total_power_by_id: dict[str, float] = {}
         # Not used now
         self._last_shedding_date = None
         self._state = False
@@ -76,7 +76,7 @@ class FeatureCentralPowerManager(BaseFeatureManager):
             and self._power_temp
         ):
             self._is_configured = True
-            self._started_vtherm_total_power = 0
+            self._started_vtherm_total_power_by_id = {}
         else:
             _LOGGER.info("%s - Power management is not fully configured and will be deactivated", self)
 
@@ -108,7 +108,7 @@ class FeatureCentralPowerManager(BaseFeatureManager):
         """Handle power changes."""
         write_event_log(_LOGGER, self, f"Receive power sensor state {event.data.get('new_state').state if event.data.get('new_state') else None}")
 
-        self._started_vtherm_total_power = 0
+        self._started_vtherm_total_power_by_id = {}
         await self.refresh_state()
 
     @callback
@@ -298,8 +298,30 @@ class FeatureCentralPowerManager(BaseFeatureManager):
     def add_started_vtherm_total_power(self, started_power: float):
         """Add the power into the _started_vtherm_total_power which holds all VTherm started after
         the last power measurement"""
-        self._started_vtherm_total_power += started_power
-        _LOGGER.debug("%s - started_vtherm_total_power is now %s", self, self._started_vtherm_total_power)
+        self.set_started_vtherm_power("__legacy__", self.get_started_vtherm_power("__legacy__") + started_power)
+
+    def get_started_vtherm_power(self, vtherm_id: str) -> float:
+        """Return the reserved started power for a given VTherm."""
+        return self._started_vtherm_total_power_by_id.get(vtherm_id, 0.0)
+
+    def set_started_vtherm_power(self, vtherm_id: str, started_power: float):
+        """Set the temporary reserved power for a given VTherm.
+
+        This reservation is used between two power sensor measurements to avoid
+        allowing several thermostats to start simultaneously based on the same
+        stale sensor reading.
+        """
+        if started_power > 0:
+            self._started_vtherm_total_power_by_id[vtherm_id] = started_power
+        else:
+            self._started_vtherm_total_power_by_id.pop(vtherm_id, None)
+
+        _LOGGER.debug(
+            "%s - started_vtherm_total_power is now %s (%s)",
+            self,
+            self.started_vtherm_total_power,
+            self._started_vtherm_total_power_by_id,
+        )
 
     @property
     def is_configured(self) -> bool:
@@ -334,7 +356,7 @@ class FeatureCentralPowerManager(BaseFeatureManager):
     @property
     def started_vtherm_total_power(self) -> float | None:
         """Return the started_vtherm_total_power"""
-        return self._started_vtherm_total_power
+        return sum(self._started_vtherm_total_power_by_id.values())
 
     @property
     def is_detected(self) -> bool:

--- a/custom_components/versatile_thermostat/feature_power_manager.py
+++ b/custom_components/versatile_thermostat/feature_power_manager.py
@@ -137,6 +137,7 @@ class FeaturePowerManager(BaseFeatureManager):
         current_power = vtherm_api.central_power_manager.current_power
         current_max_power = vtherm_api.central_power_manager.current_max_power
         started_vtherm_total_power = vtherm_api.central_power_manager.started_vtherm_total_power
+        current_vtherm_started_power = vtherm_api.central_power_manager.get_started_vtherm_power(self._vtherm_power_key)
         if (
             current_power is None
             or current_max_power is None
@@ -156,15 +157,26 @@ class FeaturePowerManager(BaseFeatureManager):
         )
 
         power_consumption_max = self.calculate_power_consumption_max()
+        additional_power = max(
+            0,
+            power_consumption_max - current_vtherm_started_power,
+        )
 
-        ret = (current_power + started_vtherm_total_power + power_consumption_max) < current_max_power
+        ret = (
+            current_power
+            + started_vtherm_total_power
+            - current_vtherm_started_power
+            + power_consumption_max
+        ) < current_max_power
         if not ret:
             _LOGGER.info(
-                "%s - there is not enough power available power=%.3f, max_power=%.3f started_power=%.3f heater power=%.3f",
+                "%s - there is not enough power available power=%.3f, max_power=%.3f started_power=%.3f current_vtherm_started_power=%.3f additional_power=%.3f heater power=%.3f",
                 self,
                 current_power,
                 current_max_power,
                 started_vtherm_total_power,
+                current_vtherm_started_power,
+                additional_power,
                 self._device_power,
             )
 
@@ -196,7 +208,10 @@ class FeaturePowerManager(BaseFeatureManager):
 
         power_consumption_max = self.calculate_power_consumption_max()
 
-        vtherm_api.central_power_manager.add_started_vtherm_total_power(power_consumption_max)
+        vtherm_api.central_power_manager.set_started_vtherm_power(
+            self._vtherm_power_key,
+            power_consumption_max,
+        )
 
     def sub_power_consumption_to_central_power_manager(self):
         """
@@ -206,20 +221,10 @@ class FeaturePowerManager(BaseFeatureManager):
         if not self._is_configured or not vtherm_api.central_power_manager.is_configured:
             return
 
-        power_consumption_max = 0
-        if self._vtherm.is_device_active:
-            if self._vtherm.is_over_climate:
-                power_consumption_max = self._device_power
-            else:
-                # if on_percent is not defined, we consider that the device can consume all its power in the worst case
-                on_percent = self._vtherm.safe_on_percent if self._vtherm.safe_on_percent is not None else 1
-
-                power_consumption_max = max(
-                    self._device_power / self._vtherm.nb_underlying_entities,
-                    self._device_power * on_percent,
-                )
-
-        vtherm_api.central_power_manager.add_started_vtherm_total_power(-power_consumption_max)
+        vtherm_api.central_power_manager.set_started_vtherm_power(
+            self._vtherm_power_key,
+            0,
+        )
 
     async def set_overpowering(self, overpowering: bool, power_consumption_max: float = 0):
         """Force the overpowering state for the VTherm"""
@@ -317,6 +322,11 @@ class FeaturePowerManager(BaseFeatureManager):
             return self._device_power if self._vtherm.is_device_active else 0.0
 
         return None
+
+    @property
+    def _vtherm_power_key(self) -> str:
+        """Return a stable key for temporary power reservations."""
+        return getattr(self._vtherm, "entity_id", None) or self._vtherm.name
 
     def __str__(self):
         return f"PowerManager-{self.name}"

--- a/tests/test_power.py
+++ b/tests/test_power.py
@@ -144,6 +144,73 @@ async def test_power_feature_manager(
             assert power_consumption_max == 1234
 
 
+async def test_power_feature_manager_reserves_startup_power_only_once_for_multi_underlyings(
+    hass: HomeAssistant,
+):
+    """A multi-underlying VTherm must reserve its startup power only once.
+
+    This prevents false shedding when several underlyings start during the same
+    startup sequence before Home Assistant has updated their states.
+    """
+
+    fake_vtherm = MagicMock(spec=BaseThermostat)
+    fake_vtherm.entity_id = "climate.theoverswitchmockname"
+    type(fake_vtherm).name = PropertyMock(return_value="the name")
+    type(fake_vtherm).is_device_active = PropertyMock(return_value=False)
+    type(fake_vtherm).is_over_climate = PropertyMock(return_value=False)
+    type(fake_vtherm).nb_underlying_entities = PropertyMock(return_value=4)
+    type(fake_vtherm).safe_on_percent = PropertyMock(return_value=1.0)
+    fake_vtherm.async_get_last_state = AsyncMock(return_value=None)
+
+    vtherm_api: VersatileThermostatAPI = VersatileThermostatAPI.get_vtherm_api(hass)
+    power_manager = FeaturePowerManager(fake_vtherm, hass)
+
+    vtherm_api.find_central_configuration = MagicMock()
+    vtherm_api.central_power_manager.post_init(
+        {
+            CONF_POWER_SENSOR: "sensor.the_power_sensor",
+            CONF_MAX_POWER_SENSOR: "sensor.the_max_power_sensor",
+            CONF_USE_POWER_FEATURE: True,
+            CONF_PRESET_POWER: 13,
+        }
+    )
+    vtherm_api.central_power_manager._current_power = 50
+    vtherm_api.central_power_manager._current_max_power = 160
+
+    power_manager.post_init(
+        {
+            CONF_USE_POWER_FEATURE: True,
+            CONF_PRESET_POWER: 10,
+            CONF_DEVICE_POWER: 100,
+        }
+    )
+
+    await power_manager.start_listening()
+
+    ret, power_consumption_max = await power_manager.check_power_available()
+    assert ret is True
+    assert power_consumption_max == 100
+
+    power_manager.add_power_consumption_to_central_power_manager()
+    assert vtherm_api.central_power_manager.started_vtherm_total_power == 100
+
+    # Simulate the next underlying starting before HA has reflected the first ON state.
+    ret, power_consumption_max = await power_manager.check_power_available()
+    assert ret is True
+    assert power_consumption_max == 100
+
+    power_manager.add_power_consumption_to_central_power_manager()
+    assert vtherm_api.central_power_manager.started_vtherm_total_power == 100
+
+    type(fake_vtherm).is_device_active = PropertyMock(return_value=True)
+    power_manager.sub_power_consumption_to_central_power_manager()
+    assert vtherm_api.central_power_manager.started_vtherm_total_power == 0
+
+    # Releasing the reservation multiple times must stay idempotent as well.
+    power_manager.sub_power_consumption_to_central_power_manager()
+    assert vtherm_api.central_power_manager.started_vtherm_total_power == 0
+
+
 @pytest.mark.parametrize(
     "current_overpowering_state, is_overpowering, new_overpowering_state, msg_sent",
     [


### PR DESCRIPTION
The power shedding logic could incorrectly trigger when a single VTherm controls multiple underlyings.

Root cause: during a startup sequence, each underlying turn_on() path called the temporary startup power reservation logic, but the reserved value was computed at VTherm scope. In a multi-underlying setup, if several underlyings started before Home Assistant had reflected the first ON state, the same VTherm startup power could be reserved multiple times.

This led to:
- false "not enough power available" detection when starting a VTherm with multiple underlyings,
- erroneous transition to power shedding even though the meter still had enough available power,
- possible lingering shedding afterwards until the next central power sensor update recalculated the state.

Changes:
- replace the temporary started power accumulator with a per-VTherm reservation map in the central power manager,
- make startup power reservation idempotent per VTherm during a sensor update window,
- make startup power release idempotent as well,
- keep the central behavior of clearing temporary reservations on the next power sensor change.

Tests:
- add a regression test proving that a multi-underlying VTherm reserves its startup power only once even if several underlyings start in the same startup sequence before HA state catches up,
- keep existing power management and multi-switch power tests passing.

This fixes the main false shedding scenario observed on startup for multi-underlying VTherms, without changing the overall shedding strategy.