### PR TITLE
Fix startup power reservation for multi-underlying VTherms

### DIFF
--- a/custom_components/versatile_thermostat/feature_central_power_manager.py
+++ b/custom_components/versatile_thermostat/feature_central_power_manager.py
@@ -295,26 +295,21 @@ class FeatureCentralPowerManager(BaseFeatureManager):
         vtherms.sort(key=cmp_to_key(cmp_temps))
         return vtherms
 
-    def add_started_vtherm_total_power(self, started_power: float):
-        """Add the power into the _started_vtherm_total_power which holds all VTherm started after
-        the last power measurement"""
-        self.set_started_vtherm_power("__legacy__", self.get_started_vtherm_power("__legacy__") + started_power)
+    def get_started_vtherm_power(self, reservation_key: str) -> float:
+        """Return the reserved started power for a given underlying key."""
+        return self._started_vtherm_total_power_by_id.get(reservation_key, 0.0)
 
-    def get_started_vtherm_power(self, vtherm_id: str) -> float:
-        """Return the reserved started power for a given VTherm."""
-        return self._started_vtherm_total_power_by_id.get(vtherm_id, 0.0)
-
-    def set_started_vtherm_power(self, vtherm_id: str, started_power: float):
-        """Set the temporary reserved power for a given VTherm.
+    def set_started_vtherm_power(self, reservation_key: str, started_power: float):
+        """Set the temporary reserved power for a given underlying key.
 
         This reservation is used between two power sensor measurements to avoid
-        allowing several thermostats to start simultaneously based on the same
+        allowing several underlyings to start simultaneously based on the same
         stale sensor reading.
         """
         if started_power > 0:
-            self._started_vtherm_total_power_by_id[vtherm_id] = started_power
+            self._started_vtherm_total_power_by_id[reservation_key] = started_power
         else:
-            self._started_vtherm_total_power_by_id.pop(vtherm_id, None)
+            self._started_vtherm_total_power_by_id.pop(reservation_key, None)
 
         _LOGGER.debug(
             "%s - started_vtherm_total_power is now %s (%s)",

--- a/custom_components/versatile_thermostat/feature_power_manager.py
+++ b/custom_components/versatile_thermostat/feature_power_manager.py
@@ -121,7 +121,7 @@ class FeaturePowerManager(BaseFeatureManager):
                 }
             )
 
-    async def check_power_available(self) -> bool:
+    async def check_power_available(self, reservation_key: str | None = None) -> bool:
         """Check if the Vtherm can be started considering overpowering.
         Returns True if no overpowering conditions are found.
         If True the vtherm power is written into the temporay vtherm started
@@ -137,7 +137,9 @@ class FeaturePowerManager(BaseFeatureManager):
         current_power = vtherm_api.central_power_manager.current_power
         current_max_power = vtherm_api.central_power_manager.current_max_power
         started_vtherm_total_power = vtherm_api.central_power_manager.started_vtherm_total_power
-        current_vtherm_started_power = vtherm_api.central_power_manager.get_started_vtherm_power(self._vtherm_power_key)
+        current_started_power = vtherm_api.central_power_manager.get_started_vtherm_power(
+            reservation_key or self._default_power_reservation_key
+        )
         if (
             current_power is None
             or current_max_power is None
@@ -156,31 +158,41 @@ class FeaturePowerManager(BaseFeatureManager):
             self._device_power,
         )
 
-        power_consumption_max = self.calculate_power_consumption_max()
-        additional_power = max(
-            0,
-            power_consumption_max - current_vtherm_started_power,
-        )
+        startup_power = self.calculate_underlying_startup_power()
 
         ret = (
             current_power
             + started_vtherm_total_power
-            - current_vtherm_started_power
-            + power_consumption_max
+            - current_started_power
+            + startup_power
         ) < current_max_power
         if not ret:
             _LOGGER.info(
-                "%s - there is not enough power available power=%.3f, max_power=%.3f started_power=%.3f current_vtherm_started_power=%.3f additional_power=%.3f heater power=%.3f",
+                "%s - there is not enough power available power=%.3f, max_power=%.3f started_power=%.3f current_started_power=%.3f startup_power=%.3f heater power=%.3f reservation_key=%s",
                 self,
                 current_power,
                 current_max_power,
                 started_vtherm_total_power,
-                current_vtherm_started_power,
-                additional_power,
+                current_started_power,
+                startup_power,
                 self._device_power,
+                reservation_key,
             )
 
-        return ret, power_consumption_max
+        return ret, startup_power
+
+    def calculate_underlying_startup_power(self) -> float:
+        """Calculate the incremental startup power for a single underlying."""
+        if not self._device_power:
+            return 0
+
+        if self._vtherm.is_over_climate:
+            return 0 if self._vtherm.is_device_active else self._device_power
+
+        if self._vtherm.nb_underlying_entities <= 1:
+            return 0 if self._vtherm.is_device_active else self._device_power
+
+        return self._device_power / self._vtherm.nb_underlying_entities
 
     def calculate_power_consumption_max(self) -> float:
         """Calculate the maximum power consumption"""
@@ -198,7 +210,10 @@ class FeaturePowerManager(BaseFeatureManager):
                 )
         return power_consumption_max
 
-    def add_power_consumption_to_central_power_manager(self):
+    def add_power_consumption_to_central_power_manager(
+        self,
+        reservation_key: str | None = None,
+    ):
         """
         Add the current power consumption to the central power manager.
         """
@@ -206,14 +221,17 @@ class FeaturePowerManager(BaseFeatureManager):
         if not self._is_configured or not vtherm_api.central_power_manager.is_configured:
             return
 
-        power_consumption_max = self.calculate_power_consumption_max()
+        startup_power = self.calculate_underlying_startup_power()
 
         vtherm_api.central_power_manager.set_started_vtherm_power(
-            self._vtherm_power_key,
-            power_consumption_max,
+            reservation_key or self._default_power_reservation_key,
+            startup_power,
         )
 
-    def sub_power_consumption_to_central_power_manager(self):
+    def sub_power_consumption_to_central_power_manager(
+        self,
+        reservation_key: str | None = None,
+    ):
         """
         Substract the current power consumption to the central power manager.
         """
@@ -222,7 +240,7 @@ class FeaturePowerManager(BaseFeatureManager):
             return
 
         vtherm_api.central_power_manager.set_started_vtherm_power(
-            self._vtherm_power_key,
+            reservation_key or self._default_power_reservation_key,
             0,
         )
 
@@ -324,8 +342,8 @@ class FeaturePowerManager(BaseFeatureManager):
         return None
 
     @property
-    def _vtherm_power_key(self) -> str:
-        """Return a stable key for temporary power reservations."""
+    def _default_power_reservation_key(self) -> str:
+        """Return a stable fallback key for temporary power reservations."""
         return getattr(self._vtherm, "entity_id", None) or self._vtherm.name
 
     def __str__(self):

--- a/custom_components/versatile_thermostat/feature_power_manager.py
+++ b/custom_components/versatile_thermostat/feature_power_manager.py
@@ -121,7 +121,9 @@ class FeaturePowerManager(BaseFeatureManager):
                 }
             )
 
-    async def check_power_available(self, reservation_key: str | None = None) -> bool:
+    async def check_power_available(
+        self, reservation_key: str | None = None
+    ) -> tuple[bool, float]:
         """Check if the Vtherm can be started considering overpowering.
         Returns True if no overpowering conditions are found.
         If True the vtherm power is written into the temporay vtherm started
@@ -134,11 +136,12 @@ class FeaturePowerManager(BaseFeatureManager):
         ):
             return True, 0
 
+        effective_reservation_key = reservation_key or self._default_power_reservation_key
         current_power = vtherm_api.central_power_manager.current_power
         current_max_power = vtherm_api.central_power_manager.current_max_power
         started_vtherm_total_power = vtherm_api.central_power_manager.started_vtherm_total_power
         current_started_power = vtherm_api.central_power_manager.get_started_vtherm_power(
-            reservation_key or self._default_power_reservation_key
+            effective_reservation_key
         )
         if (
             current_power is None
@@ -176,22 +179,37 @@ class FeaturePowerManager(BaseFeatureManager):
                 current_started_power,
                 startup_power,
                 self._device_power,
-                reservation_key,
+                effective_reservation_key,
             )
 
         return ret, startup_power
 
     def calculate_underlying_startup_power(self) -> float:
-        """Calculate the incremental startup power for a single underlying."""
+        """Calculate the incremental startup power for a single underlying.
+
+        This is the power to *reserve* between two power sensor measurements
+        when a new underlying is about to be turned on. It is deliberately
+        distinct from ``calculate_power_consumption_max()`` (used for global
+        shedding decisions) and intentionally ignores ``on_percent``: startup
+        is an instantaneous decision, not a cycle-average one.
+        """
         if not self._device_power:
             return 0
 
+        # over_climate and mono-underlying over_switch: if the device is
+        # already active, its load is already reflected in current_power, so
+        # no additional reservation is needed (returning device_power here
+        # would double-count the load between two sensor refreshes).
         if self._vtherm.is_over_climate:
             return 0 if self._vtherm.is_device_active else self._device_power
 
         if self._vtherm.nb_underlying_entities <= 1:
             return 0 if self._vtherm.is_device_active else self._device_power
 
+        # Multi-underlying over_switch: each underlying contributes an
+        # independent incremental slice, regardless of whether the VTherm is
+        # globally "active". Starting a 2nd underlying while the 1st is on
+        # must still reserve its own device_power/n slice.
         return self._device_power / self._vtherm.nb_underlying_entities
 
     def calculate_power_consumption_max(self) -> float:

--- a/custom_components/versatile_thermostat/underlyings.py
+++ b/custom_components/versatile_thermostat/underlyings.py
@@ -83,6 +83,7 @@ class UnderlyingEntity:
         self._thermostat: Any = thermostat
         self._type: UnderlyingEntityType = entity_type
         self._entity_id: str = entity_id
+        self._power_reservation_key = entity_id
         self._hvac_mode: VThermHvacMode | None = None
         self._on_cycle_start_callbacks: list[Callable] = []
         self._last_command_sent_datetime: datetime = dt_util.utc_from_timestamp(0)
@@ -102,6 +103,11 @@ class UnderlyingEntity:
     def entity_id(self):
         """The entity id represented by this class"""
         return self._entity_id
+
+    @property
+    def power_reservation_key(self) -> str:
+        """Return the stable power reservation key for this underlying."""
+        return self._power_reservation_key
 
     @property
     def entity_type(self) -> UnderlyingEntityType:
@@ -218,7 +224,9 @@ class UnderlyingEntity:
         """Check that a underlying can be turned on, else
         activate the overpowering state of the VTherm associated.
         Returns True if the check is ok (no overpowering needed)"""
-        ret, _ = await self._thermostat.power_manager.check_power_available()
+        ret, _ = await self._thermostat.power_manager.check_power_available(
+            self.power_reservation_key
+        )
         if not ret:
             _LOGGER.debug("%s - overpowering is detected", self)
             await self._thermostat.power_manager.set_overpowering(True)
@@ -480,7 +488,9 @@ class UnderlyingSwitch(UnderlyingEntity):
         # This may fails if called after shutdown
         try:
             try:
-                self._thermostat.power_manager.sub_power_consumption_to_central_power_manager()
+                self._thermostat.power_manager.sub_power_consumption_to_central_power_manager(
+                    self.power_reservation_key
+                )
                 _LOGGER.debug("%s - Sending command %s with data=%s", self, command, data)
                 await self._hass.services.async_call(self._domain, command, data)
                 self._is_on_part_running = False
@@ -506,7 +516,9 @@ class UnderlyingSwitch(UnderlyingEntity):
         data = self._on_command.get("data")
         try:
             try:
-                self._thermostat.power_manager.add_power_consumption_to_central_power_manager()
+                self._thermostat.power_manager.add_power_consumption_to_central_power_manager(
+                    self.power_reservation_key
+                )
                 _LOGGER.debug("%s - Sending command %s with data=%s", self, command, data)
                 await self._hass.services.async_call(self._domain, command, data)
                 self._is_on_part_running = True

--- a/tests/test_power.py
+++ b/tests/test_power.py
@@ -144,14 +144,10 @@ async def test_power_feature_manager(
             assert power_consumption_max == 1234
 
 
-async def test_power_feature_manager_reserves_startup_power_only_once_for_multi_underlyings(
+async def test_power_feature_manager_reserves_startup_power_per_underlying_for_multi_underlyings(
     hass: HomeAssistant,
 ):
-    """A multi-underlying VTherm must reserve its startup power only once.
-
-    This prevents false shedding when several underlyings start during the same
-    startup sequence before Home Assistant has updated their states.
-    """
+    """A multi-underlying VTherm must reserve startup power per underlying."""
 
     fake_vtherm = MagicMock(spec=BaseThermostat)
     fake_vtherm.entity_id = "climate.theoverswitchmockname"
@@ -159,7 +155,7 @@ async def test_power_feature_manager_reserves_startup_power_only_once_for_multi_
     type(fake_vtherm).is_device_active = PropertyMock(return_value=False)
     type(fake_vtherm).is_over_climate = PropertyMock(return_value=False)
     type(fake_vtherm).nb_underlying_entities = PropertyMock(return_value=4)
-    type(fake_vtherm).safe_on_percent = PropertyMock(return_value=1.0)
+    type(fake_vtherm).safe_on_percent = PropertyMock(return_value=0.1)
     fake_vtherm.async_get_last_state = AsyncMock(return_value=None)
 
     vtherm_api: VersatileThermostatAPI = VersatileThermostatAPI.get_vtherm_api(hass)
@@ -174,40 +170,46 @@ async def test_power_feature_manager_reserves_startup_power_only_once_for_multi_
             CONF_PRESET_POWER: 13,
         }
     )
-    vtherm_api.central_power_manager._current_power = 50
-    vtherm_api.central_power_manager._current_max_power = 160
+    vtherm_api.central_power_manager._current_power = 730
+    vtherm_api.central_power_manager._current_max_power = 1000
 
     power_manager.post_init(
         {
             CONF_USE_POWER_FEATURE: True,
             CONF_PRESET_POWER: 10,
-            CONF_DEVICE_POWER: 100,
+            CONF_DEVICE_POWER: 1000,
         }
     )
 
     await power_manager.start_listening()
 
-    ret, power_consumption_max = await power_manager.check_power_available()
+    ret, power_consumption_max = await power_manager.check_power_available("switch.one")
     assert ret is True
-    assert power_consumption_max == 100
+    assert power_consumption_max == 250
 
-    power_manager.add_power_consumption_to_central_power_manager()
-    assert vtherm_api.central_power_manager.started_vtherm_total_power == 100
+    power_manager.add_power_consumption_to_central_power_manager("switch.one")
+    assert vtherm_api.central_power_manager.started_vtherm_total_power == 250
+    assert len(vtherm_api.central_power_manager._started_vtherm_total_power_by_id) == 1  # pylint: disable=protected-access
 
-    # Simulate the next underlying starting before HA has reflected the first ON state.
-    ret, power_consumption_max = await power_manager.check_power_available()
+    # Re-checking the same underlying must stay idempotent.
+    ret, power_consumption_max = await power_manager.check_power_available("switch.one")
     assert ret is True
-    assert power_consumption_max == 100
+    assert power_consumption_max == 250
 
-    power_manager.add_power_consumption_to_central_power_manager()
-    assert vtherm_api.central_power_manager.started_vtherm_total_power == 100
+    power_manager.add_power_consumption_to_central_power_manager("switch.one")
+    assert vtherm_api.central_power_manager.started_vtherm_total_power == 250
+    assert len(vtherm_api.central_power_manager._started_vtherm_total_power_by_id) == 1  # pylint: disable=protected-access
 
-    type(fake_vtherm).is_device_active = PropertyMock(return_value=True)
-    power_manager.sub_power_consumption_to_central_power_manager()
+    # A distinct underlying must be denied because only one 250W slice is available.
+    ret, power_consumption_max = await power_manager.check_power_available("switch.two")
+    assert ret is False
+    assert power_consumption_max == 250
+
+    power_manager.sub_power_consumption_to_central_power_manager("switch.one")
     assert vtherm_api.central_power_manager.started_vtherm_total_power == 0
 
     # Releasing the reservation multiple times must stay idempotent as well.
-    power_manager.sub_power_consumption_to_central_power_manager()
+    power_manager.sub_power_consumption_to_central_power_manager("switch.one")
     assert vtherm_api.central_power_manager.started_vtherm_total_power == 0
 
 


### PR DESCRIPTION
Use per-underlying startup reservation instead of a single per-VTherm reservation during the power-sensor stale window.

Changes:
- reserve `device_power / nb_underlying_entities` for each underlying startup on multi-switch VTherms
- stop using `device_power * on_percent` for startup authorization
- keep idempotence for repeated reservation of the same underlying
- store temporary reservations by underlying `entity_id`
- remove the unused legacy reservation path
- update regression tests for per-underlying reservation semantics

This fixes the case where a multi-switch VTherm could start several underlyings even though only one underlying power slice was actually available.