### PR TITLE
Notify external prop handlers on every thermostat state refresh

### DIFF
--- a/custom_components/versatile_thermostat/prop_handler_tpi.py
+++ b/custom_components/versatile_thermostat/prop_handler_tpi.py
@@ -378,8 +378,9 @@ class TPIHandler:
                 force,
             )
 
-    async def on_state_changed(self, changed: bool = True):
+    async def on_state_changed(self, changed: bool):
         """Handle state changes."""
+        del changed
         # Cycle management is now passive, no need to start/stop loop
         pass
 

--- a/custom_components/versatile_thermostat/prop_handler_tpi.py
+++ b/custom_components/versatile_thermostat/prop_handler_tpi.py
@@ -378,7 +378,7 @@ class TPIHandler:
                 force,
             )
 
-    async def on_state_changed(self):
+    async def on_state_changed(self, changed: bool = True):
         """Handle state changes."""
         # Cycle management is now passive, no need to start/stop loop
         pass

--- a/custom_components/versatile_thermostat/thermostat_prop.py
+++ b/custom_components/versatile_thermostat/thermostat_prop.py
@@ -242,7 +242,9 @@ class ThermostatProp(BaseThermostat[T], Generic[T]):
     async def update_states(self, force=False):
         """Update states and delegate to handler."""
         changed = await super().update_states(force)
-        if changed and self._algo_handler:
+        if self._algo_handler:
+            # External proportional plugins may need to react to temperature
+            # crossings even when VT logical state did not change.
             await self._algo_handler.on_state_changed()
         return changed
 

--- a/custom_components/versatile_thermostat/thermostat_prop.py
+++ b/custom_components/versatile_thermostat/thermostat_prop.py
@@ -1,6 +1,7 @@
 # pylint: disable=line-too-long, abstract-method
 """Base class for proportional thermostats (TPI, SmartPI)."""
 
+import inspect
 import logging
 from vtherm_api.log_collector import get_vtherm_logger
 from typing import Generic
@@ -245,8 +246,34 @@ class ThermostatProp(BaseThermostat[T], Generic[T]):
         if self._algo_handler:
             # External proportional plugins may need to react to temperature
             # crossings even when VT logical state did not change.
-            await self._algo_handler.on_state_changed()
+            await self._notify_handler_state_changed(changed)
         return changed
+
+    async def _notify_handler_state_changed(self, changed: bool) -> None:
+        """Notify the handler with the richest supported state-change payload."""
+        on_state_changed = getattr(self._algo_handler, "on_state_changed", None)
+        if on_state_changed is None:
+            return
+
+        try:
+            signature = inspect.signature(on_state_changed)
+        except (TypeError, ValueError):
+            await on_state_changed()
+            return
+
+        supports_changed = any(
+            parameter.kind in (
+                inspect.Parameter.POSITIONAL_ONLY,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                inspect.Parameter.VAR_POSITIONAL,
+            )
+            for parameter in signature.parameters.values()
+        )
+
+        if supports_changed:
+            await on_state_changed(changed)
+        else:
+            await on_state_changed()
 
     def update_custom_attributes(self):
         """Update custom attributes."""

--- a/custom_components/versatile_thermostat/thermostat_prop.py
+++ b/custom_components/versatile_thermostat/thermostat_prop.py
@@ -1,7 +1,5 @@
 # pylint: disable=line-too-long, abstract-method
 """Base class for proportional thermostats (TPI, SmartPI)."""
-
-import inspect
 import logging
 from vtherm_api.log_collector import get_vtherm_logger
 from typing import Generic
@@ -246,34 +244,8 @@ class ThermostatProp(BaseThermostat[T], Generic[T]):
         if self._algo_handler:
             # External proportional plugins may need to react to temperature
             # crossings even when VT logical state did not change.
-            await self._notify_handler_state_changed(changed)
+            await self._algo_handler.on_state_changed(changed)
         return changed
-
-    async def _notify_handler_state_changed(self, changed: bool) -> None:
-        """Notify the handler with the richest supported state-change payload."""
-        on_state_changed = getattr(self._algo_handler, "on_state_changed", None)
-        if on_state_changed is None:
-            return
-
-        try:
-            signature = inspect.signature(on_state_changed)
-        except (TypeError, ValueError):
-            await on_state_changed()
-            return
-
-        supports_changed = any(
-            parameter.kind in (
-                inspect.Parameter.POSITIONAL_ONLY,
-                inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                inspect.Parameter.VAR_POSITIONAL,
-            )
-            for parameter in signature.parameters.values()
-        )
-
-        if supports_changed:
-            await on_state_changed(changed)
-        else:
-            await on_state_changed()
 
     def update_custom_attributes(self):
         """Update custom attributes."""

--- a/tests/test_central_boiler.py
+++ b/tests/test_central_boiler.py
@@ -801,18 +801,15 @@ async def test_update_central_boiler_state_simple_valve(
 
     # 1. start a valve
     await send_temperature_change_event(entity, 10, now)
-    # Wait for state event propagation
-    await asyncio.sleep(0.5)
+    await wait_for_local_condition(lambda: entity.hvac_action == HVACAction.HEATING, 10)
+    await wait_for_local_condition(lambda: entity.device_actives == ["number.valve1"], 10)
+    await wait_for_local_condition(lambda: api.central_boiler_manager.nb_active_device_for_boiler == 1, 10)
+    await wait_for_local_condition(lambda: boiler_binary_sensor.state == STATE_ON, 10)
+    await wait_for_local_condition(lambda: nb_device_active_sensor.state == 1, 10)
+    await wait_for_local_condition(lambda: total_power_active_sensor.state == 1500, 10)
 
-    assert entity.hvac_action == HVACAction.HEATING
     assert entity.device_actives == ["number.valve1"]
-
-    assert api.central_boiler_manager.nb_active_device_for_boiler == 1
-    assert boiler_binary_sensor.state == STATE_ON
-
-    assert nb_device_active_sensor.state == 1
     assert nb_device_active_sensor.active_device_ids == ["number.valve1"]
-    assert total_power_active_sensor.state == 1500
     assert total_power_active_sensor.active_device_ids == ["number.valve1"]
 
     # 2. stop a heater
@@ -820,19 +817,14 @@ async def test_update_central_boiler_state_simple_valve(
     # Change the valve value to 0
     valve1.set_native_value(0)
     valve1.async_write_ha_state()
-    # Wait for state event propagation
-    await asyncio.sleep(0.5)
+    await wait_for_local_condition(lambda: entity.hvac_action == HVACAction.IDLE, 10)
+    await wait_for_local_condition(lambda: entity.device_actives == [], 10)
+    await wait_for_local_condition(lambda: api.central_boiler_manager.nb_active_device_for_boiler == 0, 10)
+    await wait_for_local_condition(lambda: boiler_binary_sensor.state == STATE_OFF, 10)
+    await wait_for_local_condition(lambda: nb_device_active_sensor.state == 0, 10)
+    await wait_for_local_condition(lambda: total_power_active_sensor.state == 0, 10)
 
-    assert entity.hvac_action == HVACAction.IDLE
-    assert entity.device_actives == []
-
-    assert api.central_boiler_manager.nb_active_device_for_boiler == 0
-    assert boiler_binary_sensor.state == STATE_OFF
-
-    assert nb_device_active_sensor.state == 0
     assert nb_device_active_sensor.active_device_ids == []
-
-    assert total_power_active_sensor.state == 0
     assert total_power_active_sensor.active_device_ids == []
 
     entity.remove_thermostat()
@@ -1215,26 +1207,24 @@ async def test_update_central_boiler_state_simple_climate_valve_regulation(
     # in Boost setpoint is 21°C
     fake_temp_sensor.set_native_value(19.5)
     await hass.async_block_till_done()
-    await asyncio.sleep(0.1)
     # await send_temperature_change_event(entity, 19.5, now)
 
     # we have to simulate the climate also else the test don't work
     fake_underlying_climate.set_hvac_mode(VThermHvacMode_HEAT)
     fake_underlying_climate.set_hvac_action(HVACAction.HEATING)
-    # Wait for state event propagation
     await hass.async_block_till_done()
-    await asyncio.sleep(0.1)
+    await wait_for_local_condition(lambda: entity.hvac_action == HVACAction.HEATING, 10)
+    await wait_for_local_condition(lambda: entity.device_actives == ["number.mock_opening_degree"], 10)
+    await wait_for_local_condition(lambda: nb_device_active_sensor.state == 1, 10)
+    await wait_for_local_condition(lambda: total_power_active_sensor.state == 1125, 10)
+    await wait_for_local_condition(lambda: api.central_boiler_manager.nb_active_device_for_boiler == 1, 10)
+    await wait_for_local_condition(lambda: boiler_binary_sensor.state == STATE_ON, 10)
 
-    assert entity.hvac_action == HVACAction.HEATING
-    assert entity.device_actives == ["number.mock_opening_degree"]
-
-    assert nb_device_active_sensor.state == 1
     assert nb_device_active_sensor.active_device_ids == [
         "number.mock_opening_degree",
     ]
 
     assert entity.on_percent == 0.75  # (21-19.5)*0.3 + (21-18)*0.1 = 0.75
-    assert total_power_active_sensor.state == 1125  # on_percent is 75% x 1500W = 1125W
     assert total_power_active_sensor.active_device_ids == [
         "number.mock_opening_degree",
     ]
@@ -1242,14 +1232,11 @@ async def test_update_central_boiler_state_simple_climate_valve_regulation(
     assert api.central_boiler_manager.is_nb_active_active_for_boiler_exceeded is False
     assert api.central_boiler_manager.is_total_power_active_for_boiler_exceeded is True
 
-    assert api.central_boiler_manager.nb_active_device_for_boiler == 1
-    assert boiler_binary_sensor.state == STATE_ON
-
     # 2. stop a climate
 
     # await send_temperature_change_event(entity, 25, now)
     fake_temp_sensor.set_native_value(25)
-    await asyncio.sleep(0.1)
+    await hass.async_block_till_done()
 
     fake_underlying_climate.set_hvac_mode(VThermHvacMode_HEAT)
     fake_underlying_climate.set_hvac_action(HVACAction.IDLE)
@@ -1258,16 +1245,13 @@ async def test_update_central_boiler_state_simple_climate_valve_regulation(
     await hass.async_block_till_done()
 
     # The underlying is idle but the valve are closed -> OFF
-    await wait_for_local_condition(lambda: entity.hvac_action == HVACAction.OFF)
+    await wait_for_local_condition(lambda: entity.hvac_action == HVACAction.OFF, 10)
+    await wait_for_local_condition(lambda: api.central_boiler_manager.nb_active_device_for_boiler == 0, 10)
+    await wait_for_local_condition(lambda: boiler_binary_sensor.state == STATE_OFF, 10)
+    await wait_for_local_condition(lambda: nb_device_active_sensor.state == 0, 10)
+    await wait_for_local_condition(lambda: total_power_active_sensor.state == 0, 10)
     assert entity.device_actives == []
-
-    assert api.central_boiler_manager.nb_active_device_for_boiler == 0
-    assert boiler_binary_sensor.state == STATE_OFF
-
-    assert nb_device_active_sensor.state == 0
     assert nb_device_active_sensor.active_device_ids == []
-
-    assert total_power_active_sensor.state == 0
     assert total_power_active_sensor.active_device_ids == []
 
     entity.remove_thermostat()

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -77,8 +77,9 @@ class FakeExternalPropHandler:
         """No-op control hook for tests."""
         return
 
-    async def on_state_changed(self) -> None:
+    async def on_state_changed(self, changed: bool) -> None:
         """No-op state hook for tests."""
+        del changed
         self.state_change_calls += 1
         return
 
@@ -108,7 +109,7 @@ async def test_thermostat_prop_passes_changed_flag_to_external_handler() -> None
             super().__init__(thermostat)
             self.received_changed = None
 
-        async def on_state_changed(self, changed: bool = True) -> None:
+        async def on_state_changed(self, changed: bool) -> None:
             """Store the changed flag for assertions."""
             self.received_changed = changed
 
@@ -126,19 +127,19 @@ async def test_thermostat_prop_passes_changed_flag_to_external_handler() -> None
 
 
 @pytest.mark.asyncio
-async def test_thermostat_prop_keeps_legacy_external_handler_signature() -> None:
-    """External handlers without the changed argument remain supported."""
+async def test_thermostat_prop_passes_changed_true_to_external_handler() -> None:
+    """External handlers receive True when VT reports a state change."""
     entity = object.__new__(ThermostatProp)
-    entity._algo_handler = FakeExternalPropHandler(entity)
+    entity._algo_handler = AsyncMock()
 
     with patch(
         "custom_components.versatile_thermostat.thermostat_prop.BaseThermostat.update_states",
-        AsyncMock(return_value=False),
+        AsyncMock(return_value=True),
     ):
         changed = await ThermostatProp.update_states(entity, force=False)
 
-    assert changed is False
-    assert entity._algo_handler.state_change_calls == 1
+    assert changed is True
+    entity._algo_handler.on_state_changed.assert_awaited_once_with(True)
 
 
 @pytest.mark.parametrize("expected_lingering_tasks", [True])

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -3,7 +3,7 @@
 """Test the normal start of a Thermostat."""
 from datetime import timedelta, datetime
 
-from unittest.mock import PropertyMock
+from unittest.mock import AsyncMock, PropertyMock, patch
 
 from homeassistant.core import HomeAssistant
 
@@ -16,6 +16,7 @@ from homeassistant.const import UnitOfTime, UnitOfPower, UnitOfEnergy, PERCENTAG
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.versatile_thermostat.base_thermostat import BaseThermostat
+from custom_components.versatile_thermostat.thermostat_prop import ThermostatProp
 from custom_components.versatile_thermostat.sensor import (
     EnergySensor,
     MeanPowerSensor,
@@ -92,6 +93,23 @@ class FakeExternalPropFactory:
     def create(self, thermostat: BaseThermostat) -> FakeExternalPropHandler:
         """Create the fake handler."""
         return FakeExternalPropHandler(thermostat)
+
+
+@pytest.mark.asyncio
+async def test_thermostat_prop_notifies_external_handler_on_temperature_refresh() -> None:
+    """External handlers must receive state refreshes even without VT state changes."""
+    entity = object.__new__(ThermostatProp)
+    entity._algo_handler = FakeExternalPropHandler(entity)
+    entity._algo_handler.on_state_changed = AsyncMock()
+
+    with patch(
+        "custom_components.versatile_thermostat.thermostat_prop.BaseThermostat.update_states",
+        AsyncMock(return_value=False),
+    ):
+        changed = await ThermostatProp.update_states(entity, force=False)
+
+    assert changed is False
+    entity._algo_handler.on_state_changed.assert_awaited_once()
 
 
 @pytest.mark.parametrize("expected_lingering_tasks", [True])

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -53,6 +53,7 @@ class FakeExternalPropHandler:
         """Initialize the fake handler."""
         self._thermostat = thermostat
         self.auto_tpi_manager = None
+        self.state_change_calls = 0
 
     def init_algorithm(self) -> None:
         """Attach a fake proportional algorithm to the thermostat."""
@@ -78,6 +79,7 @@ class FakeExternalPropHandler:
 
     async def on_state_changed(self) -> None:
         """No-op state hook for tests."""
+        self.state_change_calls += 1
         return
 
     def on_scheduler_ready(self, scheduler) -> None:
@@ -96,11 +98,22 @@ class FakeExternalPropFactory:
 
 
 @pytest.mark.asyncio
-async def test_thermostat_prop_notifies_external_handler_on_temperature_refresh() -> None:
-    """External handlers must receive state refreshes even without VT state changes."""
+async def test_thermostat_prop_passes_changed_flag_to_external_handler() -> None:
+    """External handlers receive the state-change flag."""
+    class ChangedAwareFakeExternalPropHandler(FakeExternalPropHandler):
+        """Handler used to capture the propagated changed flag."""
+
+        def __init__(self, thermostat: BaseThermostat) -> None:
+            """Initialize the fake handler."""
+            super().__init__(thermostat)
+            self.received_changed = None
+
+        async def on_state_changed(self, changed: bool = True) -> None:
+            """Store the changed flag for assertions."""
+            self.received_changed = changed
+
     entity = object.__new__(ThermostatProp)
-    entity._algo_handler = FakeExternalPropHandler(entity)
-    entity._algo_handler.on_state_changed = AsyncMock()
+    entity._algo_handler = ChangedAwareFakeExternalPropHandler(entity)
 
     with patch(
         "custom_components.versatile_thermostat.thermostat_prop.BaseThermostat.update_states",
@@ -109,7 +122,23 @@ async def test_thermostat_prop_notifies_external_handler_on_temperature_refresh(
         changed = await ThermostatProp.update_states(entity, force=False)
 
     assert changed is False
-    entity._algo_handler.on_state_changed.assert_awaited_once()
+    assert entity._algo_handler.received_changed is False
+
+
+@pytest.mark.asyncio
+async def test_thermostat_prop_keeps_legacy_external_handler_signature() -> None:
+    """External handlers without the changed argument remain supported."""
+    entity = object.__new__(ThermostatProp)
+    entity._algo_handler = FakeExternalPropHandler(entity)
+
+    with patch(
+        "custom_components.versatile_thermostat.thermostat_prop.BaseThermostat.update_states",
+        AsyncMock(return_value=False),
+    ):
+        changed = await ThermostatProp.update_states(entity, force=False)
+
+    assert changed is False
+    assert entity._algo_handler.state_change_calls == 1
 
 
 @pytest.mark.parametrize("expected_lingering_tasks", [True])


### PR DESCRIPTION
External proportional plugins may need to react to temperature crossings even when VT logical state did not change.