### PR TITLE
fix(auto_start_stop): restore manager and algorithm state after HA restart

### DIFF
--- a/custom_components/versatile_thermostat/feature_auto_start_stop_manager.py
+++ b/custom_components/versatile_thermostat/feature_auto_start_stop_manager.py
@@ -3,11 +3,13 @@
 # pylint: disable=line-too-long
 
 import logging
+from datetime import datetime
 from vtherm_api.log_collector import get_vtherm_logger
 from typing import Any
 
 from homeassistant.core import (
     HomeAssistant,
+    callback,
 )
 
 from .const import *  # pylint: disable=wildcard-import, unused-wildcard-import
@@ -197,30 +199,52 @@ class FeatureAutoStartStopManager(BaseFeatureManager):
 
             self._vtherm.update_custom_attributes()
 
-        # if self._vtherm.hvac_mode == VThermHvacMode_OFF and self._vtherm.hvac_off_reason == HVAC_OFF_REASON_AUTO_START_STOP:
-        #    _LOGGER.debug(
-        #        "%s - the vtherm is off cause auto-start/stop and enable have been set to false -> starts the VTherm"
-        #    )
-        #    self.hass.create_task(self._vtherm.async_turn_on())
-        #
-        #    # Send an event
-        #    self._vtherm.send_event(
-        #        event_type=EventType.AUTO_START_STOP_EVENT,
-        #        data={
-        #            "type": "start",
-        #            "name": self.name,
-        #            "cause": "Auto start stop disabled",
-        #            "hvac_mode": self._vtherm.hvac_mode,
-        #            "saved_hvac_mode": self._vtherm.requested_state.hvac_mode,
-        #            "target_temperature": self._vtherm.target_temperature,
-        #            "current_temperature": self._vtherm.current_temperature,
-        #            "temperature_slope": round(self._vtherm.last_temperature_slope or 0, 3),
-        #            "accumulated_error": self._auto_start_stop_algo.accumulated_error,
-        #            "accumulated_error_threshold": self._auto_start_stop_algo.accumulated_error_threshold,
-        #        },
-        #    )
-        #
-        # self._vtherm.update_custom_attributes()
+    @callback
+    @overrides
+    def restore_state(self, old_state) -> None:
+        """Restore the auto start/stop manager state after a Home Assistant restart.
+
+        Restores:
+        - _is_auto_stop_detected: so the VTherm stays off if it was auto-stopped
+        - algo._accumulated_error: so the algorithm continues from where it left off
+        - algo._last_switch_date: to prevent rapid ON/OFF switching after restart
+        - algo._last_should_be_off: kept in sync with _is_auto_stop_detected
+        """
+        if old_state is None:
+            return
+
+        manager_attr = old_state.attributes.get("auto_start_stop_manager")
+        if not manager_attr:
+            return
+
+        # Restore the manager-level detected state
+        self._is_auto_stop_detected = bool(manager_attr.get("is_auto_stop_detected", False))
+
+        # Restore algorithm intermediate state
+        if self._auto_start_stop_algo is not None:
+            accumulated_error = manager_attr.get("auto_start_stop_accumulated_error")
+            if accumulated_error is not None:
+                self._auto_start_stop_algo._accumulated_error = float(accumulated_error)
+
+            last_switch_date_raw = manager_attr.get("auto_start_stop_last_switch_date")
+            if last_switch_date_raw is not None:
+                if isinstance(last_switch_date_raw, str):
+                    try:
+                        self._auto_start_stop_algo._last_switch_date = datetime.fromisoformat(last_switch_date_raw)
+                    except (ValueError, TypeError) as err:
+                        _LOGGER.warning("%s - restore_state: could not parse last_switch_date '%s': %s", self, last_switch_date_raw, err)
+                else:
+                    self._auto_start_stop_algo._last_switch_date = last_switch_date_raw
+
+            # Keep algo's internal flag in sync with the manager state
+            self._auto_start_stop_algo._last_should_be_off = self._is_auto_stop_detected
+
+        _LOGGER.info(
+            "%s - restore_state: is_auto_stop_detected=%s, accumulated_error=%s",
+            self,
+            self._is_auto_stop_detected,
+            manager_attr.get("auto_start_stop_accumulated_error"),
+        )
 
     def add_custom_attributes(self, extra_state_attributes: dict[str, Any]):
         """Add some custom attributes"""

--- a/custom_components/versatile_thermostat/feature_auto_start_stop_manager.py
+++ b/custom_components/versatile_thermostat/feature_auto_start_stop_manager.py
@@ -69,6 +69,14 @@ class FeatureAutoStartStopManager(BaseFeatureManager):
             self._auto_start_stop_level = AUTO_START_STOP_LEVEL_NONE
             self._is_configured = False
 
+        # Initialize the enable flag synchronously so the manager is operational
+        # without having to wait for the AutoStartStopEnable switch's
+        # async_added_to_hass callback (which is racy under test load).
+        # The switch's async_added_to_hass will later override this value
+        # from the persisted state if needed.
+        # This must mirror the default in switch.AutoStartStopEnable.
+        self._is_auto_start_stop_enabled = self._auto_start_stop_level != AUTO_START_STOP_LEVEL_NONE
+
         # Instanciate the auto start stop algo
         self._auto_start_stop_algo = AutoStartStopDetectionAlgorithm(
             self._auto_start_stop_level, self.name

--- a/tests/commons.py
+++ b/tests/commons.py
@@ -1503,17 +1503,20 @@ async def do_central_power_refresh(hass):
     return await hass.async_block_till_done()
 
 
-async def wait_for_local_condition(check_condition: Callable[[], bool], timeout: float = 1.0):
+async def wait_for_local_condition(check_condition: Callable[[], bool], timeout: float = 2.0, hass=None):
     """Waits that a local condition is satisfied, with a timeout.
-    Uses short sleeps to give the event loop and executor threads time to process."""
+    Uses short sleeps and optional hass.async_block_till_done() to process pending HA callbacks."""
     start_time = asyncio.get_event_loop().time()
 
     while not check_condition():
         if asyncio.get_event_loop().time() - start_time > timeout:
             raise TimeoutError("La condition locale n'a pas été satisfaite.")
 
+        # Flush all pending HA callbacks if hass is provided
+        if hass is not None:
+            await hass.async_block_till_done()
         # Yield to allow both event loop callbacks and executor threads to progress
-        await asyncio.sleep(0.1)
+        await asyncio.sleep(0.05)
 
 
 default_climate_attributes = {

--- a/tests/test_auto_start_stop.py
+++ b/tests/test_auto_start_stop.py
@@ -18,7 +18,6 @@ from .commons import *  # pylint: disable=wildcard-import, unused-wildcard-impor
 logging.getLogger().setLevel(logging.DEBUG)
 
 
-@pytest.mark.skip(reason="Disabled because it fails sometimes in CI")
 async def test_auto_start_stop_algo_slow_heat_off(hass: HomeAssistant):
     """Testing directly the algorithm in Slow level"""
     algo: AutoStartStopDetectionAlgorithm = AutoStartStopDetectionAlgorithm(
@@ -127,7 +126,6 @@ async def test_auto_start_stop_algo_slow_heat_off(hass: HomeAssistant):
     assert algo.last_switch_date == last_now
 
 
-@pytest.mark.skip(reason="Disabled because it fails sometimes in CI")
 async def test_auto_start_stop_too_fast_change(hass: HomeAssistant):
     """Testing directly the algorithm in Slow level"""
     algo: AutoStartStopDetectionAlgorithm = AutoStartStopDetectionAlgorithm(
@@ -222,7 +220,6 @@ async def test_auto_start_stop_too_fast_change(hass: HomeAssistant):
     assert algo.last_switch_date == now
 
 
-@pytest.mark.skip(reason="Disabled because it fails sometimes in CI")
 async def test_auto_start_stop_algo_medium_cool_off(hass: HomeAssistant):
     """Testing directly the algorithm in Slow level"""
     algo: AutoStartStopDetectionAlgorithm = AutoStartStopDetectionAlgorithm(
@@ -350,7 +347,6 @@ async def test_auto_start_stop_reset_switch_delay(hass: HomeAssistant):
 
 @pytest.mark.parametrize("expected_lingering_tasks", [True])
 @pytest.mark.parametrize("expected_lingering_timers", [True])
-@pytest.mark.skip(reason="Disabled because it fails sometimes in CI")
 async def test_auto_start_stop_none_vtherm(
     hass: HomeAssistant, skip_hass_states_is_state
 ):
@@ -405,28 +401,19 @@ async def test_auto_start_stop_none_vtherm(
         },
     )
 
-    fake_underlying_climate = MockClimate(
-        hass=hass,
-        unique_id="mock_climate",
-        name="mock_climate",
-        hvac_modes=[VThermHvacMode_OFF, VThermHvacMode_COOL, VThermHvacMode_HEAT],
+    await create_and_register_mock_climate(hass, "mock_climate", "mock_climate", {}, hvac_modes=[VThermHvacMode_OFF, VThermHvacMode_COOL, VThermHvacMode_HEAT])
+
+    vtherm: ThermostatOverClimate = await create_thermostat(
+        hass, config_entry, "climate.overclimate"
     )
 
-    with patch(
-        "custom_components.versatile_thermostat.underlyings.UnderlyingClimate.find_underlying_climate",
-        return_value=fake_underlying_climate,
-    ):
-        vtherm: ThermostatOverClimate = await create_thermostat(
-            hass, config_entry, "climate.overclimate"
-        )
+    assert vtherm is not None
 
-        assert vtherm is not None
-
-        # Initialize all temps
-        await set_all_climate_preset_temp(hass, vtherm, temps, "overclimate")
-        # Check correct initialization of auto_start_stop attributes
-        assert vtherm._attr_extra_state_attributes.get("auto_start_stop_level") is None
-        assert vtherm._attr_extra_state_attributes.get("auto_start_stop_dtmin") is None
+    # Initialize all temps
+    await set_all_climate_preset_temp(hass, vtherm, temps, "overclimate")
+    # Check correct initialization of auto_start_stop attributes
+    assert vtherm._attr_extra_state_attributes.get("auto_start_stop_level") is None
+    assert vtherm._attr_extra_state_attributes.get("auto_start_stop_dtmin") is None
 
     # 1. Vtherm auto-start/stop should be in NONE mode
     assert (
@@ -443,7 +430,6 @@ async def test_auto_start_stop_none_vtherm(
 
 @pytest.mark.parametrize("expected_lingering_tasks", [True])
 @pytest.mark.parametrize("expected_lingering_timers", [True])
-@pytest.mark.skip(reason="This test sometimes fails in CI only")
 async def test_auto_start_stop_medium_heat_vtherm(
     hass: HomeAssistant, skip_hass_states_is_state
 ):
@@ -498,30 +484,21 @@ async def test_auto_start_stop_medium_heat_vtherm(
         },
     )
 
-    fake_underlying_climate = MockClimate(
-        hass=hass,
-        unique_id="mock_climate",
-        name="mock_climate",
-        hvac_modes=[VThermHvacMode_OFF, VThermHvacMode_COOL, VThermHvacMode_HEAT],
+    await create_and_register_mock_climate(hass, "mock_climate", "mock_climate", {}, hvac_modes=[VThermHvacMode_OFF, VThermHvacMode_COOL, VThermHvacMode_HEAT])
+
+    vtherm: ThermostatOverClimate = await create_thermostat(
+        hass, config_entry, "climate.overclimate"
     )
 
-    with patch(
-        "custom_components.versatile_thermostat.underlyings.UnderlyingClimate.find_underlying_climate",
-        return_value=fake_underlying_climate,
-    ):
-        vtherm: ThermostatOverClimate = await create_thermostat(
-            hass, config_entry, "climate.overclimate"
-        )
+    assert vtherm is not None
 
-        assert vtherm is not None
+    # Initialize all temps
+    await set_all_climate_preset_temp(hass, vtherm, temps, "overclimate")
 
-        # Initialize all temps
-        await set_all_climate_preset_temp(hass, vtherm, temps, "overclimate")
+    # Check correct initialization of auto_start_stop attributes
+    assert vtherm._attr_extra_state_attributes["auto_start_stop_manager"]["auto_start_stop_level"] == AUTO_START_STOP_LEVEL_MEDIUM
 
-        # Check correct initialization of auto_start_stop attributes
-        assert vtherm._attr_extra_state_attributes["auto_start_stop_manager"]["auto_start_stop_level"] == AUTO_START_STOP_LEVEL_MEDIUM
-
-        assert vtherm._attr_extra_state_attributes["auto_start_stop_manager"]["auto_start_stop_dtmin"] == 15
+    assert vtherm._attr_extra_state_attributes["auto_start_stop_manager"]["auto_start_stop_dtmin"] == 15
 
     # 1. Vtherm auto-start/stop should be in MEDIUM mode and an enable entity should exists
     assert (
@@ -707,7 +684,6 @@ async def test_auto_start_stop_medium_heat_vtherm(
 
 @pytest.mark.parametrize("expected_lingering_tasks", [True])
 @pytest.mark.parametrize("expected_lingering_timers", [True])
-@pytest.mark.skip(reason="Disabled because it fails sometimes in CI")
 async def test_auto_start_stop_fast_ac_vtherm(
     hass: HomeAssistant, skip_hass_states_is_state
 ):
@@ -762,30 +738,21 @@ async def test_auto_start_stop_fast_ac_vtherm(
         },
     )
 
-    fake_underlying_climate = MockClimate(
-        hass=hass,
-        unique_id="mock_climate",
-        name="mock_climate",
-        hvac_modes=[VThermHvacMode_OFF, VThermHvacMode_COOL, VThermHvacMode_HEAT],
+    await create_and_register_mock_climate(hass, "mock_climate", "mock_climate", {}, hvac_modes=[VThermHvacMode_OFF, VThermHvacMode_COOL, VThermHvacMode_HEAT])
+
+    vtherm: ThermostatOverClimate = await create_thermostat(
+        hass, config_entry, "climate.overclimate"
     )
 
-    with patch(
-        "custom_components.versatile_thermostat.underlyings.UnderlyingClimate.find_underlying_climate",
-        return_value=fake_underlying_climate,
-    ):
-        vtherm: ThermostatOverClimate = await create_thermostat(
-            hass, config_entry, "climate.overclimate"
-        )
+    assert vtherm is not None
 
-        assert vtherm is not None
+    # Initialize all temps
+    await set_all_climate_preset_temp(hass, vtherm, temps, "overclimate")
 
-        # Initialize all temps
-        await set_all_climate_preset_temp(hass, vtherm, temps, "overclimate")
+    # Check correct initialization of auto_start_stop attributes
+    assert vtherm._attr_extra_state_attributes["auto_start_stop_manager"]["auto_start_stop_level"] == AUTO_START_STOP_LEVEL_FAST
 
-        # Check correct initialization of auto_start_stop attributes
-        assert vtherm._attr_extra_state_attributes["auto_start_stop_manager"]["auto_start_stop_level"] == AUTO_START_STOP_LEVEL_FAST
-
-        assert vtherm._attr_extra_state_attributes["auto_start_stop_manager"]["auto_start_stop_dtmin"] == 7
+    assert vtherm._attr_extra_state_attributes["auto_start_stop_manager"]["auto_start_stop_dtmin"] == 7
 
     # 1. Vtherm auto-start/stop should be in MEDIUM mode
     assert (
@@ -947,7 +914,6 @@ async def test_auto_start_stop_fast_ac_vtherm(
 
 @pytest.mark.parametrize("expected_lingering_tasks", [True])
 @pytest.mark.parametrize("expected_lingering_timers", [True])
-@pytest.mark.skip(reason="This test sometimes fails in CI only")
 async def test_auto_start_stop_medium_heat_vtherm_preset_change(
     hass: HomeAssistant, skip_hass_states_is_state
 ):
@@ -1002,30 +968,21 @@ async def test_auto_start_stop_medium_heat_vtherm_preset_change(
         },
     )
 
-    fake_underlying_climate = MockClimate(
-        hass=hass,
-        unique_id="mock_climate",
-        name="mock_climate",
-        hvac_modes=[VThermHvacMode_OFF, VThermHvacMode_COOL, VThermHvacMode_HEAT],
+    await create_and_register_mock_climate(hass, "mock_climate", "mock_climate", {}, hvac_modes=[VThermHvacMode_OFF, VThermHvacMode_COOL, VThermHvacMode_HEAT])
+
+    vtherm: ThermostatOverClimate = await create_thermostat(
+        hass, config_entry, "climate.overclimate"
     )
 
-    with patch(
-        "custom_components.versatile_thermostat.underlyings.UnderlyingClimate.find_underlying_climate",
-        return_value=fake_underlying_climate,
-    ):
-        vtherm: ThermostatOverClimate = await create_thermostat(
-            hass, config_entry, "climate.overclimate"
-        )
+    assert vtherm is not None
 
-        assert vtherm is not None
+    # Initialize all temps
+    await set_all_climate_preset_temp(hass, vtherm, temps, "overclimate")
 
-        # Initialize all temps
-        await set_all_climate_preset_temp(hass, vtherm, temps, "overclimate")
+    # Check correct initialization of auto_start_stop attributes
+    assert vtherm._attr_extra_state_attributes["auto_start_stop_manager"]["auto_start_stop_level"] == AUTO_START_STOP_LEVEL_FAST
 
-        # Check correct initialization of auto_start_stop attributes
-        assert vtherm._attr_extra_state_attributes["auto_start_stop_manager"]["auto_start_stop_level"] == AUTO_START_STOP_LEVEL_FAST
-
-        assert vtherm._attr_extra_state_attributes["auto_start_stop_manager"]["auto_start_stop_dtmin"] == 7
+    assert vtherm._attr_extra_state_attributes["auto_start_stop_manager"]["auto_start_stop_dtmin"] == 7
 
     # 1. Vtherm auto-start/stop should be in MEDIUM mode
     assert (
@@ -1156,7 +1113,6 @@ async def test_auto_start_stop_medium_heat_vtherm_preset_change(
 
 @pytest.mark.parametrize("expected_lingering_tasks", [True])
 @pytest.mark.parametrize("expected_lingering_timers", [True])
-@pytest.mark.skip(reason="Disabled because it fails sometimes in CI")
 async def test_auto_start_stop_medium_heat_vtherm_preset_change_enable_false(
     hass: HomeAssistant, skip_hass_states_is_state
 ):
@@ -1211,30 +1167,21 @@ async def test_auto_start_stop_medium_heat_vtherm_preset_change_enable_false(
         },
     )
 
-    fake_underlying_climate = MockClimate(
-        hass=hass,
-        unique_id="mock_climate",
-        name="mock_climate",
-        hvac_modes=[VThermHvacMode_OFF, VThermHvacMode_COOL, VThermHvacMode_HEAT],
+    await create_and_register_mock_climate(hass, "mock_climate", "mock_climate", {}, hvac_modes=[VThermHvacMode_OFF, VThermHvacMode_COOL, VThermHvacMode_HEAT])
+
+    vtherm: ThermostatOverClimate = await create_thermostat(
+        hass, config_entry, "climate.overclimate"
     )
 
-    with patch(
-        "custom_components.versatile_thermostat.underlyings.UnderlyingClimate.find_underlying_climate",
-        return_value=fake_underlying_climate,
-    ):
-        vtherm: ThermostatOverClimate = await create_thermostat(
-            hass, config_entry, "climate.overclimate"
-        )
+    assert vtherm is not None
 
-        assert vtherm is not None
+    # Initialize all temps
+    await set_all_climate_preset_temp(hass, vtherm, temps, "overclimate")
 
-        # Initialize all temps
-        await set_all_climate_preset_temp(hass, vtherm, temps, "overclimate")
+    # Check correct initialization of auto_start_stop attributes
+    assert vtherm._attr_extra_state_attributes["auto_start_stop_manager"]["auto_start_stop_level"] == AUTO_START_STOP_LEVEL_FAST
 
-        # Check correct initialization of auto_start_stop attributes
-        assert vtherm._attr_extra_state_attributes["auto_start_stop_manager"]["auto_start_stop_level"] == AUTO_START_STOP_LEVEL_FAST
-
-        assert vtherm._attr_extra_state_attributes["auto_start_stop_manager"]["auto_start_stop_dtmin"] == 7
+    assert vtherm._attr_extra_state_attributes["auto_start_stop_manager"]["auto_start_stop_dtmin"] == 7
 
     # 1. Vtherm auto-start/stop should be in FAST mode and enable should be on
     await wait_for_local_condition(lambda: vtherm._attr_extra_state_attributes["auto_start_stop_manager"].get("auto_start_stop_enable") is True)
@@ -1295,7 +1242,6 @@ async def test_auto_start_stop_medium_heat_vtherm_preset_change_enable_false(
 
 @pytest.mark.parametrize("expected_lingering_tasks", [True])
 @pytest.mark.parametrize("expected_lingering_timers", [True])
-@pytest.mark.skip(reason="Disabled because it fails sometimes in CI")
 async def test_auto_start_stop_fast_heat_window(
     hass: HomeAssistant, skip_hass_states_is_state
 ):
@@ -1351,30 +1297,21 @@ async def test_auto_start_stop_fast_heat_window(
         },
     )
 
-    fake_underlying_climate = MockClimate(
-        hass=hass,
-        unique_id="mock_climate",
-        name="mock_climate",
-        hvac_modes=[VThermHvacMode_OFF, VThermHvacMode_COOL, VThermHvacMode_HEAT],
+    await create_and_register_mock_climate(hass, "mock_climate", "mock_climate", {}, hvac_modes=[VThermHvacMode_OFF, VThermHvacMode_COOL, VThermHvacMode_HEAT])
+
+    vtherm: ThermostatOverClimate = await create_thermostat(
+        hass, config_entry, "climate.overclimate"
     )
 
-    with patch(
-        "custom_components.versatile_thermostat.underlyings.UnderlyingClimate.find_underlying_climate",
-        return_value=fake_underlying_climate,
-    ):
-        vtherm: ThermostatOverClimate = await create_thermostat(
-            hass, config_entry, "climate.overclimate"
-        )
+    assert vtherm is not None
 
-        assert vtherm is not None
+    # Initialize all temps
+    await set_all_climate_preset_temp(hass, vtherm, temps, "overclimate")
 
-        # Initialize all temps
-        await set_all_climate_preset_temp(hass, vtherm, temps, "overclimate")
+    # Check correct initialization of auto_start_stop attributes
+    assert vtherm._attr_extra_state_attributes["auto_start_stop_manager"]["auto_start_stop_level"] == AUTO_START_STOP_LEVEL_FAST
 
-        # Check correct initialization of auto_start_stop attributes
-        assert vtherm._attr_extra_state_attributes["auto_start_stop_manager"]["auto_start_stop_level"] == AUTO_START_STOP_LEVEL_FAST
-
-        assert vtherm._attr_extra_state_attributes["auto_start_stop_manager"]["auto_start_stop_dtmin"] == 7
+    assert vtherm._attr_extra_state_attributes["auto_start_stop_manager"]["auto_start_stop_dtmin"] == 7
 
     # 1. Vtherm auto-start/stop should be in MEDIUM mode and an enable entity should exists
     assert (
@@ -1474,7 +1411,6 @@ async def test_auto_start_stop_fast_heat_window(
 
 @pytest.mark.parametrize("expected_lingering_tasks", [True])
 @pytest.mark.parametrize("expected_lingering_timers", [True])
-@pytest.mark.skip(reason="Disabled because it fails sometimes in CI")
 async def test_auto_start_stop_fast_heat_window_mixed(
     hass: HomeAssistant, skip_hass_states_is_state
 ):
@@ -1532,30 +1468,21 @@ async def test_auto_start_stop_fast_heat_window_mixed(
         },
     )
 
-    fake_underlying_climate = MockClimate(
-        hass=hass,
-        unique_id="mock_climate",
-        name="mock_climate",
-        hvac_modes=[VThermHvacMode_OFF, VThermHvacMode_COOL, VThermHvacMode_HEAT],
+    await create_and_register_mock_climate(hass, "mock_climate", "mock_climate", {}, hvac_modes=[VThermHvacMode_OFF, VThermHvacMode_COOL, VThermHvacMode_HEAT])
+
+    vtherm: ThermostatOverClimate = await create_thermostat(
+        hass, config_entry, "climate.overclimate"
     )
 
-    with patch(
-        "custom_components.versatile_thermostat.underlyings.UnderlyingClimate.find_underlying_climate",
-        return_value=fake_underlying_climate,
-    ):
-        vtherm: ThermostatOverClimate = await create_thermostat(
-            hass, config_entry, "climate.overclimate"
-        )
+    assert vtherm is not None
 
-        assert vtherm is not None
+    # Initialize all temps
+    await set_all_climate_preset_temp(hass, vtherm, temps, "overclimate")
 
-        # Initialize all temps
-        await set_all_climate_preset_temp(hass, vtherm, temps, "overclimate")
+    # Check correct initialization of auto_start_stop attributes
+    assert vtherm._attr_extra_state_attributes["auto_start_stop_manager"]["auto_start_stop_level"] == AUTO_START_STOP_LEVEL_FAST
 
-        # Check correct initialization of auto_start_stop attributes
-        assert vtherm._attr_extra_state_attributes["auto_start_stop_manager"]["auto_start_stop_level"] == AUTO_START_STOP_LEVEL_FAST
-
-        assert vtherm._attr_extra_state_attributes["auto_start_stop_manager"]["auto_start_stop_dtmin"] == 7
+    assert vtherm._attr_extra_state_attributes["auto_start_stop_manager"]["auto_start_stop_dtmin"] == 7
 
     # 1. Vtherm auto-start/stop should be in MEDIUM mode and an enable entity should exists
     assert (
@@ -1673,7 +1600,6 @@ async def test_auto_start_stop_fast_heat_window_mixed(
 
 @pytest.mark.parametrize("expected_lingering_tasks", [True])
 @pytest.mark.parametrize("expected_lingering_timers", [True])
-@pytest.mark.skip(reason="Disabled because it fails sometimes in CI")
 async def test_auto_start_stop_disable_vtherm_off(
     hass: HomeAssistant, skip_hass_states_is_state
 ):
@@ -1716,36 +1642,27 @@ async def test_auto_start_stop_disable_vtherm_off(
         },
     )
 
-    fake_underlying_climate = MockClimate(
-        hass=hass,
-        unique_id="mock_climate",
-        name="mock_climate",
-        hvac_modes=[VThermHvacMode_OFF, VThermHvacMode_COOL, VThermHvacMode_HEAT],
-    )
+    await create_and_register_mock_climate(hass, "mock_climate", "mock_climate", {}, hvac_modes=[VThermHvacMode_OFF, VThermHvacMode_COOL, VThermHvacMode_HEAT])
 
     tz = get_tz(hass)  # pylint: disable=invalid-name
     now: datetime = datetime.now(tz=tz)
 
-    with patch(
-        "custom_components.versatile_thermostat.underlyings.UnderlyingClimate.find_underlying_climate",
-        return_value=fake_underlying_climate,
-    ):
-        vtherm: ThermostatOverClimate = await create_thermostat(
-            hass, config_entry, "climate.overclimate"
-        )
+    vtherm: ThermostatOverClimate = await create_thermostat(
+        hass, config_entry, "climate.overclimate"
+    )
 
-        assert vtherm is not None
+    assert vtherm is not None
 
-        # Initialize all temps
-        await set_all_climate_preset_temp(hass, vtherm, temps, "overclimate")
+    # Initialize all temps
+    await set_all_climate_preset_temp(hass, vtherm, temps, "overclimate")
 
-        # Check correct initialization of auto_start_stop attributes
-        assert (
-            vtherm._attr_extra_state_attributes["is_auto_start_stop_configured"] is True
-        )
-        assert vtherm._attr_extra_state_attributes["auto_start_stop_manager"]["auto_start_stop_level"] == AUTO_START_STOP_LEVEL_FAST
+    # Check correct initialization of auto_start_stop attributes
+    assert (
+        vtherm._attr_extra_state_attributes["is_auto_start_stop_configured"] is True
+    )
+    assert vtherm._attr_extra_state_attributes["auto_start_stop_manager"]["auto_start_stop_level"] == AUTO_START_STOP_LEVEL_FAST
 
-        assert vtherm._attr_extra_state_attributes["auto_start_stop_manager"]["auto_start_stop_dtmin"] == 7
+    assert vtherm._attr_extra_state_attributes["auto_start_stop_manager"]["auto_start_stop_dtmin"] == 7
 
     # 1. Vtherm auto-start/stop should be in FAST mode and enable should be on
     vtherm._set_now(now)

--- a/tests/test_auto_start_stop.py
+++ b/tests/test_auto_start_stop.py
@@ -345,8 +345,6 @@ async def test_auto_start_stop_reset_switch_delay(hass: HomeAssistant):
     assert algo.last_switch_date == now  # Switch date updated
 
 
-@pytest.mark.parametrize("expected_lingering_tasks", [True])
-@pytest.mark.parametrize("expected_lingering_timers", [True])
 async def test_auto_start_stop_none_vtherm(
     hass: HomeAssistant, skip_hass_states_is_state
 ):
@@ -427,9 +425,9 @@ async def test_auto_start_stop_none_vtherm(
         is None
     )
 
+    vtherm.remove_thermostat()
 
-@pytest.mark.parametrize("expected_lingering_tasks", [True])
-@pytest.mark.parametrize("expected_lingering_timers", [True])
+
 async def test_auto_start_stop_medium_heat_vtherm(
     hass: HomeAssistant, skip_hass_states_is_state
 ):
@@ -534,7 +532,7 @@ async def test_auto_start_stop_medium_heat_vtherm(
     ) as mock_send_event:
         vtherm._set_now(now)
         await send_temperature_change_event(vtherm, 19, now, False)
-        await wait_for_local_condition(lambda: vtherm.auto_start_stop_manager._auto_start_stop_algo.accumulated_error == 0)
+        await wait_for_local_condition(lambda: vtherm.auto_start_stop_manager._auto_start_stop_algo.accumulated_error == 0, timeout=3.0, hass=hass)
 
         # VTherm should still be heating
         assert vtherm.hvac_mode == VThermHvacMode_HEAT
@@ -550,7 +548,7 @@ async def test_auto_start_stop_medium_heat_vtherm(
     ) as mock_send_event:
         vtherm._set_now(now)
         await send_temperature_change_event(vtherm, 20, now, False)
-        await wait_for_local_condition(lambda: vtherm.auto_start_stop_manager._auto_start_stop_algo.accumulated_error == -2.5)
+        await wait_for_local_condition(lambda: vtherm.auto_start_stop_manager._auto_start_stop_algo.accumulated_error == -2.5, timeout=3.0, hass=hass)
 
         # VTherm should still be heating
         assert vtherm.hvac_mode == VThermHvacMode_HEAT
@@ -568,7 +566,7 @@ async def test_auto_start_stop_medium_heat_vtherm(
     ) as mock_send_event:
         vtherm._set_now(now)
         await send_temperature_change_event(vtherm, 21, now, False)
-        await wait_for_local_condition(lambda: vtherm.hvac_mode == VThermHvacMode_OFF)
+        await wait_for_local_condition(lambda: vtherm.hvac_mode == VThermHvacMode_OFF, timeout=3.0, hass=hass)
 
         # VTherm should have been stopped
         assert vtherm.hvac_mode == VThermHvacMode_OFF
@@ -619,7 +617,7 @@ async def test_auto_start_stop_medium_heat_vtherm(
     ) as mock_send_event:
         vtherm._set_now(now)
         await send_temperature_change_event(vtherm, 19.5, now, False)
-        await wait_for_local_condition(lambda: vtherm.hvac_mode == VThermHvacMode_OFF)
+        await wait_for_local_condition(lambda: vtherm.hvac_mode == VThermHvacMode_OFF, timeout=3.0, hass=hass)
 
         # accumulated_error = .... capped to -5
         assert (
@@ -681,9 +679,9 @@ async def test_auto_start_stop_medium_heat_vtherm(
             ]
         )
 
+    vtherm.remove_thermostat()
 
-@pytest.mark.parametrize("expected_lingering_tasks", [True])
-@pytest.mark.parametrize("expected_lingering_timers", [True])
+
 async def test_auto_start_stop_fast_ac_vtherm(
     hass: HomeAssistant, skip_hass_states_is_state
 ):
@@ -800,7 +798,7 @@ async def test_auto_start_stop_fast_ac_vtherm(
     ) as mock_send_event:
         vtherm._set_now(now)
         await send_temperature_change_event(vtherm, 23, now, True)
-        await wait_for_local_condition(lambda: vtherm.hvac_mode == VThermHvacMode_OFF)
+        await wait_for_local_condition(lambda: vtherm.hvac_mode == VThermHvacMode_OFF, timeout=3.0, hass=hass)
 
         # VTherm should have been stopped
         assert vtherm.hvac_mode == VThermHvacMode_OFF
@@ -850,7 +848,7 @@ async def test_auto_start_stop_fast_ac_vtherm(
     ) as mock_send_event:
         vtherm._set_now(now)
         await send_temperature_change_event(vtherm, 25.5, now, True)
-        await wait_for_local_condition(lambda: vtherm.hvac_mode == VThermHvacMode_OFF)
+        await wait_for_local_condition(lambda: vtherm.hvac_mode == VThermHvacMode_OFF, timeout=3.0, hass=hass)
 
         # accumulated_error = 2/2 + target - current = -1 x 20 min / 2 capped to 2
         assert (
@@ -911,9 +909,9 @@ async def test_auto_start_stop_fast_ac_vtherm(
             ]
         )
 
+    vtherm.remove_thermostat()
 
-@pytest.mark.parametrize("expected_lingering_tasks", [True])
-@pytest.mark.parametrize("expected_lingering_timers", [True])
+
 async def test_auto_start_stop_medium_heat_vtherm_preset_change(
     hass: HomeAssistant, skip_hass_states_is_state
 ):
@@ -1013,7 +1011,7 @@ async def test_auto_start_stop_medium_heat_vtherm_preset_change(
         vtherm._set_now(now)
         await send_temperature_change_event(vtherm, 19, now, False)
 
-        await wait_for_local_condition(lambda: vtherm.hvac_mode == VThermHvacMode_OFF)
+        await wait_for_local_condition(lambda: vtherm.hvac_mode == VThermHvacMode_OFF, timeout=3.0, hass=hass)
 
         # VTherm should have been stopped
         assert vtherm.hvac_mode == VThermHvacMode_OFF
@@ -1071,7 +1069,7 @@ async def test_auto_start_stop_medium_heat_vtherm_preset_change(
     ) as mock_send_event:
         vtherm._set_now(now)
         await vtherm.async_set_preset_mode(VThermPreset.BOOST)
-        await wait_for_local_condition(lambda: vtherm.target_temperature == 21)
+        await wait_for_local_condition(lambda: vtherm.target_temperature == 21, timeout=3.0, hass=hass)
 
         assert vtherm.auto_start_stop_manager._auto_start_stop_algo.accumulated_error == 2
 
@@ -1110,9 +1108,9 @@ async def test_auto_start_stop_medium_heat_vtherm_preset_change(
             ]
         )
 
+    vtherm.remove_thermostat()
 
-@pytest.mark.parametrize("expected_lingering_tasks", [True])
-@pytest.mark.parametrize("expected_lingering_timers", [True])
+
 async def test_auto_start_stop_medium_heat_vtherm_preset_change_enable_false(
     hass: HomeAssistant, skip_hass_states_is_state
 ):
@@ -1239,9 +1237,9 @@ async def test_auto_start_stop_medium_heat_vtherm_preset_change_enable_false(
         # a message should have been sent
         assert mock_send_event.call_count == 0
 
+    vtherm.remove_thermostat()
 
-@pytest.mark.parametrize("expected_lingering_tasks", [True])
-@pytest.mark.parametrize("expected_lingering_timers", [True])
+
 async def test_auto_start_stop_fast_heat_window(
     hass: HomeAssistant, skip_hass_states_is_state
 ):
@@ -1350,7 +1348,7 @@ async def test_auto_start_stop_fast_heat_window(
     ) as mock_send_event:
         vtherm._set_now(now)
         await send_temperature_change_event(vtherm, 21, now, False)
-        await wait_for_local_condition(lambda: vtherm.hvac_mode == VThermHvacMode_OFF)
+        await wait_for_local_condition(lambda: vtherm.hvac_mode == VThermHvacMode_OFF, timeout=3.0, hass=hass)
 
         # VTherm should no more be heating
         assert vtherm.hvac_mode == VThermHvacMode_OFF
@@ -1372,7 +1370,7 @@ async def test_auto_start_stop_fast_heat_window(
 
         await try_function(None)
 
-        await wait_for_local_condition(lambda: vtherm.hvac_mode == VThermHvacMode_OFF)
+        await wait_for_local_condition(lambda: vtherm.hvac_mode == VThermHvacMode_OFF, timeout=3.0, hass=hass)
 
         # Window takes precedence in the the hvac_off_reason
         assert vtherm.hvac_mode == VThermHvacMode_OFF
@@ -1397,7 +1395,7 @@ async def test_auto_start_stop_fast_heat_window(
 
         await try_function(None)
 
-        await wait_for_local_condition(lambda: vtherm.hvac_mode == VThermHvacMode_OFF)
+        await wait_for_local_condition(lambda: vtherm.hvac_mode == VThermHvacMode_OFF, timeout=3.0, hass=hass)
 
         # The VTherm should stay off because the reason of off is auto-start-stop
         assert vtherm.hvac_mode == VThermHvacMode_OFF
@@ -1408,9 +1406,9 @@ async def test_auto_start_stop_fast_heat_window(
 
         assert vtherm.window_state == STATE_OFF
 
+    vtherm.remove_thermostat()
 
-@pytest.mark.parametrize("expected_lingering_tasks", [True])
-@pytest.mark.parametrize("expected_lingering_timers", [True])
+
 async def test_auto_start_stop_fast_heat_window_mixed(
     hass: HomeAssistant, skip_hass_states_is_state
 ):
@@ -1526,7 +1524,7 @@ async def test_auto_start_stop_fast_heat_window_mixed(
 
         await try_function(None)
 
-        await wait_for_local_condition(lambda: vtherm.hvac_mode == VThermHvacMode_OFF)
+        await wait_for_local_condition(lambda: vtherm.hvac_mode == VThermHvacMode_OFF, timeout=3.0, hass=hass)
 
         # Nothing should have change (window event is ignoed as we are already OFF)
         assert vtherm.hvac_mode == VThermHvacMode_OFF
@@ -1546,7 +1544,7 @@ async def test_auto_start_stop_fast_heat_window_mixed(
     ) as mock_send_event:
         vtherm._set_now(now)
         await send_temperature_change_event(vtherm, 21, now, True)
-        await wait_for_local_condition(lambda: vtherm.hvac_mode == VThermHvacMode_OFF)
+        await wait_for_local_condition(lambda: vtherm.hvac_mode == VThermHvacMode_OFF, timeout=3.0, hass=hass)
 
         # VTherm should no more be heating
         assert vtherm.hvac_mode == VThermHvacMode_OFF
@@ -1587,7 +1585,7 @@ async def test_auto_start_stop_fast_heat_window_mixed(
         )
 
         await try_function(None)
-        await wait_for_local_condition(lambda: vtherm.hvac_mode == VThermHvacMode_OFF)
+        await wait_for_local_condition(lambda: vtherm.hvac_mode == VThermHvacMode_OFF, timeout=3.0, hass=hass)
 
         # The VTherm should turn on and off again due to auto-start-stop
         assert vtherm.hvac_mode == VThermHvacMode_OFF
@@ -1597,9 +1595,9 @@ async def test_auto_start_stop_fast_heat_window_mixed(
         assert vtherm.window_state == STATE_OFF
         assert mock_send_event.call_count == 0
 
+    vtherm.remove_thermostat()
 
-@pytest.mark.parametrize("expected_lingering_tasks", [True])
-@pytest.mark.parametrize("expected_lingering_timers", [True])
+
 async def test_auto_start_stop_disable_vtherm_off(
     hass: HomeAssistant, skip_hass_states_is_state
 ):
@@ -1689,7 +1687,7 @@ async def test_auto_start_stop_disable_vtherm_off(
         vtherm._set_now(now)
         await send_temperature_change_event(vtherm, 26, now, False)
 
-        await wait_for_local_condition(lambda: vtherm.hvac_mode == VThermHvacMode_OFF)
+        await wait_for_local_condition(lambda: vtherm.hvac_mode == VThermHvacMode_OFF, timeout=3.0, hass=hass)
 
         # VTherm should have been stopped
         assert vtherm.hvac_mode == VThermHvacMode_OFF
@@ -1701,7 +1699,7 @@ async def test_auto_start_stop_disable_vtherm_off(
 
     with patch("custom_components.versatile_thermostat.base_thermostat.BaseThermostat.send_event") as mock_send_event:
         enable_entity.turn_off()
-        await wait_for_local_condition(lambda: enable_entity.state == STATE_OFF)
+        await wait_for_local_condition(lambda: enable_entity.state == STATE_OFF, timeout=3.0, hass=hass)
 
         # VTherm should be heating
         assert vtherm.vtherm_hvac_mode == VThermHvacMode_HEAT
@@ -1736,3 +1734,5 @@ async def test_auto_start_stop_disable_vtherm_off(
             ],
             any_order=True,
         )
+
+    vtherm.remove_thermostat()

--- a/tests/test_auto_start_stop.py
+++ b/tests/test_auto_start_stop.py
@@ -548,16 +548,13 @@ async def test_auto_start_stop_medium_heat_vtherm(
     ) as mock_send_event:
         vtherm._set_now(now)
         await send_temperature_change_event(vtherm, 20, now, False)
-        await wait_for_local_condition(lambda: vtherm.auto_start_stop_manager._auto_start_stop_algo.accumulated_error == -2.5, timeout=3.0, hass=hass)
+        await wait_for_local_condition(lambda: abs(vtherm.auto_start_stop_manager._auto_start_stop_algo.accumulated_error + 2.5) < 0.01, timeout=3.0, hass=hass)
 
         # VTherm should still be heating
         assert vtherm.hvac_mode == VThermHvacMode_HEAT
         assert mock_send_event.call_count == 0
         # accumulated_error = target - current = -1 x 5 min / 2
-        assert (
-            vtherm.auto_start_stop_manager._auto_start_stop_algo.accumulated_error
-            == -2.5
-        )
+        assert abs(vtherm.auto_start_stop_manager._auto_start_stop_algo.accumulated_error + 2.5) < 0.01
 
     # 5. Set current temperature to 21 5 min later -> should turn off
     now = now + timedelta(minutes=5)
@@ -573,9 +570,7 @@ async def test_auto_start_stop_medium_heat_vtherm(
         assert vtherm.hvac_off_reason == HVAC_OFF_REASON_AUTO_START_STOP
 
         # accumulated_error = -2.5 + target - current = -2 x 5 min / 2 capped to 5
-        assert (
-            vtherm.auto_start_stop_manager._auto_start_stop_algo.accumulated_error == -5
-        )
+        assert abs(vtherm.auto_start_stop_manager._auto_start_stop_algo.accumulated_error + 5) < 0.01
 
         # a message should have been sent
         assert mock_send_event.call_count >= 1
@@ -620,9 +615,7 @@ async def test_auto_start_stop_medium_heat_vtherm(
         await wait_for_local_condition(lambda: vtherm.hvac_mode == VThermHvacMode_OFF, timeout=3.0, hass=hass)
 
         # accumulated_error = .... capped to -5
-        assert (
-            vtherm.auto_start_stop_manager._auto_start_stop_algo.accumulated_error == -5
-        )
+        assert abs(vtherm.auto_start_stop_manager._auto_start_stop_algo.accumulated_error + 5) < 0.01
 
         # VTherm should stay stopped cause slope is too low to allow the turn to On
         assert vtherm.hvac_mode == VThermHvacMode_OFF
@@ -638,9 +631,7 @@ async def test_auto_start_stop_medium_heat_vtherm(
         await hass.async_block_till_done()
 
         # accumulated_error = -5/2 + target - current = 1 x 20 min / 2 capped to 5
-        assert (
-            vtherm.auto_start_stop_manager._auto_start_stop_algo.accumulated_error == 5
-        )
+        assert abs(vtherm.auto_start_stop_manager._auto_start_stop_algo.accumulated_error - 5) < 0.01
 
         # VTherm should have been stopped
         assert vtherm.hvac_mode == VThermHvacMode_HEAT
@@ -1182,7 +1173,7 @@ async def test_auto_start_stop_medium_heat_vtherm_preset_change_enable_false(
     assert vtherm._attr_extra_state_attributes["auto_start_stop_manager"]["auto_start_stop_dtmin"] == 7
 
     # 1. Vtherm auto-start/stop should be in FAST mode and enable should be on
-    await wait_for_local_condition(lambda: vtherm._attr_extra_state_attributes["auto_start_stop_manager"].get("auto_start_stop_enable") is True)
+    await wait_for_local_condition(lambda: vtherm._attr_extra_state_attributes["auto_start_stop_manager"].get("auto_start_stop_enable") is True, timeout=3.0, hass=hass)
 
     assert (
         vtherm.auto_start_stop_manager.auto_start_stop_level
@@ -1237,6 +1228,9 @@ async def test_auto_start_stop_medium_heat_vtherm_preset_change_enable_false(
         # a message should have been sent
         assert mock_send_event.call_count == 0
 
+    # Restore enable to True before cleanup to avoid restore_state interference
+    enable_entity.turn_on()
+    await hass.async_block_till_done()
     vtherm.remove_thermostat()
 
 

--- a/tests/test_auto_start_stop_feature_manager.py
+++ b/tests/test_auto_start_stop_feature_manager.py
@@ -1,6 +1,7 @@
 # pylint: disable=unused-argument, line-too-long, protected-access, too-many-lines
 """ Test the Window management """
 import logging
+from datetime import datetime
 from unittest.mock import PropertyMock, MagicMock
 
 from custom_components.versatile_thermostat.base_thermostat import BaseThermostat
@@ -107,3 +108,113 @@ async def test_auto_start_stop_feature_manager_post_init(
             custom_attributes["auto_start_stop_manager"]["auto_start_stop_accumulated_error_threshold"] == auto_start_stop_manager._auto_start_stop_algo.accumulated_error_threshold
         )
         assert custom_attributes["auto_start_stop_manager"]["auto_start_stop_last_switch_date"] == auto_start_stop_manager._auto_start_stop_algo.last_switch_date
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Tests for restore_state()
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _make_manager(hass, level=AUTO_START_STOP_LEVEL_MEDIUM) -> FeatureAutoStartStopManager:
+    """Helper: create a fully post_init'd FeatureAutoStartStopManager."""
+    fake_vtherm = MagicMock(spec=BaseThermostat)
+    type(fake_vtherm).name = PropertyMock(return_value="test_vtherm")
+    type(fake_vtherm).have_valve_regulation = PropertyMock(return_value=False)
+    type(fake_vtherm).is_over_climate = PropertyMock(return_value=True)
+    type(fake_vtherm).is_on = PropertyMock(return_value=False)
+    fake_vtherm.hvac_off_reason = None
+
+    manager = FeatureAutoStartStopManager(fake_vtherm, hass)
+    manager.post_init(
+        {
+            CONF_USE_AUTO_START_STOP_FEATURE: True,
+            CONF_AUTO_START_STOP_LEVEL: level,
+        }
+    )
+    return manager
+
+
+async def test_restore_state_when_auto_stopped(hass: HomeAssistant):
+    """Test that restore_state correctly restores manager and algo state
+    when the VTherm was auto-stopped before the restart."""
+
+    manager = _make_manager(hass)
+    last_switch = datetime(2026, 1, 2, 8, 30, 0)
+
+    old_state = MagicMock()
+    old_state.attributes = {
+        "auto_start_stop_manager": {
+            "is_auto_stop_detected": True,
+            "auto_start_stop_enable": True,
+            "auto_start_stop_level": AUTO_START_STOP_LEVEL_MEDIUM,
+            "auto_start_stop_accumulated_error": -4.5,
+            "auto_start_stop_accumulated_error_threshold": 5.0,
+            "auto_start_stop_last_switch_date": last_switch.isoformat(),
+        }
+    }
+
+    manager.restore_state(old_state)
+
+    # Manager flag must be restored
+    assert manager.is_auto_stop_detected is True
+    # Algorithm intermediate state must be restored
+    assert manager._auto_start_stop_algo.accumulated_error == -4.5
+    assert manager._auto_start_stop_algo.last_switch_date == last_switch
+    # Algorithm internal _last_should_be_off must be in sync
+    assert manager._auto_start_stop_algo._last_should_be_off is True
+
+
+async def test_restore_state_when_not_auto_stopped(hass: HomeAssistant):
+    """Test restore_state when VTherm was running normally (not auto-stopped).
+    Algorithm intermediate values (accumulated_error, last_switch_date) must
+    still be restored so the algorithm continues from where it left off."""
+
+    manager = _make_manager(hass)
+    last_switch = datetime(2026, 1, 1, 12, 0, 0)
+
+    old_state = MagicMock()
+    old_state.attributes = {
+        "auto_start_stop_manager": {
+            "is_auto_stop_detected": False,
+            "auto_start_stop_enable": True,
+            "auto_start_stop_level": AUTO_START_STOP_LEVEL_MEDIUM,
+            "auto_start_stop_accumulated_error": 2.0,
+            "auto_start_stop_accumulated_error_threshold": 5.0,
+            "auto_start_stop_last_switch_date": last_switch.isoformat(),
+        }
+    }
+
+    manager.restore_state(old_state)
+
+    assert manager.is_auto_stop_detected is False
+    assert manager._auto_start_stop_algo.accumulated_error == 2.0
+    assert manager._auto_start_stop_algo.last_switch_date == last_switch
+    assert manager._auto_start_stop_algo._last_should_be_off is False
+
+
+async def test_restore_state_none_old_state(hass: HomeAssistant):
+    """Test that restore_state(None) does not raise and keeps defaults."""
+
+    manager = _make_manager(hass)
+
+    manager.restore_state(None)  # must not raise
+
+    assert manager.is_auto_stop_detected is False
+    assert manager._auto_start_stop_algo.accumulated_error == 0
+    assert manager._auto_start_stop_algo.last_switch_date is None
+
+
+async def test_restore_state_no_manager_attribute(hass: HomeAssistant):
+    """Test that restore_state is a no-op when auto_start_stop_manager attribute is absent.
+    This covers backward-compatibility with states saved before this feature."""
+
+    manager = _make_manager(hass)
+
+    old_state = MagicMock()
+    old_state.attributes = {}  # no auto_start_stop_manager key
+
+    manager.restore_state(old_state)
+
+    assert manager.is_auto_stop_detected is False
+    assert manager._auto_start_stop_algo.accumulated_error == 0
+    assert manager._auto_start_stop_algo.last_switch_date is None

--- a/tests/test_auto_start_stop_feature_manager.py
+++ b/tests/test_auto_start_stop_feature_manager.py
@@ -92,7 +92,8 @@ async def test_auto_start_stop_feature_manager_post_init(
         if level and is_configured
         else AUTO_START_STOP_LEVEL_NONE
     )
-    assert auto_start_stop_manager.auto_start_stop_enable is False
+    should_be_enabled = level not in [None, AUTO_START_STOP_LEVEL_NONE] and is_configured
+    assert auto_start_stop_manager.auto_start_stop_enable is should_be_enabled
     assert auto_start_stop_manager._auto_start_stop_algo is not None
 
     custom_attributes = {}
@@ -100,7 +101,7 @@ async def test_auto_start_stop_feature_manager_post_init(
     assert custom_attributes["is_auto_start_stop_configured"] is is_configured
 
     if auto_start_stop_manager.is_configured:
-        assert custom_attributes["auto_start_stop_manager"]["auto_start_stop_enable"] is False
+        assert custom_attributes["auto_start_stop_manager"]["auto_start_stop_enable"] is should_be_enabled
         assert custom_attributes["auto_start_stop_manager"]["auto_start_stop_level"] == level if level and is_configured else AUTO_START_STOP_LEVEL_NONE
         assert custom_attributes["auto_start_stop_manager"]["auto_start_stop_dtmin"] == auto_start_stop_manager._auto_start_stop_algo.dt_min
         assert custom_attributes["auto_start_stop_manager"]["auto_start_stop_accumulated_error"] == auto_start_stop_manager._auto_start_stop_algo.accumulated_error


### PR DESCRIPTION
## Summary

Fixes #1953

After a Home Assistant restart, the `FeatureAutoStartStopManager` was starting fresh with default values. This could cause:
- The VTherm to send unwanted ON commands to the underlying device if it had been auto-stopped before the restart
- The auto-start/stop algorithm to restart its accumulated error from 0, losing all the intermediate computation that had been built up

## Root cause

`FeatureAutoStartStopManager` did not implement `restore_state()`. The base class `BaseFeatureManager` provides an empty default, so all state was lost on restart.

## Changes

### `feature_auto_start_stop_manager.py`
- Add `restore_state()` method that reads from the already-persisted `auto_start_stop_manager` attribute dict
- Restores `_is_auto_stop_detected` → VTherm underlying device stays OFF if it was auto-stopped
- Restores `algo._accumulated_error` → algorithm continues from where it left off (no cold-start)
- Restores `algo._last_switch_date` → prevents rapid ON/OFF switching right after restart  
- Keeps `algo._last_should_be_off` in sync with `_is_auto_stop_detected`
- Initialize [_is_auto_start_stop_enabled](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) synchronously in [post_init()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) based on the configured level, mirroring the default value of the [AutoStartStopEnable](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) switch entity. Previously, this flag was only set when the switch's [async_added_to_hass](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) callback ran asynchronously, defaulting to False until then. Under heavy parallel test load (pytest-xdist), the switch entity could finish setting up after temperature change events were processed, leaving the manager disabled and causing tests like [test_auto_start_stop_medium_heat_vtherm](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), [test_auto_start_stop_fast_ac_vtherm](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), etc. to fail randomly while always passing when run individually. The switch's [async_added_to_hass](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) still overrides this from persisted state when restoring after a HA restart.

All these values were **already being persisted** by `add_custom_attributes()` — only the restore side was missing.

### `tests/test_auto_start_stop_feature_manager.py`
- `test_restore_state_when_auto_stopped` — nominal case: VTherm was auto-stopped, full state is restored
- `test_restore_state_when_not_auto_stopped` — VTherm was running, accumulated error and last switch date are restored
- `test_restore_state_none_old_state` — `old_state=None` does not raise, defaults are preserved
- `test_restore_state_no_manager_attribute` — backward-compatible: no `auto_start_stop_manager` key → no-op
- `test_auto_start_stop_feature_manager_post_init` — updated to reflect that the enable flag is now initialized from the configured level instead of always being False
