### PR TITLE
Fix used preset when window is open (issue #1958)

### DIFF
--- a/custom_components/versatile_thermostat/base_thermostat.py
+++ b/custom_components/versatile_thermostat/base_thermostat.py
@@ -1677,6 +1677,9 @@ class BaseThermostat(ClimateEntity, RestoreEntity, Generic[T]):
             if (
                 (self._ac_mode and self.vtherm_hvac_mode == VThermHvacMode_COOL)
                 or (self.vtherm_hvac_mode == VThermHvacMode_OFF and self.requested_state.hvac_mode == VThermHvacMode_COOL)
+                # issue #1958 - when window_action=fan_only temporarily switches the mode to FAN_ONLY,
+                # the user's intent (requested_state) is still COOL, so we must use AC presets.
+                or (self.vtherm_hvac_mode == VThermHvacMode_FAN_ONLY and self.requested_state.hvac_mode == VThermHvacMode_COOL)
                 #                (self.is_over_switch and self._ac_mode)
                 #                or self.vtherm_hvac_mode == VThermHvacMode_COOL
                 #                or (self.vtherm_hvac_mode == VThermHvacMode_OFF and self.requested_state.hvac_mode == VThermHvacMode_COOL)

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -2992,3 +2992,124 @@ async def test_window_no_motion_absence(hass: HomeAssistant, skip_hass_states_is
 
     # Clean the entity
     entity.remove_thermostat()
+
+
+@pytest.mark.parametrize("expected_lingering_tasks", [True])
+@pytest.mark.parametrize("expected_lingering_timers", [True])
+async def test_window_action_fan_only_ac_mode_uses_ac_preset_temp(hass: HomeAssistant, skip_hass_states_is_state):
+    """Test issue #1958: when window_action=fan_only on an AC-mode over-climate VTherm
+    running in cool mode, switching to fan_only must still use the AC eco preset
+    temperature (eco_ac_temp), not the heating eco preset temperature (eco_temp).
+
+    Without the fix find_preset_temp() checks `vtherm_hvac_mode == COOL` which is
+    False during the fan_only window period, so it falls back to the heating preset
+    (18.5 °C) instead of the AC preset (25 °C).  This causes the compressor to
+    activate on window-close because the regulation accumulated error is huge.
+    """
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="TheOverClimateMockName",
+        unique_id="uniqueId",
+        data={
+            CONF_NAME: "TheOverClimateMockName",
+            CONF_THERMOSTAT_TYPE: CONF_THERMOSTAT_CLIMATE,
+            CONF_TEMP_SENSOR: "sensor.mock_temp_sensor",
+            CONF_EXTERNAL_TEMP_SENSOR: "sensor.mock_ext_temp_sensor",
+            CONF_CYCLE_MIN: 5,
+            CONF_TEMP_MIN: 7,
+            CONF_TEMP_MAX: 35,
+            # Heating presets (should NOT be used in AC/cool mode)
+            "eco_temp": 18.5,
+            "comfort_temp": 20.5,
+            "boost_temp": 22.5,
+            # AC (cooling) presets (SHOULD be used when requested mode is COOL)
+            "eco_ac_temp": 25.0,
+            "comfort_ac_temp": 23.0,
+            "boost_ac_temp": 21.0,
+            CONF_USE_WINDOW_FEATURE: True,
+            CONF_USE_MOTION_FEATURE: False,
+            CONF_USE_POWER_FEATURE: False,
+            CONF_USE_PRESENCE_FEATURE: False,
+            CONF_UNDERLYING_LIST: ["climate.mock_climate"],
+            CONF_SAFETY_DELAY_MIN: 60,
+            CONF_SAFETY_MIN_ON_PERCENT: 0.3,
+            CONF_WINDOW_SENSOR: "binary_sensor.mock_window_sensor",
+            CONF_WINDOW_DELAY: 1,
+            CONF_WINDOW_ACTION: CONF_WINDOW_FAN_ONLY,
+            CONF_AC_MODE: True,
+        },
+    )
+
+    # The underlying must support FAN_ONLY so that the fan_only action is taken
+    fake_underlying_climate = await create_and_register_mock_climate(
+        hass,
+        "mock_climate",
+        "MockClimateName",
+        {},
+        hvac_modes=[VThermHvacMode_HEAT, VThermHvacMode_COOL, VThermHvacMode_FAN_ONLY],
+    )
+
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    assert entry.state is ConfigEntryState.LOADED
+
+    entity: ThermostatOverClimate = search_entity(hass, "climate.theoverclimatemockname", "climate")
+    assert entity
+    assert entity.is_over_climate is True
+    assert entity.window_manager.window_action == CONF_WINDOW_FAN_ONLY
+    assert entity._ac_mode is True
+
+    # 1. Set the thermostat in COOL mode with ECO preset — should use AC eco preset
+    await entity.async_set_hvac_mode(VThermHvacMode_COOL)
+    assert entity.hvac_mode == VThermHvacMode_COOL
+    await entity.async_set_preset_mode(VThermPreset.ECO)
+    assert entity.preset_mode == VThermPreset.ECO
+    # Must be the AC eco temperature, not the heating eco temperature
+    assert entity.target_temperature == 25.0, f"Expected AC eco preset temp 25.0 but got {entity.target_temperature}"
+
+    # 2. Open the window — device switches to FAN_ONLY
+    tz = get_tz(hass)
+    now: datetime = datetime.now(tz=tz)
+
+    with patch("custom_components.versatile_thermostat.base_thermostat.BaseThermostat.send_event") as mock_send_event, patch(
+        "homeassistant.helpers.condition.state", return_value=True
+    ), patch("custom_components.versatile_thermostat.underlyings.UnderlyingClimate.set_hvac_mode") as mock_underlying_set_hvac_mode:
+        event_timestamp = now - timedelta(minutes=2)
+        try_window_condition = await send_window_change_event(entity, True, False, event_timestamp)
+        await try_window_condition(None)
+
+        # HVAC mode must have switched to FAN_ONLY
+        assert entity.vtherm_hvac_mode is VThermHvacMode_FAN_ONLY, f"Expected FAN_ONLY hvac mode but got {entity.vtherm_hvac_mode}"
+        assert entity.window_state == STATE_ON
+        assert entity.preset_mode == VThermPreset.ECO
+
+        # THE KEY ASSERTION: target temperature must still be the AC eco preset (25 °C)
+        # Before the fix, find_preset_temp() returns 18.5 (heating eco) because the
+        # current hvac_mode is FAN_ONLY, not COOL, and the FAN_ONLY case is not handled.
+        assert entity.target_temperature == 25.0, (
+            f"BUG #1958: While in fan_only (window open), target temperature should "
+            f"remain at AC eco preset (25.0 °C) but got {entity.target_temperature}. "
+            f"This causes the heating eco preset (18.5 °C) to be used instead, making "
+            f"the compressor activate aggressively when the window closes."
+        )
+
+        mock_underlying_set_hvac_mode.assert_called_with(VThermHvacMode_FAN_ONLY)
+
+    # 3. Close the window — device should return to COOL with the AC eco preset temp
+    with patch("custom_components.versatile_thermostat.base_thermostat.BaseThermostat.send_event") as mock_send_event, patch(
+        "homeassistant.helpers.condition.state", return_value=True
+    ), patch("custom_components.versatile_thermostat.underlyings.UnderlyingClimate.set_hvac_mode") as mock_underlying_set_hvac_mode:
+        event_timestamp = now - timedelta(minutes=1)
+        try_function = await send_window_change_event(entity, False, True, event_timestamp, sleep=False)
+        await try_function(None)
+        await hass.async_block_till_done()
+
+        assert entity.window_state == STATE_OFF
+        assert entity.vtherm_hvac_mode is VThermHvacMode_COOL, f"Expected COOL hvac mode after window close but got {entity.vtherm_hvac_mode}"
+        assert entity.preset_mode == VThermPreset.ECO
+        # Target temperature must be the AC eco preset after window close too
+        assert entity.target_temperature == 25.0, f"Expected AC eco preset temp 25.0 after window close but got {entity.target_temperature}"
+
+    # Clean the entity
+    entity.remove_thermostat()


### PR DESCRIPTION
## Issue #1958 — Complete Fix

### Root Cause

[`find_preset_temp()`](custom_components/versatile_thermostat/base_thermostat.py:1677) in `base_thermostat.py` decides whether to use the AC preset variant (e.g. `eco_ac_temp = 25 °C`) or the heating preset (e.g. `eco_temp = 18.5 °C`) based on the **current** `vtherm_hvac_mode`. The condition was:

```python
if (
    (self._ac_mode and self.vtherm_hvac_mode == VThermHvacMode_COOL)
    or (self.vtherm_hvac_mode == VThermHvacMode_OFF and self.requested_state.hvac_mode == VThermHvacMode_COOL)
):
    preset_name += PRESET_AC_SUFFIX
```

When the window opens with `window_action = fan_only`, `StateManager.calculate_hvac_mode()` temporarily switches `current_state.hvac_mode` to `FAN_ONLY` — but the user's **requested** mode is still `COOL`. The first condition (`vtherm_hvac_mode == COOL`) is now `False`. The second condition handles the `OFF` case (auto-start-stop), but the identical `FAN_ONLY` case was simply missing. As a result, `find_preset_temp()` fell through and returned the heating eco preset (18.5 °C), which was sent as the setpoint to the underlying AC unit. When the window closed and `COOL` was restored, the regulation had accumulated a large negative error, causing the compressor to activate immediately and aggressively cool toward 18.5 °C.

### The Fix — [`base_thermostat.py`](custom_components/versatile_thermostat/base_thermostat.py:1677)

One condition was added, mirroring the existing `OFF` case:

```python
if (
    (self._ac_mode and self.vtherm_hvac_mode == VThermHvacMode_COOL)
    or (self.vtherm_hvac_mode == VThermHvacMode_OFF and self.requested_state.hvac_mode == VThermHvacMode_COOL)
    # issue #1958 - when window_action=fan_only temporarily switches the mode to FAN_ONLY,
    # the user's intent (requested_state) is still COOL, so we must use AC presets.
    or (self.vtherm_hvac_mode == VThermHvacMode_FAN_ONLY and self.requested_state.hvac_mode == VThermHvacMode_COOL)
):
    preset_name += PRESET_AC_SUFFIX
```

### The Failing Test — [`tests/test_window.py`](tests/test_window.py:2996)

`test_window_action_fan_only_ac_mode_uses_ac_preset_temp` creates an AC-mode `over_climate` VTherm with:
- `eco_temp = 18.5 °C` (heating) and `eco_ac_temp = 25.0 °C` (cooling)
- `window_action = fan_only`
- underlying that supports `FAN_ONLY`

It asserts that while the window is open (mode = `fan_only`) the target temperature is **25.0 °C** (AC eco), not 18.5 °C (heating eco). This test failed before the fix and passes after it.

### Test Results

```
603 passed, 2 skipped in 67.85s   ← full suite, zero regressions
```
