### PR TITLE
prevent overide of origional preset on additional presses

### DIFF
--- a/custom_components/versatile_thermostat/feature_timed_preset_manager.py
+++ b/custom_components/versatile_thermostat/feature_timed_preset_manager.py
@@ -148,7 +148,8 @@ class FeatureTimedPresetManager(BaseFeatureManager):
         self._cancel_timed_preset_timer()
 
         # Capture the original preset before overriding it
-        self._original_preset = self._vtherm.requested_state.preset
+        if not self._is_timed_preset_active:
+            self._original_preset = self._vtherm.requested_state.preset
 
         # Store the timed preset information
         self._timed_preset = preset


### PR DESCRIPTION
Fixes a bug where calling set_timed_preset while a timed preset is already active would overwrite _original_preset with the currently active timed preset. When the timer expired, the thermostat would "restore" to the boost preset rather than the genuine pre-boost preset, leaving it stuck in boost indefinitely with timed_active: false.

In feature_timed_preset_manager.py, _original_preset is now only captured when no timed preset is currently active, so subsequent calls preserve the true restore target.

Related issue

Fixes #1961  set_timed_preset called while timed preset already active overwrites original_preset, leaving thermostat stuck in boost indefinitely.

Change

custom_components/versatile_thermostat/feature_timed_preset_manager.py:151

# Before
  self._original_preset = self._vtherm.requested_state.preset

# After
  if not self._is_timed_preset_active:
      self._original_preset = self._vtherm.requested_state.preset