### PR TITLE
Fix over_climate underlying HVAC sync when VTherm is off (#1976)

### DIFF
--- a/custom_components/versatile_thermostat/underlyings.py
+++ b/custom_components/versatile_thermostat/underlyings.py
@@ -630,6 +630,16 @@ class UnderlyingClimate(UnderlyingEntity):
 
         return True
 
+    async def turn_off(self):
+        """Turn the underlying climate off."""
+        await self.set_hvac_mode(VThermHvacMode_OFF)
+
+    async def turn_on(self):
+        """Turn the underlying climate back on using the VTherm mode."""
+        desired_hvac_mode = self._thermostat.vtherm_hvac_mode
+        if desired_hvac_mode not in [None, VThermHvacMode_OFF, VThermHvacMode_SLEEP]:
+            await self.set_hvac_mode(desired_hvac_mode)
+
     @overrides
     def remove_entity(self):
         """Remove the entity"""
@@ -640,6 +650,39 @@ class UnderlyingClimate(UnderlyingEntity):
             self._cancel_set_temperature_later()
             self._cancel_set_temperature_later = None
         super().remove_entity()
+
+    def _desired_device_active_state(self) -> bool | None:
+        """Return whether the underlying climate is expected to actively run.
+
+        This is derived from the VTherm requested HVAC mode plus the current /
+        target temperatures, so it still works when the underlying climate was
+        forced to OFF while VTherm itself remains in HEAT/COOL.
+        """
+        desired_hvac_mode = self._thermostat.vtherm_hvac_mode
+        if desired_hvac_mode in [VThermHvacMode_OFF, VThermHvacMode_SLEEP, None]:
+            return False
+
+        if desired_hvac_mode == VThermHvacMode_FAN_ONLY:
+            return True
+
+        target = self.underlying_target_temperature
+        if target is None:
+            target = self._thermostat.target_temperature
+
+        current = self.underlying_current_temperature
+        if current is None:
+            current = self._thermostat.current_temperature
+
+        if target is None or current is None:
+            return None
+
+        if desired_hvac_mode in [VThermHvacMode_COOL, VThermHvacMode_DRY]:
+            return target < current
+
+        if desired_hvac_mode in [VThermHvacMode_HEAT, VThermHvacMode_HEAT_COOL, VThermHvacMode_AUTO]:
+            return target > current
+
+        return None
 
     @property
     def should_device_be_active(self):
@@ -1109,22 +1152,36 @@ class UnderlyingClimate(UnderlyingEntity):
         self._step_sync_entity = step_sync_entity
 
     async def check_and_repair(self) -> bool:
-        """Check if the underlying device state matches the desired state and repair if needed.
-        Returns True if a repair was performed."""
-        hvac_mode = self._thermostat.vtherm_hvac_mode
+        """Repair an underlying climate that stayed ON while VTherm is idle/OFF.
 
-        under_hvac_mode = self.hvac_mode
-
-        _LOGGER.debug("%s - Checking if underlying climate state needs repair. hvac_mode=%s, under_hvac_mode=%s", self, hvac_mode, under_hvac_mode)
-
-        if hvac_mode is None or under_hvac_mode is None:
+        For climates, a mode mismatch matters even when both VTherm and the
+        underlying report an inactive/idle action. In that case the generic
+        active/inactive comparison is insufficient because the device can still
+        physically blow air while remaining in HEAT/COOL.
+        """
+        state = self._state_manager.get_state(self._entity_id)
+        if state is None or state.state in [STATE_UNAVAILABLE, STATE_UNKNOWN]:
             return False
 
-        if str(hvac_mode) == str(under_hvac_mode):
-            return False
+        desired_active = self._desired_device_active_state()
+        current_hvac_mode = VThermHvacMode(state.state)
 
-        await self.set_hvac_mode(hvac_mode)
-        return True
+        _LOGGER.debug(
+            "%s - Checking if underlying climate state needs repair. desired_active=%s, current_hvac_mode=%s",
+            self,
+            desired_active,
+            current_hvac_mode,
+        )
+
+        if desired_active is False and current_hvac_mode != VThermHvacMode_OFF:
+            await self.turn_off()
+            return True
+
+        if desired_active is True and current_hvac_mode == VThermHvacMode_OFF:
+            await self.turn_on()
+            return True
+
+        return False
 
     @property
     def min_sync_entity(self) -> float:

--- a/tests/test_underlying_climate_repair.py
+++ b/tests/test_underlying_climate_repair.py
@@ -1,0 +1,116 @@
+# pylint: disable=missing-function-docstring, protected-access
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from homeassistant.components.climate import HVACAction, HVACMode
+from homeassistant.core import State
+
+from custom_components.versatile_thermostat.underlyings import UnderlyingClimate
+from custom_components.versatile_thermostat.vtherm_hvac_mode import (
+    VThermHvacMode_COOL,
+    VThermHvacMode_HEAT,
+    VThermHvacMode_OFF,
+)
+
+
+def _make_thermostat(hvac_mode, target_temperature, current_temperature):
+    thermostat = MagicMock()
+    thermostat.vtherm_hvac_mode = hvac_mode
+    thermostat.target_temperature = target_temperature
+    thermostat.current_temperature = current_temperature
+    thermostat.now = None
+    thermostat.init_underlyings_completed = AsyncMock()
+    thermostat.underlying_changed = AsyncMock()
+
+    power_manager = MagicMock()
+    power_manager.add_power_consumption_to_central_power_manager = MagicMock()
+    power_manager.sub_power_consumption_to_central_power_manager = MagicMock()
+    power_manager.check_power_available = AsyncMock(return_value=(True, None))
+    thermostat.power_manager = power_manager
+    return thermostat
+
+
+@pytest.mark.asyncio
+async def test_underlying_climate_turn_off_delegates_to_hvac_off(hass):
+    hass.services = MagicMock()
+    hass.services.async_call = AsyncMock()
+
+    thermostat = _make_thermostat(VThermHvacMode_COOL, 20, 26)
+    under = UnderlyingClimate(hass=hass, thermostat=thermostat, climate_entity_id="climate.test")
+    under.set_hvac_mode = AsyncMock()
+
+    await under.turn_off()
+
+    under.set_hvac_mode.assert_awaited_once_with(VThermHvacMode_OFF)
+
+
+@pytest.mark.asyncio
+async def test_underlying_climate_turn_on_restores_vtherm_mode(hass):
+    hass.services = MagicMock()
+    hass.services.async_call = AsyncMock()
+
+    thermostat = _make_thermostat(VThermHvacMode_HEAT, 22, 18)
+    under = UnderlyingClimate(hass=hass, thermostat=thermostat, climate_entity_id="climate.test")
+    under.set_hvac_mode = AsyncMock()
+
+    await under.turn_on()
+
+    under.set_hvac_mode.assert_awaited_once_with(VThermHvacMode_HEAT)
+
+
+@pytest.mark.asyncio
+async def test_underlying_climate_repair_turns_idle_cool_mode_off(hass):
+    hass.services = MagicMock()
+    hass.services.async_call = AsyncMock()
+
+    thermostat = _make_thermostat(VThermHvacMode_COOL, 25, 23)
+    under = UnderlyingClimate(hass=hass, thermostat=thermostat, climate_entity_id="climate.test")
+    under.turn_off = AsyncMock()
+    under.turn_on = AsyncMock()
+    under.state_manager.get_state = MagicMock(
+        return_value=State(
+            "climate.test",
+            HVACMode.COOL,
+            {
+                "hvac_action": HVACAction.IDLE,
+                "temperature": 25,
+                "current_temperature": 23,
+            },
+        )
+    )
+
+    repaired = await under.check_and_repair()
+
+    assert repaired is True
+    under.turn_off.assert_awaited_once()
+    under.turn_on.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_underlying_climate_repair_turns_off_climate_back_on_when_demand_returns(hass):
+    hass.services = MagicMock()
+    hass.services.async_call = AsyncMock()
+
+    thermostat = _make_thermostat(VThermHvacMode_COOL, 20, 26)
+    under = UnderlyingClimate(hass=hass, thermostat=thermostat, climate_entity_id="climate.test")
+    under.turn_off = AsyncMock()
+    under.turn_on = AsyncMock()
+    under.state_manager.get_state = MagicMock(
+        return_value=State(
+            "climate.test",
+            HVACMode.OFF,
+            {
+                "hvac_action": HVACAction.OFF,
+                "temperature": 20,
+                "current_temperature": 26,
+            },
+        )
+    )
+
+    repaired = await under.check_and_repair()
+
+    assert repaired is True
+    under.turn_on.assert_awaited_once()
+    under.turn_off.assert_not_awaited()


### PR DESCRIPTION
## Summary
Fixes #1976.

Turn the underlying climate off when an `over_climate` VTherm is idle/off but the underlying entity is still left in its previous HVAC mode.

## Changes
- add an `UnderlyingClimate` repair path to sync the underlying HVAC mode to `off` when needed
- add regression tests for the idle/off synchronization cases

## Validation
- `pytest -q tests/test_underlying_climate_repair.py`
- `pytest -q`

## Disclaimer

I used Codex to help prepare this fix, so please review the repair logic carefully.

The added tests reproduce the `UnderlyingClimate` state mismatch and validate the repair path, but they do not cover the full end-to-end `auto_start_stop` flow with a real underlying climate integration.
