### PR TITLE
Register underlying entities before startup state reads

### DIFF
--- a/custom_components/versatile_thermostat/underlying_state_manager.py
+++ b/custom_components/versatile_thermostat/underlying_state_manager.py
@@ -78,7 +78,11 @@ class UnderlyingStateManager:
         """Return the last known `State` for `entity_id`, or `None` if unknown."""
         idx = self._index_of(entity_id)
         if idx is None:
-            _LOGGER.error("UnderlyingStateManager - Requested state for unknown entity_id: %s", entity_id)
+            _LOGGER.error(
+                "UnderlyingStateManager - Requested state for unknown entity_id: %s. Managed entity_ids are: %s",
+                entity_id,
+                self._entity_ids,
+            )
             return None
         return self._states[idx]
 
@@ -125,6 +129,14 @@ class UnderlyingStateManager:
         except ValueError:
             return None
 
+    def register_underlying_entities(self, entity_ids: List[str]) -> None:
+        """Register entity IDs without starting listeners or notifying callbacks."""
+        for entity_id in entity_ids:
+            if entity_id in self._entity_ids:
+                continue
+            self._entity_ids.append(entity_id)
+            self._states.append(None)
+
     def add_underlying_entities(self, entity_ids: List[str]) -> None:
         """Add multiple entity_ids to the monitored list at runtime.
 
@@ -135,12 +147,14 @@ class UnderlyingStateManager:
         """
         added = []
         for entity_id in entity_ids:
-            if entity_id in self._entity_ids:
-                continue
-            self._entity_ids.append(entity_id)
+            idx = self._index_of(entity_id)
             state = self._hass.states.get(entity_id)
-            # should always add an initial state even if None
-            self._states.append(state)
+            if idx is None:
+                self._entity_ids.append(entity_id)
+                self._states.append(state)
+                idx = len(self._states) - 1
+            else:
+                self._states[idx] = state
             if state and state.state not in [STATE_UNAVAILABLE, STATE_UNKNOWN, None]:
                 # but don't notify if not a real state
                 added.append(entity_id)

--- a/custom_components/versatile_thermostat/underlyings.py
+++ b/custom_components/versatile_thermostat/underlyings.py
@@ -87,6 +87,7 @@ class UnderlyingEntity:
         self._last_command_sent_datetime: datetime = dt_util.utc_from_timestamp(0)
         # Use UnderlyingStateManager to track underlying entity state
         self._state_manager: UnderlyingStateManager = UnderlyingStateManager(self._hass, on_change=self._underlying_changed)
+        self._state_manager.register_underlying_entities([self._entity_id])
         self._is_initialized: bool = False
         self._api = VersatileThermostatAPI.get_vtherm_api(hass)
 

--- a/tests/test_check_initial_state.py
+++ b/tests/test_check_initial_state.py
@@ -57,7 +57,7 @@ async def test_check_initial_state_underlying_switch(hass, hvac_mode, last_state
 
     # Ensure no previous state
     assert u._last_known_underlying_state is None
-    assert u.state_manager.is_all_states_initialized is True
+    assert u.state_manager.is_all_states_initialized is False
 
     u.startup()
     # because hass is a MagicMock, the switch.test will have an initial state

--- a/tests/test_under_state_manager.py
+++ b/tests/test_under_state_manager.py
@@ -1,5 +1,6 @@
 # pylint: disable=unused-argument, line-too-long, protected-access
 """Unit tests for UnderlyingStateManager."""
+import logging
 from typing import List
 
 import pytest
@@ -17,6 +18,54 @@ async def test_manager_initial_empty(hass: HomeAssistant):
     assert mgr._entity_ids == []
     # empty set of states should be considered initialized
     assert mgr.is_all_states_initialized is True
+
+
+async def test_registered_entity_before_startup_does_not_log_error(hass: HomeAssistant, caplog):
+    """A registered entity can be read before startup without being unknown."""
+    mgr = UnderlyingStateManager(hass)
+    mgr.register_underlying_entities(["climate.late_start"])
+
+    with caplog.at_level(logging.ERROR):
+        state = mgr.get_state("climate.late_start")
+
+    assert state is None
+    assert "Requested state for unknown entity_id" not in caplog.text
+    assert mgr._entity_ids == ["climate.late_start"]
+
+
+async def test_registered_entity_startup_refreshes_state_and_notifies(hass: HomeAssistant):
+    """Startup refreshes a pre-registered entity and sends the initial callback."""
+    calls: List[tuple] = []
+
+    async def on_change(entity_id: str, state, old_state):
+        calls.append((entity_id, state.state if state else None))
+
+    mgr = UnderlyingStateManager(hass, on_change=on_change)
+    mgr.register_underlying_entities(["climate.late_start"])
+    hass.states.async_set("climate.late_start", "cool")
+
+    mgr.add_underlying_entities(["climate.late_start"])
+    await hass.async_block_till_done()
+
+    state = mgr.get_state("climate.late_start")
+    assert state is not None
+    assert state.state == "cool"
+    assert calls == [("climate.late_start", "cool")]
+
+
+async def test_get_state_for_unmanaged_entity_after_registration_logs_error(
+    hass: HomeAssistant, caplog
+):
+    """A real unmanaged lookup remains visible as a configuration/code error."""
+    mgr = UnderlyingStateManager(hass)
+    mgr.add_underlying_entities(["climate.managed"])
+
+    with caplog.at_level(logging.ERROR):
+        state = mgr.get_state("climate.other")
+
+    assert state is None
+    assert "Requested state for unknown entity_id: climate.other" in caplog.text
+    assert mgr._entity_ids == ["climate.managed"]
 
 
 async def test_add_entities_and_state_tracking(hass: HomeAssistant):


### PR DESCRIPTION
#### Summary
- Register underlying entity IDs in `UnderlyingStateManager` when the underlying entity is created.
- Refresh registered states when startup listeners are attached.
- Keep the error log for truly unmanaged entity IDs, with managed IDs included for diagnostics.
- Add tests for pre-startup state reads and startup refresh behavior.

#### Rationale
During startup, VTherm can request the state of a configured underlying entity before `add_underlying_entities()` has attached listeners. Those reads were logged as unknown entity IDs even though the entities were valid. Registering the IDs earlier fixes the lifecycle ordering instead of hiding the error.