### PR TITLE
Add return type annotation to test_ema_basics function

### DIFF
--- a/tests/test_ema.py
+++ b/tests/test_ema.py
@@ -9,7 +9,7 @@ from custom_components.versatile_thermostat.ema import ExponentialMovingAverage
 from .commons import get_tz
 
 
-def test_ema_basics(hass: HomeAssistant):
+def test_ema_basics(hass: HomeAssistant) -> None:
     """Test the EMA calculation with basic features"""
 
     tz = get_tz(hass)  # pylint: disable=invalid-name


### PR DESCRIPTION
### Problem Background
The test function `test_ema_basics` in `tests/test_ema.py` was missing a return type annotation. Adding type annotations enhances code readability, supports static type checking tools like mypy, and aligns with best practices for Python code quality.

### Changes
- Added return type annotation `-> None` to the `test_ema_basics` function, as it is a test function that does not return any value. This change is minimal and does not affect the function's behavior or API.

### Verification
- Run the existing test suite to ensure no functional regressions occur.
- Optionally, use a type checker (e.g., mypy) to verify the annotation is correct and there are no type-related issues.