### PR TITLE
Fix #2003: set_temperature crashes when underlying supported_features is a plain int

### DIFF
--- a/custom_components/versatile_thermostat/underlyings.py
+++ b/custom_components/versatile_thermostat/underlyings.py
@@ -860,8 +860,15 @@ class UnderlyingClimate(UnderlyingEntity):
 
         _LOGGER.info("%s - Set setpoint temperature to: %s", self, target_temp)
 
-        # Issue 807 add TARGET_TEMPERATURE only if in the features
-        if ClimateEntityFeature.TARGET_TEMPERATURE_RANGE in self.supported_features:
+        # Issue 807 add TARGET_TEMPERATURE only if in the features.
+        # Use a bitwise test (not the `in` operator): self.supported_features is read
+        # from the underlying entity's state attributes, where Home Assistant may store
+        # it as a plain int (e.g. for restored states). `EnumMember in <int>` raises
+        # `TypeError: argument of type 'int' is not a container or iterable`, whereas
+        # the bitwise `&` works for both a plain int and a ClimateEntityFeature IntFlag.
+        # This matches the bitwise pattern already used elsewhere in this class
+        # (fan_modes / swing_modes).
+        if self.supported_features & ClimateEntityFeature.TARGET_TEMPERATURE_RANGE:
             data.update(
                 {
                     "target_temp_high": target_temp,
@@ -869,7 +876,7 @@ class UnderlyingClimate(UnderlyingEntity):
                 }
             )
 
-        if ClimateEntityFeature.TARGET_TEMPERATURE in self.supported_features:
+        if self.supported_features & ClimateEntityFeature.TARGET_TEMPERATURE:
             data["temperature"] = target_temp
 
         try:

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -1340,3 +1340,66 @@ async def test_bug_1947(hass: HomeAssistant, skip_hass_states_is_state):
     assert vtherm.hvac_off_reason is None
     assert fake_underlying_climate.hvac_mode == VThermHvacMode_HEAT
     assert fake_underlying_climate.target_temperature == 21.0
+
+
+@pytest.mark.parametrize(
+    "supported_features",
+    [
+        # The bug: a restored / rehydrated underlying state carries
+        # `supported_features` as a plain int (this is how Home Assistant stores
+        # it for restored states). `EnumMember in <int>` used to raise TypeError.
+        int(ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE),
+        # The healthy case: a live state carries the ClimateEntityFeature IntFlag.
+        ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE,
+    ],
+    ids=["plain_int_restored_state", "intflag_live_state"],
+)
+async def test_bug_2003(hass: HomeAssistant, supported_features):
+    """Bug #2003 - UnderlyingClimate.set_temperature() must not crash when the
+    underlying entity's `supported_features` state attribute is a plain int.
+
+    Home Assistant stores `supported_features` as a plain int for restored states
+    (e.g. right after the underlying entity comes back from `unavailable` or its
+    integration is reloaded). The previous code used
+    `ClimateEntityFeature.X in self.supported_features`, which raises
+    `TypeError: argument of type 'int' is not a container or iterable` for a plain
+    int. The fix uses a bitwise test, which works for both a plain int and a
+    ClimateEntityFeature IntFlag.
+    """
+
+    thermostat = MagicMock()
+
+    under = UnderlyingClimate(hass=hass, thermostat=thermostat, climate_entity_id="climate.test")
+
+    # Reproduce the underlying state: `supported_features` of the parametrized type,
+    # plus min/max so clamp_sent_value() works.
+    under_state = State(
+        "climate.test",
+        HVACMode.COOL,
+        attributes={
+            "supported_features": supported_features,
+            "min_temp": 7.0,
+            "max_temp": 35.0,
+            "temperature": 20.0,
+        },
+    )
+    under.state_manager.get_state = MagicMock(return_value=under_state)
+
+    # Capture the underlying service call instead of really issuing it.
+    under.hass_services_async_call = AsyncMock()
+
+    with patch.object(type(under), "is_initialized", new_callable=PropertyMock, return_value=True):
+        # Must not raise (it used to raise TypeError for the plain-int case).
+        await under.set_temperature(20.0, 35.0, 7.0)
+
+    # The setpoint was delivered to the underlying climate entity.
+    assert under.hass_services_async_call.await_count == 1
+    call_args = under.hass_services_async_call.await_args
+    assert call_args.args[0] == CLIMATE_DOMAIN
+    assert call_args.args[1] == SERVICE_SET_TEMPERATURE
+    sent_data = call_args.args[2]
+    # TARGET_TEMPERATURE is supported -> the "temperature" key is sent.
+    assert sent_data["temperature"] == 20.0
+    # TARGET_TEMPERATURE_RANGE is NOT supported -> the range keys are absent.
+    assert "target_temp_high" not in sent_data
+    assert "target_temp_low" not in sent_data


### PR DESCRIPTION
## Fixes #2003

### Problem

For an `over_climate` VTherm, `UnderlyingClimate.set_temperature()` can crash with:

```
TypeError: argument of type 'int' is not a container or iterable
```

every time VTherm pushes a setpoint to the underlying `climate` entity (manual temperature change, preset change, or an auto-regulation cycle). It is intermittent and "goes away after a few tries", but it is a deterministic type bug.

`set_temperature()` used the membership operator `in` against `self.supported_features`:

```python
if ClimateEntityFeature.TARGET_TEMPERATURE_RANGE in self.supported_features:
    ...
if ClimateEntityFeature.TARGET_TEMPERATURE in self.supported_features:
    ...
```

`self.supported_features` is read from the underlying entity's **state attributes**:

```python
return self.get_underlying_attribute("supported_features") or ClimateEntityFeature(0)
```

Home Assistant stores `supported_features` as a **plain `int`** for restored states (e.g. right after the underlying entity returns from `unavailable`, or its integration is reloaded). `ClimateEntityFeature.X in <int>` raises, because a plain `int` is not iterable. When the live state (carrying the `ClimateEntityFeature` `IntFlag`) lands a moment later, the retry succeeds — hence the intermittency.

A worse consequence than the UI toast: an auto-regulation cycle that lands in that window is silently dropped, so the underlying device never receives the computed setpoint until the next successful cycle. See #2003 for a full real-world example (LG VRF heat pump via the `lg_thinq` cloud integration, whose entities frequently flap to `unavailable`).

### Fix

Use a bitwise test instead of `in`. This is correct for both a plain `int` and a `ClimateEntityFeature` `IntFlag`, and matches the pattern already used elsewhere in the same class (`fan_modes` / `swing_modes` / `swing_horizontal_modes`):

```python
if self.supported_features & ClimateEntityFeature.TARGET_TEMPERATURE_RANGE:
    ...
if self.supported_features & ClimateEntityFeature.TARGET_TEMPERATURE:
    ...
```

### Test

Adds `test_bug_2003` to `tests/test_bugs.py`, parametrized over `supported_features` being a **plain `int`** (the restored-state case that previously crashed) and a **`ClimateEntityFeature` IntFlag** (the healthy case). It asserts `set_temperature()` does not raise and that the underlying `climate.set_temperature` service call is issued with the correct payload. The test fails on `main` (TypeError for the plain-int parametrization) and passes with this fix.

### Checklist

- [x] Code lints with `black`
- [x] Regression test added and passing
- [x] No behavior change for the healthy (IntFlag) path
