### PR TITLE
Add optional fan-only action for auto-start/stop

### DIFF
--- a/custom_components/versatile_thermostat/config_flow.py
+++ b/custom_components/versatile_thermostat/config_flow.py
@@ -1242,6 +1242,7 @@ class VersatileThermostatBaseConfigFlow(FlowHandler):
                 del self._infos[CONF_CENTRAL_BOILER_DEACTIVATION_SRV]
         if not self._infos[CONF_USE_AUTO_START_STOP_FEATURE]:
             self._infos[CONF_AUTO_START_STOP_LEVEL] = AUTO_START_STOP_LEVEL_NONE
+            self._infos[CONF_AUTO_START_STOP_ACTION] = AUTO_START_STOP_ACTION_TURN_OFF
 
         # Removes temporary value
         if COMES_FROM in self._infos:

--- a/custom_components/versatile_thermostat/config_schema.py
+++ b/custom_components/versatile_thermostat/config_schema.py
@@ -265,6 +265,13 @@ STEP_AUTO_START_STOP = vol.Schema(  # pylint: disable=invalid-name
                 mode="dropdown",
             )
         ),
+        vol.Optional(CONF_AUTO_START_STOP_ACTION, default=AUTO_START_STOP_ACTION_TURN_OFF): selector.SelectSelector(
+            selector.SelectSelectorConfig(
+                options=CONF_AUTO_START_STOP_ACTIONS,
+                translation_key="auto_start_stop_action",
+                mode="dropdown",
+            )
+        ),
     }
 )
 

--- a/custom_components/versatile_thermostat/const.py
+++ b/custom_components/versatile_thermostat/const.py
@@ -222,6 +222,7 @@ CONF_USED_BY_CENTRAL_BOILER = "used_by_controls_central_boiler"
 CONF_WINDOW_ACTION = "window_action"
 
 CONF_AUTO_START_STOP_LEVEL = "auto_start_stop_level"
+CONF_AUTO_START_STOP_ACTION = "auto_start_stop_action"
 AUTO_START_STOP_LEVEL_NONE = "auto_start_stop_none"
 AUTO_START_STOP_LEVEL_VERY_SLOW = "auto_start_stop_very_slow"
 AUTO_START_STOP_LEVEL_SLOW = "auto_start_stop_slow"
@@ -234,6 +235,12 @@ CONF_AUTO_START_STOP_LEVELS = [
     AUTO_START_STOP_LEVEL_MEDIUM,
     AUTO_START_STOP_LEVEL_FAST,
 ]
+AUTO_START_STOP_ACTION_TURN_OFF = "auto_start_stop_action_turn_off"
+AUTO_START_STOP_ACTION_FAN_ONLY = "auto_start_stop_action_fan_only"
+CONF_AUTO_START_STOP_ACTIONS = [
+    AUTO_START_STOP_ACTION_TURN_OFF,
+    AUTO_START_STOP_ACTION_FAN_ONLY,
+]
 
 # For explicit typing purpose only
 TYPE_AUTO_START_STOP_LEVELS = Literal[  # pylint: disable=invalid-name
@@ -242,6 +249,10 @@ TYPE_AUTO_START_STOP_LEVELS = Literal[  # pylint: disable=invalid-name
     AUTO_START_STOP_LEVEL_SLOW,
     AUTO_START_STOP_LEVEL_VERY_SLOW,
     AUTO_START_STOP_LEVEL_NONE,
+]
+TYPE_AUTO_START_STOP_ACTIONS = Literal[  # pylint: disable=invalid-name
+    AUTO_START_STOP_ACTION_TURN_OFF,
+    AUTO_START_STOP_ACTION_FAN_ONLY,
 ]
 
 HVAC_OFF_REASON_NAME = "hvac_off_reason"

--- a/custom_components/versatile_thermostat/feature_auto_start_stop_manager.py
+++ b/custom_components/versatile_thermostat/feature_auto_start_stop_manager.py
@@ -35,6 +35,7 @@ class FeatureAutoStartStopManager(BaseFeatureManager):
             "auto_start_stop_level",
             "auto_start_stop_dtmin",
             "auto_start_stop_enable",
+            "auto_start_stop_action",
             "auto_start_stop_accumulated_error",
             "auto_start_stop_accumulated_error_threshold",
             "auto_start_stop_last_switch_date",
@@ -46,6 +47,7 @@ class FeatureAutoStartStopManager(BaseFeatureManager):
         super().__init__(vtherm, hass)
 
         self._auto_start_stop_level: str = AUTO_START_STOP_LEVEL_NONE
+        self._auto_start_stop_action: str = AUTO_START_STOP_ACTION_TURN_OFF
         self._auto_start_stop_algo: AutoStartStopDetectionAlgorithm | None = None
         self._is_configured: bool = False
         self._is_auto_start_stop_enabled: bool = False
@@ -64,9 +66,14 @@ class FeatureAutoStartStopManager(BaseFeatureManager):
                 entry_infos.get(CONF_AUTO_START_STOP_LEVEL, None)
                 or AUTO_START_STOP_LEVEL_NONE
             )
+            self._auto_start_stop_action = (
+                entry_infos.get(CONF_AUTO_START_STOP_ACTION, None)
+                or AUTO_START_STOP_ACTION_TURN_OFF
+            )
             self._is_configured = True
         else:
             self._auto_start_stop_level = AUTO_START_STOP_LEVEL_NONE
+            self._auto_start_stop_action = AUTO_START_STOP_ACTION_TURN_OFF
             self._is_configured = False
 
         # Initialize the enable flag synchronously so the manager is operational
@@ -126,7 +133,7 @@ class FeatureAutoStartStopManager(BaseFeatureManager):
                             "type": "stop",
                             "name": self.name,
                             "cause": "Auto stop conditions reached",
-                            "hvac_mode": str(VThermHvacMode_OFF),
+                            "hvac_mode": str(self.auto_stop_hvac_mode),
                             "saved_hvac_mode": str(self._vtherm.requested_state.hvac_mode),
                             "target_temperature": self._vtherm.target_temperature,
                             "current_temperature": self._vtherm.current_temperature,
@@ -182,7 +189,7 @@ class FeatureAutoStartStopManager(BaseFeatureManager):
             self._is_auto_start_stop_enabled = is_enabled
 
             # Send an event if the vtherm was off due to auto-start/stop and enable has been set to false
-            if not is_enabled and self._vtherm.hvac_mode == VThermHvacMode_OFF and self._vtherm.hvac_off_reason == HVAC_OFF_REASON_AUTO_START_STOP:
+            if not is_enabled and self.is_auto_stop_detected:
                 _LOGGER.debug("%s - the vtherm is off cause auto-start/stop and enable have been set to false -> starts the VTherm")
                 # Send an event
                 self._vtherm.send_event(
@@ -268,6 +275,7 @@ class FeatureAutoStartStopManager(BaseFeatureManager):
                         "auto_start_stop_enable": self.auto_start_stop_enable,
                         "auto_start_stop_level": self._auto_start_stop_algo.level,
                         "auto_start_stop_dtmin": self._auto_start_stop_algo.dt_min,
+                        "auto_start_stop_action": self.auto_start_stop_action,
                         "auto_start_stop_accumulated_error": self._auto_start_stop_algo.accumulated_error,
                         "auto_start_stop_accumulated_error_threshold": self._auto_start_stop_algo.accumulated_error_threshold,
                         "auto_start_stop_last_switch_date": self._auto_start_stop_algo.last_switch_date,
@@ -298,14 +306,26 @@ class FeatureAutoStartStopManager(BaseFeatureManager):
         return self._auto_start_stop_level
 
     @property
+    def auto_start_stop_action(self) -> str:
+        """Return the auto start/stop action."""
+        return self._auto_start_stop_action
+
+    @property
+    def auto_stop_hvac_mode(self) -> VThermHvacMode:
+        """Return the hvac mode used when auto-stop is detected."""
+        if self.auto_start_stop_action == AUTO_START_STOP_ACTION_FAN_ONLY and VThermHvacMode_FAN_ONLY in self._vtherm.vtherm_hvac_modes:
+            return VThermHvacMode_FAN_ONLY
+        return VThermHvacMode_OFF
+
+    @property
     def auto_start_stop_enable(self) -> bool:
         """Returns the auto_start_stop_enable"""
         return self._is_auto_start_stop_enabled
 
     @property
     def is_auto_stopped(self) -> bool:
-        """Returns the is vtherm is stopped and reason is AUTO_START_STOP"""
-        return self._vtherm.hvac_mode == VThermHvacMode_OFF and self._vtherm.hvac_off_reason == HVAC_OFF_REASON_AUTO_START_STOP
+        """Returns if vtherm is auto-stopped"""
+        return self.is_auto_stop_detected
 
     def reset_switch_delay(self):
         """Reset the switch delay in the algorithm to allow immediate restart.

--- a/custom_components/versatile_thermostat/state_manager.py
+++ b/custom_components/versatile_thermostat/state_manager.py
@@ -128,8 +128,10 @@ class StateManager:
                 vtherm.set_hvac_off_reason(HVAC_OFF_REASON_WINDOW_DETECTION)
 
         elif vtherm.auto_start_stop_manager and vtherm.auto_start_stop_manager.is_auto_stop_detected and self._requested_state.hvac_mode != VThermHvacMode_OFF:
-            self._current_state.set_hvac_mode(VThermHvacMode_OFF)
-            vtherm.set_hvac_off_reason(HVAC_OFF_REASON_AUTO_START_STOP)
+            auto_stop_hvac_mode = vtherm.auto_start_stop_manager.auto_stop_hvac_mode
+            self._current_state.set_hvac_mode(auto_stop_hvac_mode)
+            if auto_stop_hvac_mode == VThermHvacMode_OFF:
+                vtherm.set_hvac_off_reason(HVAC_OFF_REASON_AUTO_START_STOP)
 
         elif vtherm.last_central_mode == CENTRAL_MODE_COOL_ONLY and self._requested_state.hvac_mode != VThermHvacMode_OFF:
             if VThermHvacMode_COOL in vtherm.vtherm_hvac_modes:

--- a/custom_components/versatile_thermostat/strings.json
+++ b/custom_components/versatile_thermostat/strings.json
@@ -833,6 +833,12 @@
         "auto_start_stop_fast": "Fast detection"
       }
     },
+    "auto_start_stop_action": {
+      "options": {
+        "auto_start_stop_action_turn_off": "Turn off",
+        "auto_start_stop_action_fan_only": "Fan only"
+      }
+    },
     "auto_tpi_calculation_method": {
       "options": {
         "average": "Average",

--- a/custom_components/versatile_thermostat/thermostat_climate.py
+++ b/custom_components/versatile_thermostat/thermostat_climate.py
@@ -158,9 +158,11 @@ class ThermostatOverClimate(BaseThermostat[UnderlyingClimate]):
 
         self.stop_recalculate_later()
 
-        if self.vtherm_hvac_mode == VThermHvacMode_OFF:
+        if self.vtherm_hvac_mode in (VThermHvacMode_OFF, VThermHvacMode_FAN_ONLY):
             _LOGGER.debug(
-                "%s - don't send regulated temperature cause VTherm is off ", self
+                "%s - don't send regulated temperature cause VTherm is %s",
+                self,
+                self.vtherm_hvac_mode,
             )
             # In this case, reset the timer of last regulation change to avoid time delta too high
             self._last_regulation_change = self.now
@@ -308,6 +310,9 @@ class ThermostatOverClimate(BaseThermostat[UnderlyingClimate]):
     async def _send_auto_fan_mode(self):
         """Send the fan mode if auto_fan_mode and temperature gap is > threshold"""
         if not self._auto_fan_mode or not self._auto_activated_fan_mode:
+            return
+
+        if self.vtherm_hvac_mode == VThermHvacMode_FAN_ONLY:
             return
 
         dtemp = (

--- a/custom_components/versatile_thermostat/translations/cs.json
+++ b/custom_components/versatile_thermostat/translations/cs.json
@@ -833,6 +833,12 @@
                 "auto_start_stop_fast": "Rychlá detekce"
             }
         },
+        "auto_start_stop_action": {
+            "options": {
+                "auto_start_stop_action_turn_off": "Vypnout",
+                "auto_start_stop_action_fan_only": "Pouze ventilátor"
+            }
+        },
         "auto_tpi_calculation_method": {
             "options": {
                 "average": "Průměrný",

--- a/custom_components/versatile_thermostat/translations/de.json
+++ b/custom_components/versatile_thermostat/translations/de.json
@@ -825,6 +825,12 @@
         "auto_start_stop_fast": "Schnell"
       }
     },
+    "auto_start_stop_action": {
+      "options": {
+        "auto_start_stop_action_turn_off": "Ausschalten",
+        "auto_start_stop_action_fan_only": "Nur Lüfter"
+      }
+    },
     "auto_tpi_calculation_method": {
       "options": {
         "average": "Durchschnitt",

--- a/custom_components/versatile_thermostat/translations/en.json
+++ b/custom_components/versatile_thermostat/translations/en.json
@@ -833,6 +833,12 @@
                 "auto_start_stop_fast": "Fast detection"
             }
         },
+        "auto_start_stop_action": {
+            "options": {
+                "auto_start_stop_action_turn_off": "Turn off",
+                "auto_start_stop_action_fan_only": "Fan only"
+            }
+        },
         "auto_tpi_calculation_method": {
             "options": {
                 "average": "Average",

--- a/custom_components/versatile_thermostat/translations/fr.json
+++ b/custom_components/versatile_thermostat/translations/fr.json
@@ -835,6 +835,12 @@
         "auto_start_stop_fast": "Rapide"
       }
     },
+    "auto_start_stop_action": {
+      "options": {
+        "auto_start_stop_action_turn_off": "Éteindre",
+        "auto_start_stop_action_fan_only": "Ventilation seule"
+      }
+    },
     "auto_tpi_calculation_method": {
       "options": {
         "average": "Moyenne",

--- a/custom_components/versatile_thermostat/translations/it.json
+++ b/custom_components/versatile_thermostat/translations/it.json
@@ -835,6 +835,12 @@
                 "auto_start_stop_fast": "Rilevamento veloce"
             }
         },
+        "auto_start_stop_action": {
+            "options": {
+                "auto_start_stop_action_turn_off": "Spegni",
+                "auto_start_stop_action_fan_only": "Solo ventilatore"
+            }
+        },
         "auto_tpi_calculation_method": {
             "options": {
                 "average": "Media",

--- a/custom_components/versatile_thermostat/translations/pl.json
+++ b/custom_components/versatile_thermostat/translations/pl.json
@@ -774,6 +774,12 @@
         "auto_start_stop_fast": "Szybka detekcja"
       }
     },
+    "auto_start_stop_action": {
+      "options": {
+        "auto_start_stop_action_turn_off": "Wyłącz",
+        "auto_start_stop_action_fan_only": "Tylko wentylacja"
+      }
+    },
     "auto_tpi_calculation_method": {
       "options": {
         "average": "Średnia",

--- a/custom_components/versatile_thermostat/translations/ru.json
+++ b/custom_components/versatile_thermostat/translations/ru.json
@@ -726,6 +726,12 @@
         "auto_start_stop_medium": "Среднее обнаружение",
         "auto_start_stop_fast": "Быстрое обнаружение"
       }
+    },
+    "auto_start_stop_action": {
+      "options": {
+        "auto_start_stop_action_turn_off": "Выключить",
+        "auto_start_stop_action_fan_only": "Только вентилятор"
+      }
     }
   },
   "entity": {

--- a/custom_components/versatile_thermostat/translations/zh-Hans.json
+++ b/custom_components/versatile_thermostat/translations/zh-Hans.json
@@ -833,6 +833,12 @@
                 "auto_start_stop_fast": "快速检测"
             }
         },
+        "auto_start_stop_action": {
+            "options": {
+                "auto_start_stop_action_turn_off": "关闭",
+                "auto_start_stop_action_fan_only": "仅风扇"
+            }
+        },
         "auto_tpi_calculation_method": {
             "options": {
                 "average": "平均值",

--- a/documentation/en/feature-auto-start-stop.md
+++ b/documentation/en/feature-auto-start-stop.md
@@ -4,19 +4,22 @@
   - [Configure Auto-start/stop](#configure-auto-startstop)
   - [Usage](#usage)
 
-This feature allows _VTherm_ to stop an appliance that doesn't need to be on and restart it when conditions require it. This function includes three settings that control how quickly the appliance is stopped and restarted.
+This feature allows _VTherm_ to stop an appliance that doesn't need to be on and restart it when conditions require it. This function includes settings that control how quickly the appliance is stopped and restarted, and what action is used while auto-stop is active.
 Exclusively reserved for _VTherm_ of type `over_climate`, it applies to the following use case:
 1. Your appliance is permanently powered on and consumes electricity even when heating (or cooling) is not needed. This is often the case with heat pumps (_PAC_) that consume power even in standby mode.
 2. The temperature conditions are such that heating (or cooling) is not needed for a long period: the setpoint is higher (or lower) than the room temperature.
 3. The temperature rises (or falls), remains stable, or falls (or rises) slowly.
 
-In such cases, it is preferable to ask the appliance to turn off to avoid unnecessary power consumption in standby mode.
+In such cases, it is preferable to ask the appliance to turn off to avoid unnecessary power consumption in standby mode. For climate devices that support it, auto-start/stop can also switch the appliance to `fan_only` instead of `off` while keeping the requested heating or cooling mode ready to resume.
 
 ## Configure Auto-start/stop
 
 To use this feature, you need to:
 1. Add the `With auto-start and stop` function in the 'Functions' menu.
 2. Set the detection level in the 'Auto-start/stop' option that appears when the function is activated. Choose the detection level between 'Slow', 'Medium', and 'Fast'. With the 'Fast' setting, stops and restarts will occur more frequently.
+3. Choose the auto-stop action:
+   - `Turn off` keeps the existing behavior and switches the _VTherm_ and the underlying climate entity to `off`.
+   - `Fan only` switches the _VTherm_ and the underlying climate entity to `fan_only` while auto-stop is active, if the underlying climate entity supports this HVAC mode.
 
 ![image](images/config-auto-start-stop.png)
 
@@ -26,6 +29,8 @@ The 'Medium' setting sets the threshold to about 15 minutes, and the 'Fast' sett
 
 Note that these are not absolute settings since the algorithm takes into account the slope of the room temperature curve to respond accordingly. It is still possible that a restart occurs shortly after a stop if the temperature drops significantly.
 
+If `Fan only` is selected but the _VTherm_ does not support the `fan_only` HVAC mode, _VTherm_ falls back to `off`.
+
 ## Usage
 
 Once the function is configured, you will now have a new `switch` type entity that allows you to enable or disable auto-start/stop without modifying the configuration. This entity is available on the _VTherm_ device and is named `switch.<name>_enable_auto_start_stop`.
@@ -34,7 +39,7 @@ Once the function is configured, you will now have a new `switch` type entity th
 
 Check the box to allow auto-start and auto-stop, and leave it unchecked to disable the feature.
 
-Note: The auto-start/stop function will only turn a _VTherm_ back on if it was turned off by this function. This prevents unwanted or unexpected activations. Naturally, the off state is preserved even after a Home Assistant restart.
+Note: The auto-start/stop function will only restart a _VTherm_ from a state that was applied by this function. This prevents unwanted or unexpected activations. Naturally, the auto-stop state is preserved even after a Home Assistant restart.
 
 > ![Tip](images/tips.png) _*Notes*_
 > 1. The detection algorithm is described [here](algorithms.md#auto-startstop-algorithm).

--- a/tests/test_auto_start_stop.py
+++ b/tests/test_auto_start_stop.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 import logging
 from unittest.mock import patch, call
 
+from homeassistant.components.climate import SERVICE_SET_TEMPERATURE
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 
 from custom_components.versatile_thermostat.thermostat_climate import (
@@ -954,6 +955,122 @@ async def test_auto_start_stop_fast_ac_vtherm(
                 )
             ]
         )
+
+    vtherm.remove_thermostat()
+
+
+async def test_auto_start_stop_fan_only_action_sets_vtherm_and_underlying(hass: HomeAssistant, skip_hass_states_is_state):
+    """Test that auto-start/stop can use FAN_ONLY instead of OFF."""
+    fan_modes = ["low", "medium", "high", "boost", "mute", "auto", "turbo"]
+    temps = {
+        "frost": 7.0,
+        "eco": 17.0,
+        "comfort": 19.0,
+        "boost": 21.0,
+        "eco_ac": 27.0,
+        "comfort_ac": 25.0,
+        "boost_ac": 23.0,
+        "frost_away": 7.1,
+        "eco_away": 17.1,
+        "comfort_away": 19.1,
+        "boost_away": 21.1,
+        "eco_ac_away": 27.1,
+        "comfort_ac_away": 25.1,
+        "boost_ac_away": 23.1,
+    }
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="TheOverClimateMockName",
+        unique_id="overClimateUniqueId",
+        data={
+            CONF_NAME: "overClimate",
+            CONF_TEMP_SENSOR: "sensor.mock_temp_sensor",
+            CONF_THERMOSTAT_TYPE: CONF_THERMOSTAT_CLIMATE,
+            CONF_EXTERNAL_TEMP_SENSOR: "sensor.mock_ext_temp_sensor",
+            CONF_CYCLE_MIN: 5,
+            CONF_TEMP_MIN: 15,
+            CONF_TEMP_MAX: 30,
+            CONF_USE_WINDOW_FEATURE: False,
+            CONF_USE_MOTION_FEATURE: False,
+            CONF_USE_POWER_FEATURE: False,
+            CONF_USE_AUTO_START_STOP_FEATURE: True,
+            CONF_USE_PRESENCE_FEATURE: True,
+            CONF_PRESENCE_SENSOR: "binary_sensor.presence_sensor",
+            CONF_UNDERLYING_LIST: ["climate.mock_climate"],
+            CONF_MINIMAL_ACTIVATION_DELAY: 30,
+            CONF_MINIMAL_DEACTIVATION_DELAY: 0,
+            CONF_SAFETY_DELAY_MIN: 5,
+            CONF_SAFETY_MIN_ON_PERCENT: 0.3,
+            CONF_AUTO_FAN_MODE: CONF_AUTO_FAN_TURBO,
+            CONF_AC_MODE: True,
+            CONF_AUTO_START_STOP_LEVEL: AUTO_START_STOP_LEVEL_FAST,
+            CONF_AUTO_START_STOP_ACTION: AUTO_START_STOP_ACTION_FAN_ONLY,
+        },
+    )
+
+    fake_underlying_climate = await create_and_register_mock_climate(
+        hass,
+        "mock_climate",
+        "mock_climate",
+        {},
+        fan_modes=fan_modes,
+        hvac_modes=[
+            VThermHvacMode_OFF,
+            VThermHvacMode_COOL,
+            VThermHvacMode_HEAT,
+            VThermHvacMode_FAN_ONLY,
+        ],
+    )
+
+    vtherm: ThermostatOverClimate = await create_thermostat(hass, config_entry, "climate.overclimate")
+
+    await set_all_climate_preset_temp(hass, vtherm, temps, "overclimate")
+    assert vtherm._attr_extra_state_attributes["auto_start_stop_manager"]["auto_start_stop_action"] == AUTO_START_STOP_ACTION_FAN_ONLY
+    assert vtherm._auto_activated_fan_mode == "turbo"
+
+    tz = get_tz(hass)  # pylint: disable=invalid-name
+    now: datetime = datetime.now(tz=tz)
+
+    await send_presence_change_event(vtherm, True, False, now)
+    await send_temperature_change_event(vtherm, 27, now, True)
+    await vtherm.async_set_hvac_mode(VThermHvacMode_COOL)
+    await vtherm.async_set_preset_mode(VThermPreset.COMFORT)
+    await hass.async_block_till_done()
+
+    assert vtherm.target_temperature == 25.0
+    assert vtherm.hvac_mode == VThermHvacMode_COOL
+
+    now = now + timedelta(minutes=5)
+    vtherm.auto_start_stop_manager._auto_start_stop_algo._accumulated_error = 0
+    vtherm._set_now(now)
+    await send_temperature_change_event(vtherm, 25, now, True)
+    await hass.async_block_till_done()
+
+    now = now + timedelta(minutes=5)
+    with patch("custom_components.versatile_thermostat.underlyings.UnderlyingClimate.set_hvac_mode") as mock_underlying_set_hvac_mode:
+        vtherm._set_now(now)
+        await send_temperature_change_event(vtherm, 23, now, True)
+        await wait_for_local_condition(lambda: vtherm.hvac_mode == VThermHvacMode_FAN_ONLY, timeout=3.0, hass=hass)
+
+        assert vtherm.hvac_mode == VThermHvacMode_FAN_ONLY
+        assert vtherm.requested_state.hvac_mode == VThermHvacMode_COOL
+        mock_underlying_set_hvac_mode.assert_has_awaits(
+            [
+                call(VThermHvacMode_FAN_ONLY),
+            ]
+        )
+
+    with patch("homeassistant.core.ServiceRegistry.async_call") as mock_service_call:
+        await vtherm._send_regulated_temperature(force=True)
+        set_temperature_calls = [call_args for call_args in mock_service_call.call_args_list if call_args[0][0] == "climate" and call_args[0][1] == SERVICE_SET_TEMPERATURE]
+        assert set_temperature_calls == []
+
+    fake_underlying_climate.set_fan_mode("mute")
+    await hass.async_block_till_done()
+    with patch("custom_components.versatile_thermostat.underlyings.UnderlyingClimate.set_fan_mode") as mock_underlying_set_fan_mode:
+        await vtherm._send_auto_fan_mode()
+        mock_underlying_set_fan_mode.assert_not_awaited()
 
     vtherm.remove_thermostat()
 

--- a/tests/test_auto_start_stop_feature_manager.py
+++ b/tests/test_auto_start_stop_feature_manager.py
@@ -111,6 +111,38 @@ async def test_auto_start_stop_feature_manager_post_init(
         assert custom_attributes["auto_start_stop_manager"]["auto_start_stop_last_switch_date"] == auto_start_stop_manager._auto_start_stop_algo.last_switch_date
 
 
+async def test_auto_start_stop_feature_manager_stores_configured_action(
+    hass: HomeAssistant,
+):
+    """Test that the configured auto-start/stop action is stored and exposed."""
+    fake_vtherm = MagicMock(spec=BaseThermostat)
+    type(fake_vtherm).name = PropertyMock(return_value="the name")
+    type(fake_vtherm).have_valve_regulation = PropertyMock(return_value=False)
+    type(fake_vtherm).is_over_climate = PropertyMock(return_value=True)
+    type(fake_vtherm).is_on = PropertyMock(return_value=False)
+    fake_vtherm.hvac_off_reason = None
+
+    auto_start_stop_manager = FeatureAutoStartStopManager(fake_vtherm, hass)
+    auto_start_stop_manager.post_init(
+        {
+            CONF_USE_AUTO_START_STOP_FEATURE: True,
+            CONF_AUTO_START_STOP_LEVEL: AUTO_START_STOP_LEVEL_MEDIUM,
+            CONF_AUTO_START_STOP_ACTION: AUTO_START_STOP_ACTION_FAN_ONLY,
+        }
+    )
+
+    assert auto_start_stop_manager.auto_start_stop_action == AUTO_START_STOP_ACTION_FAN_ONLY
+    type(fake_vtherm).vtherm_hvac_modes = PropertyMock(return_value=[VThermHvacMode_HEAT, VThermHvacMode_COOL, VThermHvacMode_FAN_ONLY, VThermHvacMode_OFF])
+    type(fake_vtherm).hvac_mode = PropertyMock(return_value=VThermHvacMode_FAN_ONLY)
+    assert auto_start_stop_manager.auto_stop_hvac_mode == VThermHvacMode_FAN_ONLY
+    auto_start_stop_manager._is_auto_stop_detected = True
+    assert auto_start_stop_manager.is_auto_stopped is True
+
+    custom_attributes = {}
+    auto_start_stop_manager.add_custom_attributes(custom_attributes)
+    assert custom_attributes["auto_start_stop_manager"]["auto_start_stop_action"] == AUTO_START_STOP_ACTION_FAN_ONLY
+
+
 # ──────────────────────────────────────────────────────────────────────────────
 # Tests for restore_state()
 # ──────────────────────────────────────────────────────────────────────────────

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -295,6 +295,7 @@ async def test_user_config_flow_over_switch(
             CONF_USE_PRESENCE_FEATURE: True,
             CONF_USE_CENTRAL_BOILER_FEATURE: False,
             CONF_AUTO_START_STOP_LEVEL: AUTO_START_STOP_LEVEL_NONE,
+            CONF_AUTO_START_STOP_ACTION: AUTO_START_STOP_ACTION_TURN_OFF,
         }
     )
     assert result["result"]
@@ -527,6 +528,7 @@ async def test_user_config_flow_over_climate(
         CONF_USE_CENTRAL_MODE: False,
         CONF_AUTO_REGULATION_MODE: CONF_AUTO_REGULATION_STRONG,
         CONF_AUTO_START_STOP_LEVEL: AUTO_START_STOP_LEVEL_NONE,
+        CONF_AUTO_START_STOP_ACTION: AUTO_START_STOP_ACTION_TURN_OFF,
         CONF_SYNC_DEVICE_INTERNAL_TEMP: False,
     }
     assert result["result"]
@@ -617,6 +619,7 @@ async def test_user_config_flow_over_climate_auto_start_stop(
         result["flow_id"],
         user_input={
             CONF_AUTO_START_STOP_LEVEL: AUTO_START_STOP_LEVEL_MEDIUM,
+            CONF_AUTO_START_STOP_ACTION: AUTO_START_STOP_ACTION_FAN_ONLY,
         },
     )
     assert result["type"] == FlowResultType.MENU
@@ -778,6 +781,7 @@ async def test_user_config_flow_over_climate_auto_start_stop(
         CONF_USED_BY_CENTRAL_BOILER: False,
         CONF_USE_AUTO_START_STOP_FEATURE: True,
         CONF_AUTO_START_STOP_LEVEL: AUTO_START_STOP_LEVEL_MEDIUM,
+        CONF_AUTO_START_STOP_ACTION: AUTO_START_STOP_ACTION_FAN_ONLY,
         CONF_AUTO_REGULATION_MODE: CONF_AUTO_REGULATION_STRONG,
         CONF_SYNC_DEVICE_INTERNAL_TEMP: False,
     }
@@ -1042,6 +1046,7 @@ async def test_user_config_flow_over_switch_bug_552_tpi(
             CONF_USE_PRESENCE_FEATURE: False,
             CONF_USE_CENTRAL_BOILER_FEATURE: False,
             CONF_AUTO_START_STOP_LEVEL: AUTO_START_STOP_LEVEL_NONE,
+            CONF_AUTO_START_STOP_ACTION: AUTO_START_STOP_ACTION_TURN_OFF,
         }
     )
     assert result["result"]
@@ -1529,6 +1534,7 @@ async def test_user_config_flow_over_climate_valve(
         CONF_MAX_OPENING_DEGREES: "90",
         CONF_OPENING_THRESHOLD_DEGREE: 5,
         CONF_AUTO_START_STOP_LEVEL: AUTO_START_STOP_LEVEL_NONE,
+        CONF_AUTO_START_STOP_ACTION: AUTO_START_STOP_ACTION_TURN_OFF,
     }
     assert result["result"]
     assert result["result"].domain == DOMAIN

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -8,7 +8,7 @@ from homeassistant.components.climate import HVACMode
 from custom_components.versatile_thermostat.base_thermostat import BaseThermostat
 from custom_components.versatile_thermostat.state_manager import StateManager
 from custom_components.versatile_thermostat.vtherm_state import VThermState
-from custom_components.versatile_thermostat.vtherm_hvac_mode import VThermHvacMode_OFF, VThermHvacMode_HEAT, VThermHvacMode_COOL
+from custom_components.versatile_thermostat.vtherm_hvac_mode import VThermHvacMode_OFF, VThermHvacMode_HEAT, VThermHvacMode_COOL, VThermHvacMode_FAN_ONLY
 from custom_components.versatile_thermostat.vtherm_preset import VThermPreset
 
 from .commons import *  # pylint: disable=wildcard-import, unused-wildcard-import
@@ -325,6 +325,7 @@ async def test_state_manager_calculate_hvac_mode(
 
     fake_vtherm.auto_start_stop_manager = MagicMock()
     type(fake_vtherm.auto_start_stop_manager).is_auto_stop_detected = PropertyMock(return_value=is_auto_stop_detected)
+    type(fake_vtherm.auto_start_stop_manager).auto_stop_hvac_mode = PropertyMock(return_value=VThermHvacMode_OFF)
 
     ret = await state_manager.calculate_current_hvac_mode(fake_vtherm)
     assert ret is expected_result
@@ -335,6 +336,76 @@ async def test_state_manager_calculate_hvac_mode(
         fake_vtherm.set_hvac_off_reason.assert_called_with(expected_hvac_off_reason)
     else:
         fake_vtherm.set_hvac_off_reason.assert_not_called()
+
+
+async def test_state_manager_auto_start_stop_can_use_fan_only_when_supported(
+    hass: HomeAssistant,
+) -> None:
+    """Auto-start/stop can temporarily switch to FAN_ONLY instead of OFF."""
+    fake_vtherm = MagicMock(spec=BaseThermostat)
+    type(fake_vtherm).name = PropertyMock(return_value="the name")
+    type(fake_vtherm).is_over_climate = PropertyMock(return_value=True)
+    type(fake_vtherm).vtherm_hvac_modes = PropertyMock(return_value=[VThermHvacMode_HEAT, VThermHvacMode_COOL, VThermHvacMode_FAN_ONLY, VThermHvacMode_OFF])
+    type(fake_vtherm).hvac_off_reason = PropertyMock(return_value=None)
+    fake_vtherm.set_hvac_off_reason = MagicMock()
+
+    fake_vtherm.safety_manager = MagicMock()
+    type(fake_vtherm.safety_manager).is_safety_detected = PropertyMock(return_value=False)
+
+    fake_vtherm.window_manager = MagicMock()
+    type(fake_vtherm.window_manager).is_window_detected = PropertyMock(return_value=False)
+
+    fake_vtherm.auto_start_stop_manager = MagicMock()
+    type(fake_vtherm.auto_start_stop_manager).is_auto_stop_detected = PropertyMock(return_value=True)
+    type(fake_vtherm.auto_start_stop_manager).auto_stop_hvac_mode = PropertyMock(return_value=VThermHvacMode_FAN_ONLY)
+    type(fake_vtherm).last_central_mode = PropertyMock(return_value=CENTRAL_MODE_AUTO)
+
+    state_manager = StateManager()
+    state_manager.requested_state.set_state(hvac_mode=VThermHvacMode_COOL, preset=VThermPreset.ECO, target_temperature=22)
+    state_manager.current_state.set_state(hvac_mode=VThermHvacMode_COOL, preset=VThermPreset.ECO, target_temperature=22)
+    state_manager.requested_state.reset_changed()
+    state_manager.current_state.reset_changed()
+
+    ret = await state_manager.calculate_current_hvac_mode(fake_vtherm)
+
+    assert ret is True
+    assert state_manager.current_state.hvac_mode == VThermHvacMode_FAN_ONLY
+    fake_vtherm.set_hvac_off_reason.assert_not_called()
+
+
+async def test_state_manager_auto_start_stop_falls_back_to_off_when_fan_only_is_not_supported(
+    hass: HomeAssistant,
+) -> None:
+    """Auto-start/stop uses OFF when FAN_ONLY action is selected but unsupported."""
+    fake_vtherm = MagicMock(spec=BaseThermostat)
+    type(fake_vtherm).name = PropertyMock(return_value="the name")
+    type(fake_vtherm).is_over_climate = PropertyMock(return_value=True)
+    type(fake_vtherm).vtherm_hvac_modes = PropertyMock(return_value=[VThermHvacMode_HEAT, VThermHvacMode_COOL, VThermHvacMode_OFF])
+    type(fake_vtherm).hvac_off_reason = PropertyMock(return_value=None)
+    fake_vtherm.set_hvac_off_reason = MagicMock()
+
+    fake_vtherm.safety_manager = MagicMock()
+    type(fake_vtherm.safety_manager).is_safety_detected = PropertyMock(return_value=False)
+
+    fake_vtherm.window_manager = MagicMock()
+    type(fake_vtherm.window_manager).is_window_detected = PropertyMock(return_value=False)
+
+    fake_vtherm.auto_start_stop_manager = MagicMock()
+    type(fake_vtherm.auto_start_stop_manager).is_auto_stop_detected = PropertyMock(return_value=True)
+    type(fake_vtherm.auto_start_stop_manager).auto_stop_hvac_mode = PropertyMock(return_value=VThermHvacMode_OFF)
+    type(fake_vtherm).last_central_mode = PropertyMock(return_value=CENTRAL_MODE_AUTO)
+
+    state_manager = StateManager()
+    state_manager.requested_state.set_state(hvac_mode=VThermHvacMode_COOL, preset=VThermPreset.ECO, target_temperature=22)
+    state_manager.current_state.set_state(hvac_mode=VThermHvacMode_COOL, preset=VThermPreset.ECO, target_temperature=22)
+    state_manager.requested_state.reset_changed()
+    state_manager.current_state.reset_changed()
+
+    ret = await state_manager.calculate_current_hvac_mode(fake_vtherm)
+
+    assert ret is True
+    assert state_manager.current_state.hvac_mode == VThermHvacMode_OFF
+    fake_vtherm.set_hvac_off_reason.assert_called_with(HVAC_OFF_REASON_AUTO_START_STOP)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

This PR extends the existing auto-start/stop feature for `over_climate` thermostats with an optional `fan_only` auto-stop action.

The current behavior remains the default:

* `Turn off` — existing behavior, switches VTherm and the underlying climate entity to `off`
* `Fan only` — switches VTherm and the underlying climate entity to `fan_only` while auto-stop is active, when supported

If `fan_only` is selected but the underlying climate entity does not support it, VTherm falls back to `off`.

## Motivation

I use VTherm with many devices and really like the auto-start/stop feature. My motivation here was to make it less intrusive for bedrooms and split AC units, where fully turning the unit off and back on can cause noise, beeps, compressor cycling, or airflow changes during the night.

For those cases, `fan_only` can stop active cooling/heating while keeping the unit in a quieter and less disruptive state.

## Implementation notes

The goal was to keep this as a small extension of the current feature:

* auto-start/stop detection logic is unchanged
* default behavior remains `turn_off`
* `requested_state` remains the requested heating/cooling mode, so auto-start can restore it
* `current_state` temporarily becomes `fan_only` when selected and supported
* temperature self-regulation and auto-fan adjustments are not sent while `fan_only` auto-stop is active

<img width="609" height="342" alt="image" src="https://github.com/user-attachments/assets/917689e8-3658-4ced-b27b-bf5f174f2603" />


The PR is split into three commits:

1. Functional implementation and tests
2. English UI strings and documentation
3. Additional translations

The third commit can be adjusted or dropped if maintainers prefer translations to be handled separately.

## Tests

Added/updated tests for:

* fan-only auto-stop when supported
* fallback to off when fan-only is unsupported
* preserving requested heat/cool mode while current mode is fan-only
* avoiding regulated temperature sends while fan-only auto-stop is active
* avoiding auto-fan changes while fan-only auto-stop is active

## Verification

Black check was run on changed Python files. It reports existing formatting differences in upstream files, so I did not apply full-file formatting to avoid unrelated diff noise and ballooning this PR to 600+ lines.

I tested this on my two AC units on my HA instance. Works beautiflly. Auto start/stop works exactly as before just with different action. Mixing off or fan only works as expected
<img width="514" height="136" alt="image" src="https://github.com/user-attachments/assets/ac2eff29-3eb2-4389-bcca-69b0e3e742e5" />

## Possible future follow-up - If you like my code and this would align with project's goals 

I got quite confused by how auto start/stop actually operates without digging into docs. I was thinking of adding threshold parameter of how much overcooling or overheating user allows while speed of auto start/stop limits cycling (minimal cycle length) then. What do you think?

Thank you for this awesome project!