### PR TITLE
Add supply temperature safety lockout

### DIFF
--- a/custom_components/versatile_thermostat/base_thermostat.py
+++ b/custom_components/versatile_thermostat/base_thermostat.py
@@ -64,6 +64,7 @@ from .feature_power_manager import FeaturePowerManager
 from .feature_motion_manager import FeatureMotionManager
 from .feature_window_manager import FeatureWindowManager
 from .feature_safety_manager import FeatureSafetyManager
+from .feature_supply_temperature_safety_manager import FeatureSupplyTemperatureSafetyManager
 from .feature_auto_start_stop_manager import FeatureAutoStartStopManager
 from .feature_lock_manager import FeatureLockManager
 from .feature_timed_preset_manager import FeatureTimedPresetManager
@@ -90,6 +91,7 @@ class BaseThermostat(ClimateEntity, RestoreEntity, Generic[T]):
         .union(FeaturePowerManager.unrecorded_attributes)
         .union(FeatureMotionManager.unrecorded_attributes)
         .union(FeatureWindowManager.unrecorded_attributes)
+        .union(FeatureSupplyTemperatureSafetyManager.unrecorded_attributes)
     )
 
     ##
@@ -206,6 +208,7 @@ class BaseThermostat(ClimateEntity, RestoreEntity, Generic[T]):
         self._motion_manager: FeatureMotionManager = FeatureMotionManager(self, hass)
         self._window_manager: FeatureWindowManager = FeatureWindowManager(self, hass)
         self._safety_manager: FeatureSafetyManager = FeatureSafetyManager(self, hass)
+        self._supply_temperature_safety_manager: FeatureSupplyTemperatureSafetyManager = FeatureSupplyTemperatureSafetyManager(self, hass)
         # Auto start/stop is only for over_climate
         self._auto_start_stop_manager: FeatureAutoStartStopManager | None = None
         self._lock_manager: FeatureLockManager = FeatureLockManager(self, hass)
@@ -218,6 +221,7 @@ class BaseThermostat(ClimateEntity, RestoreEntity, Generic[T]):
         self.register_manager(self._motion_manager)
         self.register_manager(self._window_manager)
         self.register_manager(self._safety_manager)
+        self.register_manager(self._supply_temperature_safety_manager)
         self.register_manager(self._lock_manager)
         self.register_manager(self._timed_preset_manager)
         self.register_manager(self._heating_failure_detection_manager)
@@ -984,6 +988,11 @@ class BaseThermostat(ClimateEntity, RestoreEntity, Generic[T]):
         return self._safety_manager
 
     @property
+    def supply_temperature_safety_manager(self) -> FeatureSupplyTemperatureSafetyManager | None:
+        """Get the supply temperature safety manager"""
+        return self._supply_temperature_safety_manager
+
+    @property
     def auto_start_stop_manager(self) -> FeatureAutoStartStopManager | None:
         """Get the auto start/stop manager (only implemented in over_climate)"""
         return self._auto_start_stop_manager
@@ -1579,6 +1588,19 @@ class BaseThermostat(ClimateEntity, RestoreEntity, Generic[T]):
             _LOGGER.info("%s - async_control_heating is called but the entity is not ready yet (not initialized or startup not done). Skip the cycle", self)
             return False
 
+        await self._supply_temperature_safety_manager.refresh_state(restart_on_clear=False)
+        if self._supply_temperature_safety_manager.is_supply_temperature_safety_detected:
+            _LOGGER.warning(
+                "%s - End of cycle (supply temperature safety detected: %s)",
+                self,
+                self._supply_temperature_safety_manager.safety_reason,
+            )
+            await self.async_underlying_entity_turn_off()
+            self.calculate_hvac_action()
+            self.update_custom_attributes()
+            self.async_write_ha_state()
+            return True
+
         # check auto_window conditions
         await self._window_manager.manage_window_auto(in_cycle=True)
 
@@ -1787,6 +1809,8 @@ class BaseThermostat(ClimateEntity, RestoreEntity, Generic[T]):
         messages: list[str] = []
         if self.safety_manager.is_safety_detected:
             messages.append(MSG_SAFETY_DETECTED)
+        if self.supply_temperature_safety_manager.is_supply_temperature_safety_detected:
+            messages.append(MSG_SUPPLY_TEMP_SAFETY_DETECTED)
         if self.power_manager.is_overpowering_detected:
             messages.append(MSG_OVERPOWERING_DETECTED)
         if self.hvac_off_reason:

--- a/custom_components/versatile_thermostat/config_flow.py
+++ b/custom_components/versatile_thermostat/config_flow.py
@@ -211,6 +211,7 @@ class VersatileThermostatBaseConfigFlow(FlowHandler):
             CONF_TEMP_SENSOR,
             CONF_EXTERNAL_TEMP_SENSOR,
             CONF_WINDOW_SENSOR,
+            CONF_SUPPLY_TEMP_SENSOR,
             CONF_MOTION_SENSOR,
             CONF_POWER_SENSOR,
             CONF_MAX_POWER_SENSOR,

--- a/custom_components/versatile_thermostat/config_schema.py
+++ b/custom_components/versatile_thermostat/config_schema.py
@@ -70,6 +70,51 @@ def build_step_thermostat_switch_schema() -> vol.Schema:
             vol.Optional(CONF_VSWITCH_ON_CMD_LIST): selector.TextSelector(selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT, multiple=True)),
             vol.Optional("off_command_text"): vol.In([]),
             vol.Optional(CONF_VSWITCH_OFF_CMD_LIST): selector.TextSelector(selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT, multiple=True)),
+            vol.Optional(CONF_SUPPLY_TEMP_SENSOR): selector.EntitySelector(
+                selector.EntitySelectorConfig(domain=[SENSOR_DOMAIN, INPUT_NUMBER_DOMAIN, NUMBER_DOMAIN]),
+            ),
+            vol.Optional(CONF_SUPPLY_TEMP_HEAT_MAX, default=45): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=20.0,
+                    max=80.0,
+                    step=0.5,
+                    mode=selector.NumberSelectorMode.BOX,
+                    unit_of_measurement="°C",
+                )
+            ),
+            vol.Optional(CONF_SUPPLY_TEMP_COOL_MIN, default=18): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=5.0,
+                    max=30.0,
+                    step=0.5,
+                    mode=selector.NumberSelectorMode.BOX,
+                    unit_of_measurement="°C",
+                )
+            ),
+            vol.Optional(
+                CONF_SUPPLY_TEMP_TOLERANCE,
+                default=DEFAULT_SUPPLY_TEMP_TOLERANCE,
+            ): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=0.0,
+                    max=10.0,
+                    step=0.5,
+                    mode=selector.NumberSelectorMode.BOX,
+                    unit_of_measurement="°C",
+                )
+            ),
+            vol.Optional(
+                CONF_SUPPLY_TEMP_DELAY_SEC,
+                default=DEFAULT_SUPPLY_TEMP_DELAY_SEC,
+            ): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=0,
+                    max=600,
+                    step=5,
+                    mode=selector.NumberSelectorMode.BOX,
+                    unit_of_measurement="s",
+                )
+            ),
         }
     )
 

--- a/custom_components/versatile_thermostat/const.py
+++ b/custom_components/versatile_thermostat/const.py
@@ -90,6 +90,11 @@ CONF_TEMP_MAX = "temp_max"
 CONF_SAFETY_DELAY_MIN = "safety_delay_min"
 CONF_SAFETY_MIN_ON_PERCENT = "safety_min_on_percent"
 CONF_SAFETY_DEFAULT_ON_PERCENT = "safety_default_on_percent"
+CONF_SUPPLY_TEMP_SENSOR = "supply_temperature_sensor_entity_id"
+CONF_SUPPLY_TEMP_HEAT_MAX = "supply_temperature_heat_max"
+CONF_SUPPLY_TEMP_COOL_MIN = "supply_temperature_cool_min"
+CONF_SUPPLY_TEMP_TOLERANCE = "supply_temperature_tolerance"
+CONF_SUPPLY_TEMP_DELAY_SEC = "supply_temperature_delay_sec"
 CONF_THERMOSTAT_TYPE = "thermostat_type"
 CONF_THERMOSTAT_CENTRAL_CONFIG = "thermostat_central_config"
 CONF_THERMOSTAT_SWITCH = "thermostat_over_switch"
@@ -355,6 +360,11 @@ ALL_CONF = (
         CONF_SAFETY_DELAY_MIN,
         CONF_SAFETY_MIN_ON_PERCENT,
         CONF_SAFETY_DEFAULT_ON_PERCENT,
+        CONF_SUPPLY_TEMP_SENSOR,
+        CONF_SUPPLY_TEMP_HEAT_MAX,
+        CONF_SUPPLY_TEMP_COOL_MIN,
+        CONF_SUPPLY_TEMP_TOLERANCE,
+        CONF_SUPPLY_TEMP_DELAY_SEC,
         CONF_THERMOSTAT_TYPE,
         CONF_THERMOSTAT_SWITCH,
         CONF_THERMOSTAT_CLIMATE,
@@ -483,6 +493,8 @@ SERVICE_DOWNLOAD_LOGS = "download_logs"
 
 DEFAULT_SAFETY_MIN_ON_PERCENT = 0.5
 DEFAULT_SAFETY_DEFAULT_ON_PERCENT = 0.1
+DEFAULT_SUPPLY_TEMP_TOLERANCE = 2.0
+DEFAULT_SUPPLY_TEMP_DELAY_SEC = 0
 
 # Repair incorrect state defaults
 DEFAULT_REPAIR_INCORRECT_STATE = False
@@ -524,6 +536,7 @@ ATTR_REQUESTED_STATE = "requested_state"
 
 MSG_OVERPOWERING_DETECTED = "overpowering_detected"
 MSG_SAFETY_DETECTED = "safety_detected"
+MSG_SUPPLY_TEMP_SAFETY_DETECTED = "supply_temperature_safety_detected"
 MSG_TARGET_TEMP_WINDOW_ECO = "target_temp_window_eco"
 MSG_TARGET_TEMP_WINDOW_FROST = "target_temp_window_frost"
 MSG_TARGET_TEMP_POWER = "target_temp_power"

--- a/custom_components/versatile_thermostat/feature_supply_temperature_safety_manager.py
+++ b/custom_components/versatile_thermostat/feature_supply_temperature_safety_manager.py
@@ -1,0 +1,375 @@
+# pylint: disable=line-too-long
+
+"""Supply-water temperature safety manager."""
+
+from datetime import timedelta
+from collections.abc import Callable
+from typing import Any
+
+from homeassistant.const import (
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+)
+from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.helpers.event import (
+    EventStateChangedData,
+    async_call_later,
+    async_track_state_change_event,
+)
+
+from vtherm_api.log_collector import get_vtherm_logger
+
+from .base_manager import BaseFeatureManager
+from .commons import write_event_log
+from .commons_type import ConfigData
+from .const import (
+    CONF_SUPPLY_TEMP_COOL_MIN,
+    CONF_SUPPLY_TEMP_DELAY_SEC,
+    CONF_SUPPLY_TEMP_HEAT_MAX,
+    CONF_SUPPLY_TEMP_SENSOR,
+    CONF_SUPPLY_TEMP_TOLERANCE,
+    DEFAULT_SUPPLY_TEMP_DELAY_SEC,
+    DEFAULT_SUPPLY_TEMP_TOLERANCE,
+    EventType,
+    overrides,
+)
+from .vtherm_hvac_mode import (
+    VThermHvacMode_COOL,
+    VThermHvacMode_HEAT,
+    VThermHvacMode_OFF,
+)
+
+_LOGGER = get_vtherm_logger(__name__)
+
+REASON_HEAT_TOO_HOT = "heat_supply_temperature_too_hot"
+REASON_COOL_TOO_COLD = "cool_supply_temperature_too_cold"
+REASON_SENSOR_UNAVAILABLE = "supply_temperature_sensor_unavailable"
+
+
+class FeatureSupplyTemperatureSafetyManager(BaseFeatureManager):
+    """Blocks switch actuation when the supply-water temperature is unsafe."""
+
+    unrecorded_attributes = frozenset(
+        {
+            "is_supply_temperature_safety_configured",
+            "supply_temperature_sensor_entity_id",
+            "supply_temperature",
+            "supply_temperature_safety_state",
+            "supply_temperature_safety_reason",
+            "supply_temperature_heat_max",
+            "supply_temperature_cool_min",
+            "supply_temperature_tolerance",
+            "supply_temperature_delay_sec",
+        }
+    )
+
+    def __init__(self, vtherm: Any, hass: HomeAssistant):
+        """Initialize the manager."""
+        super().__init__(vtherm, hass)
+        self._is_configured: bool = False
+        self._supply_temp_sensor_entity_id: str | None = None
+        self._heat_max: float | None = None
+        self._cool_min: float | None = None
+        self._tolerance: float = DEFAULT_SUPPLY_TEMP_TOLERANCE
+        self._delay_sec: int = DEFAULT_SUPPLY_TEMP_DELAY_SEC
+        self._current_supply_temperature: float | None = None
+        self._safety_state: str = STATE_UNAVAILABLE
+        self._safety_reason: str | None = None
+        self._pending_call_cancel: Callable[[], None] | None = None
+
+    @overrides
+    def post_init(self, entry_infos: ConfigData):
+        """Load configuration."""
+        self._cancel_pending_call()
+
+        self._supply_temp_sensor_entity_id = entry_infos.get(CONF_SUPPLY_TEMP_SENSOR)
+        self._heat_max = entry_infos.get(CONF_SUPPLY_TEMP_HEAT_MAX)
+        self._cool_min = entry_infos.get(CONF_SUPPLY_TEMP_COOL_MIN)
+        self._tolerance = entry_infos.get(
+            CONF_SUPPLY_TEMP_TOLERANCE,
+            DEFAULT_SUPPLY_TEMP_TOLERANCE,
+        )
+        self._delay_sec = entry_infos.get(
+            CONF_SUPPLY_TEMP_DELAY_SEC,
+            DEFAULT_SUPPLY_TEMP_DELAY_SEC,
+        )
+
+        self._is_configured = bool(self._supply_temp_sensor_entity_id and (self._heat_max is not None or self._cool_min is not None))
+        self._current_supply_temperature = None
+        self._safety_reason = None
+        self._safety_state = STATE_UNKNOWN if self._is_configured else STATE_UNAVAILABLE
+
+    @overrides
+    async def start_listening(self):
+        """Listen to the configured supply temperature sensor."""
+        if not self._is_configured:
+            return
+
+        self.stop_listening()
+        self.add_listener(
+            async_track_state_change_event(
+                self.hass,
+                [self._supply_temp_sensor_entity_id],
+                self._supply_temperature_changed,
+            )
+        )
+        await self.refresh_state()
+
+    @overrides
+    def stop_listening(self):
+        """Stop listening and cancel pending delayed checks."""
+        self._cancel_pending_call()
+        super().stop_listening()
+
+    @overrides
+    async def refresh_state(self, restart_on_clear: bool = True) -> bool:
+        """Refresh from the current sensor state."""
+        if not self._is_configured:
+            return False
+
+        state = self.hass.states.get(self._supply_temp_sensor_entity_id)
+        if state is None or state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
+            return await self._apply_state(
+                STATE_ON,
+                REASON_SENSOR_UNAVAILABLE,
+                restart_on_clear=restart_on_clear,
+            )
+
+        try:
+            supply_temp = float(state.state)
+        except (TypeError, ValueError):
+            return await self._apply_state(
+                STATE_ON,
+                REASON_SENSOR_UNAVAILABLE,
+                restart_on_clear=restart_on_clear,
+            )
+
+        self._current_supply_temperature = supply_temp
+        return await self._evaluate_temperature(
+            supply_temp,
+            allow_delay=False,
+            restart_on_clear=restart_on_clear,
+        )
+
+    @callback
+    async def _supply_temperature_changed(self, event: Event[EventStateChangedData]):
+        """Handle supply temperature changes."""
+        new_state = event.data.get("new_state")
+        old_state = event.data.get("old_state")
+        write_event_log(
+            _LOGGER,
+            self._vtherm,
+            f"Supply temperature changed from {old_state.state if old_state else None} to {new_state.state if new_state else None}",
+        )
+
+        if new_state is None or new_state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
+            self._current_supply_temperature = None
+            await self._apply_state(STATE_ON, REASON_SENSOR_UNAVAILABLE)
+            return
+
+        try:
+            supply_temp = float(new_state.state)
+        except (TypeError, ValueError):
+            self._current_supply_temperature = None
+            await self._apply_state(STATE_ON, REASON_SENSOR_UNAVAILABLE)
+            return
+
+        self._current_supply_temperature = supply_temp
+        await self._evaluate_temperature(
+            supply_temp,
+            allow_delay=True,
+            restart_on_clear=True,
+        )
+
+    async def _evaluate_temperature(
+        self,
+        supply_temp: float,
+        allow_delay: bool,
+        restart_on_clear: bool,
+    ) -> bool:
+        """Evaluate the temperature and apply or schedule a state change."""
+        desired_state, reason = self._desired_state(supply_temp)
+
+        if desired_state != STATE_ON:
+            self._cancel_pending_call()
+            return await self._apply_state(
+                STATE_OFF,
+                None,
+                restart_on_clear=restart_on_clear,
+            )
+
+        if self.is_supply_temperature_safety_detected:
+            return await self._apply_state(
+                STATE_ON,
+                reason,
+                restart_on_clear=restart_on_clear,
+            )
+
+        if allow_delay and self._delay_sec > 0:
+            self._schedule_delayed_trip(reason)
+            return False
+
+        return await self._apply_state(
+            STATE_ON,
+            reason,
+            restart_on_clear=restart_on_clear,
+        )
+
+    def _desired_state(self, supply_temp: float) -> tuple[str, str | None]:
+        """Return desired safety state and reason, with hysteresis."""
+        hvac_mode = self._vtherm.vtherm_hvac_mode
+
+        if hvac_mode == VThermHvacMode_OFF:
+            return STATE_OFF, None
+
+        if hvac_mode == VThermHvacMode_HEAT and self._heat_max is not None:
+            if self._safety_reason == REASON_HEAT_TOO_HOT:
+                if supply_temp > self._heat_max - self._tolerance:
+                    return STATE_ON, REASON_HEAT_TOO_HOT
+            elif supply_temp >= self._heat_max:
+                return STATE_ON, REASON_HEAT_TOO_HOT
+
+        if hvac_mode == VThermHvacMode_COOL and self._cool_min is not None:
+            if self._safety_reason == REASON_COOL_TOO_COLD:
+                if supply_temp < self._cool_min + self._tolerance:
+                    return STATE_ON, REASON_COOL_TOO_COLD
+            elif supply_temp <= self._cool_min:
+                return STATE_ON, REASON_COOL_TOO_COLD
+
+        return STATE_OFF, None
+
+    def _schedule_delayed_trip(self, reason: str | None) -> None:
+        """Schedule a delayed trip check if one is not already pending."""
+        if self._pending_call_cancel is not None:
+            return
+
+        async def try_trip(_):
+            self._pending_call_cancel = None
+            await self.refresh_state()
+
+        _LOGGER.debug(
+            "%s - supply temperature safety condition detected (%s). Waiting %s seconds before tripping.",
+            self,
+            reason,
+            self._delay_sec,
+        )
+        self._pending_call_cancel = async_call_later(
+            self.hass,
+            timedelta(seconds=self._delay_sec),
+            try_trip,
+        )
+
+    def _cancel_pending_call(self) -> None:
+        """Cancel a delayed trip check."""
+        if self._pending_call_cancel:
+            self._pending_call_cancel()
+            self._pending_call_cancel = None
+
+    async def _apply_state(
+        self,
+        new_state: str,
+        reason: str | None,
+        restart_on_clear: bool = True,
+    ) -> bool:
+        """Apply the safety state and trigger the necessary device action."""
+        old_state = self._safety_state
+        old_reason = self._safety_reason
+
+        self._safety_state = new_state
+        self._safety_reason = reason if new_state == STATE_ON else None
+
+        changed = old_state != self._safety_state or old_reason != self._safety_reason
+        if not changed:
+            return False
+
+        if self._safety_state == STATE_ON:
+            write_event_log(
+                _LOGGER,
+                self._vtherm,
+                f"Supply temperature safety started ({self._safety_reason})",
+            )
+            _LOGGER.warning(
+                "%s - supply temperature safety started. temp=%s reason=%s",
+                self,
+                self._current_supply_temperature,
+                self._safety_reason,
+            )
+            await self._vtherm.async_underlying_entity_turn_off()
+            self._send_event("start")
+        else:
+            write_event_log(_LOGGER, self._vtherm, "Supply temperature safety ended")
+            _LOGGER.info("%s - supply temperature safety ended", self)
+            self._send_event("end")
+            if restart_on_clear and self._vtherm.is_ready:
+                await self._vtherm.async_control_heating(force=True)
+
+        self._vtherm.update_custom_attributes()
+        self._vtherm.async_write_ha_state()
+        return True
+
+    def _send_event(self, event_action: str) -> None:
+        """Send a VTherm safety event."""
+        self._vtherm.send_event(
+            EventType.SAFETY_EVENT,
+            {
+                "type": f"supply_temperature_{event_action}",
+                "supply_temperature": self._current_supply_temperature,
+                "reason": self._safety_reason,
+                "heat_max": self._heat_max,
+                "cool_min": self._cool_min,
+            },
+        )
+
+    def add_custom_attributes(self, extra_state_attributes: dict[str, Any]):
+        """Add custom state attributes."""
+        extra_state_attributes.update(
+            {
+                "is_supply_temperature_safety_configured": self._is_configured,
+            }
+        )
+
+        if self._is_configured:
+            extra_state_attributes.update(
+                {
+                    "supply_temperature_safety_manager": {
+                        "supply_temperature_safety_state": self._safety_state,
+                        "supply_temperature_safety_reason": self._safety_reason,
+                        "supply_temperature_sensor_entity_id": self._supply_temp_sensor_entity_id,
+                        "supply_temperature": self._current_supply_temperature,
+                        "supply_temperature_heat_max": self._heat_max,
+                        "supply_temperature_cool_min": self._cool_min,
+                        "supply_temperature_tolerance": self._tolerance,
+                        "supply_temperature_delay_sec": self._delay_sec,
+                    }
+                }
+            )
+
+    @property
+    def is_configured(self) -> bool:
+        """Return True when the feature is configured."""
+        return self._is_configured
+
+    @property
+    def is_supply_temperature_safety_detected(self) -> bool:
+        """Return True when the supply-water safety is tripped."""
+        return self._safety_state == STATE_ON
+
+    @property
+    def is_detected(self) -> bool:
+        """Return the detected state."""
+        return self.is_supply_temperature_safety_detected
+
+    @property
+    def safety_state(self) -> str:
+        """Return the raw safety state."""
+        return self._safety_state
+
+    @property
+    def safety_reason(self) -> str | None:
+        """Return the current safety reason."""
+        return self._safety_reason
+
+    def __str__(self):
+        return f"SupplyTemperatureSafetyManager-{self.name}"

--- a/custom_components/versatile_thermostat/strings.json
+++ b/custom_components/versatile_thermostat/strings.json
@@ -114,7 +114,12 @@
           "on_command_text": "Turn on command customization",
           "vswitch_on_command": "Optional turn on commands",
           "off_command_text": "Turn off command customization",
-          "vswitch_off_command": "Optional turn off commands"
+          "vswitch_off_command": "Optional turn off commands",
+          "supply_temperature_sensor_entity_id": "Supply temperature sensor",
+          "supply_temperature_heat_max": "Maximum supply temperature in heating mode",
+          "supply_temperature_cool_min": "Minimum supply temperature in cooling mode",
+          "supply_temperature_tolerance": "Supply temperature safety hysteresis",
+          "supply_temperature_delay_sec": "Supply temperature safety delay"
         },
         "data_description": {
           "underlying_entity_ids": "The device(s) to be controlled - 1 is required",
@@ -128,7 +133,12 @@
           "auto_regulation_use_device_temp": "Use the eventual internal temperature sensor of the underlying to speedup the self-regulation (not needed in most cases)",
           "inverse_switch_command": "For switch with pilot wire and diode you may need to inverse the command",
           "auto_fan_mode": "Automatically activate fan when huge heating/cooling is necessary",
-          "on_command_text": "For underlying of type `select` or `climate` you have to customize the commands."
+          "on_command_text": "For underlying of type `select` or `climate` you have to customize the commands.",
+          "supply_temperature_sensor_entity_id": "Optional temperature sensor measuring the supply water temperature. When configured, VTherm blocks switch activation if the supply temperature is unsafe.",
+          "supply_temperature_heat_max": "In heating mode, switch activation is blocked when the supply temperature is greater than or equal to this value.",
+          "supply_temperature_cool_min": "In cooling mode, switch activation is blocked when the supply temperature is less than or equal to this value.",
+          "supply_temperature_tolerance": "Hysteresis used to clear the safety trip. Heating clears below heat max minus this value; cooling clears above cool min plus this value.",
+          "supply_temperature_delay_sec": "Optional delay before applying a new supply temperature safety trip."
         }
       },
       "tpi": {
@@ -500,7 +510,12 @@
           "on_command_text": "Turn on command customization",
           "vswitch_on_command": "Optional turn on commands",
           "off_command_text": "Turn off command customization",
-          "vswitch_off_command": "Optional turn off commands"
+          "vswitch_off_command": "Optional turn off commands",
+          "supply_temperature_sensor_entity_id": "Supply temperature sensor",
+          "supply_temperature_heat_max": "Maximum supply temperature in heating mode",
+          "supply_temperature_cool_min": "Minimum supply temperature in cooling mode",
+          "supply_temperature_tolerance": "Supply temperature safety hysteresis",
+          "supply_temperature_delay_sec": "Supply temperature safety delay"
         },
         "data_description": {
           "underlying_entity_ids": "The device(s) to be controlled - 1 is required",
@@ -514,7 +529,12 @@
           "auto_regulation_use_device_temp": "Use the eventual internal temperature sensor of the underlying to speedup the self-regulation (not needed in most cases)",
           "inverse_switch_command": "For switch with pilot wire and diode you may need to inverse the command",
           "auto_fan_mode": "Automatically activate fan when huge heating/cooling is necessary",
-          "on_command_text": "For underlying of type `select` or `climate` you have to customize the commands."
+          "on_command_text": "For underlying of type `select` or `climate` you have to customize the commands.",
+          "supply_temperature_sensor_entity_id": "Optional temperature sensor measuring the supply water temperature. When configured, VTherm blocks switch activation if the supply temperature is unsafe.",
+          "supply_temperature_heat_max": "In heating mode, switch activation is blocked when the supply temperature is greater than or equal to this value.",
+          "supply_temperature_cool_min": "In cooling mode, switch activation is blocked when the supply temperature is less than or equal to this value.",
+          "supply_temperature_tolerance": "Hysteresis used to clear the safety trip. Heating clears below heat max minus this value; cooling clears above cool min plus this value.",
+          "supply_temperature_delay_sec": "Optional delay before applying a new supply temperature safety trip."
         }
       },
       "tpi": {

--- a/custom_components/versatile_thermostat/translations/en.json
+++ b/custom_components/versatile_thermostat/translations/en.json
@@ -114,7 +114,12 @@
                     "on_command_text": "Turn on command customization",
                     "vswitch_on_command": "Optional turn on commands",
                     "off_command_text": "Turn off command customization",
-                    "vswitch_off_command": "Optional turn off commands"
+                    "vswitch_off_command": "Optional turn off commands",
+                    "supply_temperature_sensor_entity_id": "Supply temperature sensor",
+                    "supply_temperature_heat_max": "Maximum supply temperature in heating mode",
+                    "supply_temperature_cool_min": "Minimum supply temperature in cooling mode",
+                    "supply_temperature_tolerance": "Supply temperature safety hysteresis",
+                    "supply_temperature_delay_sec": "Supply temperature safety delay"
                 },
                 "data_description": {
                     "underlying_entity_ids": "The device(s) to be controlled - 1 is required",
@@ -128,7 +133,12 @@
                     "auto_regulation_use_device_temp": "Use the eventual internal temperature sensor of the underlying to speedup the self-regulation (not needed in most cases)",
                     "inverse_switch_command": "For switch with pilot wire and diode you may need to inverse the command",
                     "auto_fan_mode": "Automatically activate fan when huge heating/cooling is necessary",
-                    "on_command_text": "For underlying of type `select` or `climate` you have to customize the commands."
+                    "on_command_text": "For underlying of type `select` or `climate` you have to customize the commands.",
+                    "supply_temperature_sensor_entity_id": "Optional temperature sensor measuring the supply water temperature. When configured, VTherm blocks switch activation if the supply temperature is unsafe.",
+                    "supply_temperature_heat_max": "In heating mode, switch activation is blocked when the supply temperature is greater than or equal to this value.",
+                    "supply_temperature_cool_min": "In cooling mode, switch activation is blocked when the supply temperature is less than or equal to this value.",
+                    "supply_temperature_tolerance": "Hysteresis used to clear the safety trip. Heating clears below heat max minus this value; cooling clears above cool min plus this value.",
+                    "supply_temperature_delay_sec": "Optional delay before applying a new supply temperature safety trip."
                 }
             },
             "tpi": {
@@ -500,7 +510,12 @@
                     "on_command_text": "Turn on command customization",
                     "vswitch_on_command": "Optional turn on commands",
                     "off_command_text": "Turn off command customization",
-                    "vswitch_off_command": "Optional turn off commands"
+                    "vswitch_off_command": "Optional turn off commands",
+                    "supply_temperature_sensor_entity_id": "Supply temperature sensor",
+                    "supply_temperature_heat_max": "Maximum supply temperature in heating mode",
+                    "supply_temperature_cool_min": "Minimum supply temperature in cooling mode",
+                    "supply_temperature_tolerance": "Supply temperature safety hysteresis",
+                    "supply_temperature_delay_sec": "Supply temperature safety delay"
                 },
                 "data_description": {
                     "underlying_entity_ids": "The device(s) to be controlled - 1 is required",
@@ -514,7 +529,12 @@
                     "auto_regulation_use_device_temp": "Use the eventual internal temperature sensor of the underlying to speedup the self-regulation (not needed in most cases)",
                     "inverse_switch_command": "For switch with pilot wire and diode you may need to inverse the command",
                     "auto_fan_mode": "Automatically activate fan when huge heating/cooling is necessary",
-                    "on_command_text": "For underlying of type `select` or `climate` you have to customize the commands."
+                    "on_command_text": "For underlying of type `select` or `climate` you have to customize the commands.",
+                    "supply_temperature_sensor_entity_id": "Optional temperature sensor measuring the supply water temperature. When configured, VTherm blocks switch activation if the supply temperature is unsafe.",
+                    "supply_temperature_heat_max": "In heating mode, switch activation is blocked when the supply temperature is greater than or equal to this value.",
+                    "supply_temperature_cool_min": "In cooling mode, switch activation is blocked when the supply temperature is less than or equal to this value.",
+                    "supply_temperature_tolerance": "Hysteresis used to clear the safety trip. Heating clears below heat max minus this value; cooling clears above cool min plus this value.",
+                    "supply_temperature_delay_sec": "Optional delay before applying a new supply temperature safety trip."
                 }
             },
             "tpi": {

--- a/custom_components/versatile_thermostat/underlyings.py
+++ b/custom_components/versatile_thermostat/underlyings.py
@@ -385,6 +385,14 @@ class UnderlyingSwitch(UnderlyingEntity):
 
     def _calculate_should_be_on(self, should_be_on: bool | None = None) -> bool:
         """Calculate and update the _should_be_on flag"""
+        supply_safety_manager = getattr(self._thermostat, "supply_temperature_safety_manager", None)
+        if (
+            supply_safety_manager is not None
+            and supply_safety_manager.is_supply_temperature_safety_detected
+        ):
+            self._should_be_on = False
+            return self._should_be_on
+
         self._should_be_on = self._hvac_mode in [VThermHvacMode_HEAT, VThermHvacMode_COOL] and self._on_time_sec > 0
 
         return self._should_be_on
@@ -503,6 +511,22 @@ class UnderlyingSwitch(UnderlyingEntity):
         """Turn heater toggleable device on."""
         self._keep_alive.cancel()  # Cancel early to avoid a turn_on/turn_off race condition
         _LOGGER.debug("%s - Starting underlying entity %s", self, self._entity_id)
+
+        supply_safety_manager = getattr(self._thermostat, "supply_temperature_safety_manager", None)
+        if (
+            supply_safety_manager is not None
+            and supply_safety_manager.is_supply_temperature_safety_detected
+        ):
+            _LOGGER.warning(
+                "%s - Refusing to turn on because supply temperature safety is detected (%s)",
+                self,
+                supply_safety_manager.safety_reason,
+            )
+            self._is_on_part_running = False
+            self._should_be_on = False
+            if self.is_device_active:
+                await self.turn_off()
+            return False
 
         if not await self.check_overpowering():
             self._thermostat.requested_state.force_changed()

--- a/documentation/en/over-switch.md
+++ b/documentation/en/over-switch.md
@@ -6,6 +6,7 @@
     - [The underlying devices](#the-underlying-devices)
     - [Keep-Alive](#keep-alive)
     - [AC Mode](#ac-mode)
+    - [Supply Temperature Safety](#supply-temperature-safety)
     - [Command Inversion](#command-inversion)
     - [Command Customization](#command-customization)
 
@@ -54,6 +55,31 @@ Some equipment requires periodic activation to prevent a safety shutdown. Known 
 ### AC Mode
 
 It is possible to choose a `thermostat_over_switch` to control an air conditioner by checking the "AC Mode" box. In this case, only the cooling mode will be visible.
+
+### Supply Temperature Safety
+
+For hydronic heating or cooling systems, the optional supply temperature safety can prevent VTherm from activating the underlying switch when the water temperature is outside configured limits.
+
+This is useful when the underlying switch controls a circulation pump for a floor system:
+
+- in heating mode, water that is too hot can damage the floor construction or floor covering,
+- in cooling mode, water that is too cold can cause condensation.
+
+When configured, VTherm monitors the `supply_temperature_sensor_entity_id` sensor. If the limit is reached, VTherm cancels the current cycle, turns off the underlying switch, and blocks future switch activation until the temperature returns inside the hysteresis band.
+
+The available parameters are:
+
+| Parameter | Description |
+| --------- | ----------- |
+| `supply_temperature_sensor_entity_id` | Temperature sensor measuring the supply water temperature. |
+| `supply_temperature_heat_max` | Maximum allowed supply temperature while in heating mode. |
+| `supply_temperature_cool_min` | Minimum allowed supply temperature while in cooling mode. |
+| `supply_temperature_tolerance` | Hysteresis used before clearing a safety trip. |
+| `supply_temperature_delay_sec` | Optional delay before applying a new trip. |
+
+If the supply temperature sensor becomes unavailable or unknown, VTherm blocks activation as a fail-safe behavior.
+
+> This feature is software supervision only. Turning off a pump does not guarantee zero water flow. Physical protection such as a suitable safety thermostat, condensation protection, check valve, or isolation valve may still be required depending on the installation.
 
 ### Command Inversion
 

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -44,6 +44,96 @@ async def test_safety_feature_manager_create(
     assert custom_attributes.get("safety_manager") is None
 
 
+async def test_supply_temperature_safety_blocks_underlying_switch(
+    hass: HomeAssistant,
+    skip_hass_states_is_state,
+    fake_underlying_switch: MockSwitch,
+):
+    """Supply temperature safety turns off and blocks the pump switch."""
+
+    hass.states.async_set("sensor.mock_supply_temperature", "35")
+    await hass.async_block_till_done()
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="TheOverSwitchMockName",
+        unique_id="uniqueId",
+        data={
+            CONF_NAME: "TheOverSwitchMockName",
+            CONF_THERMOSTAT_TYPE: CONF_THERMOSTAT_SWITCH,
+            CONF_TEMP_SENSOR: "sensor.mock_temp_sensor",
+            CONF_EXTERNAL_TEMP_SENSOR: "sensor.mock_ext_temp_sensor",
+            CONF_CYCLE_MIN: 5,
+            CONF_TEMP_MIN: 15,
+            CONF_TEMP_MAX: 30,
+            CONF_STEP_TEMPERATURE: 0.1,
+            "frost_temp": 10,
+            "eco_temp": 17,
+            "comfort_temp": 19,
+            "boost_temp": 21,
+            CONF_USE_WINDOW_FEATURE: False,
+            CONF_USE_MOTION_FEATURE: False,
+            CONF_USE_POWER_FEATURE: False,
+            CONF_USE_PRESENCE_FEATURE: False,
+            CONF_UNDERLYING_LIST: ["switch.mock_switch"],
+            CONF_HEATER_KEEP_ALIVE: 0,
+            CONF_PROP_FUNCTION: PROPORTIONAL_FUNCTION_TPI,
+            CONF_TPI_COEF_INT: 0.3,
+            CONF_TPI_COEF_EXT: 0.01,
+            CONF_MINIMAL_ACTIVATION_DELAY: 10,
+            CONF_MINIMAL_DEACTIVATION_DELAY: 0,
+            CONF_SAFETY_DELAY_MIN: 60,
+            CONF_SAFETY_MIN_ON_PERCENT: 0.3,
+            CONF_SUPPLY_TEMP_SENSOR: "sensor.mock_supply_temperature",
+            CONF_SUPPLY_TEMP_HEAT_MAX: 45,
+            CONF_SUPPLY_TEMP_COOL_MIN: 18,
+            CONF_SUPPLY_TEMP_TOLERANCE: 2,
+            CONF_SUPPLY_TEMP_DELAY_SEC: 0,
+        },
+    )
+
+    entity: ThermostatOverSwitch = await create_thermostat(
+        hass, entry, "climate.theoverswitchmockname"
+    )
+    assert entity
+    assert entity.supply_temperature_safety_manager.is_configured is True
+    assert entity.supply_temperature_safety_manager.is_supply_temperature_safety_detected is False
+
+    await entity.async_set_hvac_mode(VThermHvacMode_HEAT)
+    underlying = entity.underlying_entity(0)
+
+    assert await underlying.turn_on() is True
+    await hass.async_block_till_done()
+    assert fake_underlying_switch.is_on is True
+
+    hass.states.async_set("sensor.mock_supply_temperature", "50")
+    await wait_for_local_condition(
+        lambda: entity.supply_temperature_safety_manager.is_supply_temperature_safety_detected,
+        hass=hass,
+    )
+    assert fake_underlying_switch.is_on is False
+    assert underlying.should_device_be_active is False
+
+    assert await underlying.turn_on() is False
+    await hass.async_block_till_done()
+    assert fake_underlying_switch.is_on is False
+
+    with patch(
+        "custom_components.versatile_thermostat.base_thermostat.BaseThermostat.async_control_heating"
+    ):
+        hass.states.async_set("sensor.mock_supply_temperature", "40")
+        await wait_for_local_condition(
+            lambda: not entity.supply_temperature_safety_manager.is_supply_temperature_safety_detected,
+            hass=hass,
+        )
+
+    assert await underlying.turn_on() is True
+    await hass.async_block_till_done()
+    assert fake_underlying_switch.is_on is True
+
+    entity.remove_thermostat()
+
+
 @pytest.mark.parametrize(
     "safety_delay_min, safety_min_on_percent, safety_default_on_percent, is_configured, state",
     [


### PR DESCRIPTION
## Summary

Adds an optional supply-water temperature safety lockout for `over_switch` thermostats.

When configured, VTherm watches a supply temperature sensor and blocks underlying switch activation if the water temperature is unsafe:

- in `HEAT`, supply temperature at or above `supply_temperature_heat_max` trips the lockout,
- in `COOL`, supply temperature at or below `supply_temperature_cool_min` trips the lockout,
- `supply_temperature_tolerance` provides hysteresis before the lockout clears,
- unavailable/unknown supply temperature fails safe by blocking activation.

While tripped, the feature cancels the current cycle, turns off underlying switch entities, and makes `UnderlyingSwitch.turn_on()` refuse reactivation so keep-alive, repair, and cycle logic do not fight the lockout.

## Why

Hydronic floor-heating/floor-cooling systems may use an `over_switch` thermostat to control a circulation pump. A Home Assistant automation can turn that pump off, but VTherm can later turn it back on because normal room demand still exists. Keeping the lockout inside VTherm makes the protection part of the same command path as TPI, keep-alive, and repair logic.

## Documentation

Updated the English `over_switch` documentation with the new supply temperature safety fields and a note that this is software supervision only. Physical protection may still be required depending on the installation.

## Validation

- `python3 -m json.tool custom_components/versatile_thermostat/strings.json`
- `python3 -m json.tool custom_components/versatile_thermostat/translations/en.json`
- `python3 -m compileall -q custom_components/versatile_thermostat tests/test_safety.py`
- `git diff --check`
- `black --check custom_components/versatile_thermostat/feature_supply_temperature_safety_manager.py`

I also attempted to install the repository test requirements and run the focused regression test, but the local Python is 3.13 and `homeassistant==2026.3.1` requires Python `>=3.14.2`, so the test dependency installation cannot complete in this environment.
