### PR TITLE
fix: set_auto_regulation_mode to None left the previous regulation algo active

### DIFF
--- a/custom_components/versatile_thermostat/thermostat_climate.py
+++ b/custom_components/versatile_thermostat/thermostat_climate.py
@@ -416,8 +416,10 @@ class ThermostatOverClimate(BaseThermostat[UnderlyingClimate]):
                     DOMAIN,
                 )
 
-        if not self._regulation_algo:
-            # A default empty algo (which does nothing)
+        if self._auto_regulation_mode == CONF_AUTO_REGULATION_NONE or not self._regulation_algo:
+            # A default empty algo (which does nothing). It must also replace any
+            # previously active algo when switching to None at runtime, else the
+            # old regulator keeps sending regulated setpoints to the underlyings.
             self._regulation_algo = PITemperatureRegulator(self.target_temperature, 0, 0, 0, 0, 0, True)
 
     def choose_auto_fan_mode(self, auto_fan_mode: str):

--- a/tests/test_auto_regulation.py
+++ b/tests/test_auto_regulation.py
@@ -656,3 +656,38 @@ async def test_over_climate_regulation_calculation_scheduled(hass: HomeAssistant
     assert vtherm.is_recalculate_scheduled is True
 
     vtherm.remove_thermostat()
+
+
+async def test_over_climate_set_regulation_mode_none_replaces_algo(
+    hass: HomeAssistant, skip_hass_states_is_state, skip_send_event, fake_underlying_climate
+):
+    """Test that switching the auto regulation mode to None at runtime replaces the
+    active regulation algo with the do-nothing one. Before the fix the previous algo
+    stayed in place and kept sending regulated setpoints to the underlyings, while
+    is_regulated was already reporting False"""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="TheOverClimateMockName",
+        unique_id="uniqueId",
+        # This is include a medium regulation
+        data=PARTIAL_CLIMATE_CONFIG,
+    )
+
+    entity = await create_thermostat(hass, entry, "climate.theoverclimatemockname")
+    assert entity
+    assert isinstance(entity, ThermostatOverClimate)
+    assert entity.is_regulated is True
+
+    # The medium algo regulates: with a room temp below the target it adds an offset
+    entity._regulation_algo.set_target_temp(20)
+    assert entity._regulation_algo.calculate_regulated_temperature(17, 10, 1.0) != 20
+
+    await entity.service_set_auto_regulation_mode("None")
+    assert entity.is_regulated is False
+
+    # The do-nothing algo must now be in place: it always returns the target
+    entity._regulation_algo.set_target_temp(20)
+    assert entity._regulation_algo.calculate_regulated_temperature(17, 10, 1.0) == 20
+
+    entity.remove_thermostat()


### PR DESCRIPTION
## Problem

Calling the `versatile_thermostat.set_auto_regulation_mode` service with `auto_regulation_mode: 'None'` on a VTherm `over_climate` that was configured with an active self-regulation mode (e.g. Medium) does not actually stop the regulation.

`choose_auto_regulation_mode()` sets `self._auto_regulation_mode` (so `is_regulated` correctly starts reporting `False`), but the do-nothing regulator is only installed when no algo exists yet:

```python
if not self._regulation_algo:
    # A default empty algo (which does nothing)
    self._regulation_algo = PITemperatureRegulator(self.target_temperature, 0, 0, 0, 0, 0, True)
```

Since the previously configured regulator (e.g. Medium) is still assigned, `_send_regulated_temperature()` keeps using it and keeps sending regulated setpoints to the underlying climate entities — while the entity attributes claim regulation is off.

## Real-world impact

I use the service to freeze regulation overnight because my Matter AC units relight their display LED on every command received. After calling `set_auto_regulation_mode: 'None'` (and disabling auto start/stop), the underlying unit still received regulated setpoint changes through the night (e.g. 73→74→75→76°F as the room cooled), stepping every `auto_regulation_periode_min` whenever the drift exceeded `auto_regulation_dtemp` — waking the display each time. Attributes showed `is_regulated: false` the whole time, which made this quite hard to diagnose.

## Fix

Always install the do-nothing regulator when the mode is None:

```python
if self._auto_regulation_mode == CONF_AUTO_REGULATION_NONE or not self._regulation_algo:
```

## Test

Added `test_over_climate_set_regulation_mode_none_replaces_algo`: creates a Medium-regulated over_climate VTherm, asserts the regulator produces an offset, switches to `None` via the service, and asserts the active algo now returns exactly the target temperature. The test fails on `main` and passes with this fix; the full `tests/test_auto_regulation.py` suite passes (7/7, Python 3.14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)