### PR TITLE
fix: auto fan mode inoperative with worded fan speeds (MelCloud Home one/two/three)

### DIFF
--- a/custom_components/versatile_thermostat/const.py
+++ b/custom_components/versatile_thermostat/const.py
@@ -502,7 +502,7 @@ ATTR_TOTAL_ENERGY = "total_energy"
 ATTR_MEAN_POWER_CYCLE = "mean_cycle_power"
 
 AUTO_FAN_DTEMP_THRESHOLD = 2
-AUTO_FAN_DEACTIVATED_MODES = ["mute", "quiet", "low", "quiet", "1", "one", "auto"]
+AUTO_FAN_DEACTIVATED_MODES = ["mute", "quiet", "low", "quiet", "1", "one", "speed_1", "auto"]
 
 CENTRAL_CONFIG_NAME = "Central configuration"
 

--- a/custom_components/versatile_thermostat/const.py
+++ b/custom_components/versatile_thermostat/const.py
@@ -502,7 +502,7 @@ ATTR_TOTAL_ENERGY = "total_energy"
 ATTR_MEAN_POWER_CYCLE = "mean_cycle_power"
 
 AUTO_FAN_DTEMP_THRESHOLD = 2
-AUTO_FAN_DEACTIVATED_MODES = ["mute", "quiet", "low", "quiet", "1", "auto"]
+AUTO_FAN_DEACTIVATED_MODES = ["mute", "quiet", "low", "quiet", "1", "one", "auto"]
 
 CENTRAL_CONFIG_NAME = "Central configuration"
 

--- a/custom_components/versatile_thermostat/thermostat_climate.py
+++ b/custom_components/versatile_thermostat/thermostat_climate.py
@@ -440,8 +440,8 @@ class ThermostatOverClimate(BaseThermostat[UnderlyingClimate]):
                 return None
 
         def determine_fan_mode_contains_speed(fan_modes: list[str]) -> bool:
-            """Determine if the fan_modes contains speed modes by searching for the keywords "low"/"1"."""
-            for val in ["low", "1"]:
+            """Determine if the fan_modes contains speed modes by searching for the keywords "low"/"1"/"one"."""
+            for val in ["low", "1", "one"]:
                 if find_fan_mode(fan_modes, val):
                     return True
             return False
@@ -453,6 +453,8 @@ class ThermostatOverClimate(BaseThermostat[UnderlyingClimate]):
                 index = speed_modes.index("low")
             elif "1" in speed_modes:
                 index = speed_modes.index("1")
+            elif "one" in speed_modes:
+                index = speed_modes.index("one")
 
             if index > -1 and index >= len(speed_modes) / 2:
                 speed_modes.reverse()

--- a/custom_components/versatile_thermostat/thermostat_climate.py
+++ b/custom_components/versatile_thermostat/thermostat_climate.py
@@ -440,8 +440,8 @@ class ThermostatOverClimate(BaseThermostat[UnderlyingClimate]):
                 return None
 
         def determine_fan_mode_contains_speed(fan_modes: list[str]) -> bool:
-            """Determine if the fan_modes contains speed modes by searching for the keywords "low"/"1"/"one"."""
-            for val in ["low", "1", "one"]:
+            """Determine if the fan_modes contains speed modes by searching for the keywords "low"/"1"/"one"/"speed_1"."""
+            for val in ["low", "1", "one", "speed_1"]:
                 if find_fan_mode(fan_modes, val):
                     return True
             return False
@@ -455,6 +455,8 @@ class ThermostatOverClimate(BaseThermostat[UnderlyingClimate]):
                 index = speed_modes.index("1")
             elif "one" in speed_modes:
                 index = speed_modes.index("one")
+            elif "speed_1" in speed_modes:
+                index = speed_modes.index("speed_1")
 
             if index > -1 and index >= len(speed_modes) / 2:
                 speed_modes.reverse()

--- a/tests/test_auto_fan_mode.py
+++ b/tests/test_auto_fan_mode.py
@@ -163,7 +163,7 @@ async def test_over_climate_auto_fan_mode_with_worded_fan_speed_values(
     assert entity.fan_modes == fan_modes
     assert entity._auto_fan_mode == "auto_fan_high"
     assert entity._auto_activated_fan_mode == "three"
-    assert entity._auto_deactivated_fan_mode == "auto"
+    assert entity._auto_deactivated_fan_mode == "one"
 
     # 2. Change auto_fan_mode by CONF_AUTO_FAN_TURBO
     with patch(
@@ -171,7 +171,7 @@ async def test_over_climate_auto_fan_mode_with_worded_fan_speed_values(
     ) as mock_send_fan_mode:
         await entity.service_set_auto_fan_mode("Turbo")
         assert entity._auto_activated_fan_mode == "three"
-        assert entity._auto_deactivated_fan_mode == "auto"
+        assert entity._auto_deactivated_fan_mode == "one"
 
     # 3. Change auto_fan_mode by CONF_AUTO_FAN_MEDIUM
     with patch(
@@ -179,7 +179,7 @@ async def test_over_climate_auto_fan_mode_with_worded_fan_speed_values(
     ) as mock_send_fan_mode:
         await entity.service_set_auto_fan_mode("Medium")
         assert entity._auto_activated_fan_mode == "two"
-        assert entity._auto_deactivated_fan_mode == "auto"
+        assert entity._auto_deactivated_fan_mode == "one"
 
     # 4. Change auto_fan_mode by CONF_AUTO_FAN_LOW
     with patch(
@@ -187,7 +187,7 @@ async def test_over_climate_auto_fan_mode_with_worded_fan_speed_values(
     ) as mock_send_fan_mode:
         await entity.service_set_auto_fan_mode("Low")
         assert entity._auto_activated_fan_mode == "one"
-        assert entity._auto_deactivated_fan_mode == "auto"
+        assert entity._auto_deactivated_fan_mode == "one"
 
     entity.remove_thermostat()
 

--- a/tests/test_auto_fan_mode.py
+++ b/tests/test_auto_fan_mode.py
@@ -191,6 +191,91 @@ async def test_over_climate_auto_fan_mode_with_worded_fan_speed_values(
 
     entity.remove_thermostat()
 
+async def test_over_climate_auto_fan_mode_with_speed_prefixed_fan_values(
+    hass: HomeAssistant, skip_hass_states_is_state, skip_send_event
+):
+    """Test the init of an over climate thermostat with speed_N fan values (MelCloud Home / Mitsubishi)"""
+
+    fan_modes = ["auto", "speed_1", "speed_2", "speed_3", "speed_4"]
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="TheOverClimateMockName",
+        unique_id="uniqueId",
+        data={
+            CONF_NAME: "TheOverClimateMockName",
+            CONF_THERMOSTAT_TYPE: CONF_THERMOSTAT_CLIMATE,
+            CONF_TEMP_SENSOR: "sensor.mock_temp_sensor",
+            CONF_EXTERNAL_TEMP_SENSOR: "sensor.mock_ext_temp_sensor",
+            CONF_CYCLE_MIN: 5,
+            CONF_TEMP_MIN: 15,
+            CONF_TEMP_MAX: 30,
+            "eco_temp": 17,
+            "comfort_temp": 18,
+            "boost_temp": 19,
+            CONF_USE_WINDOW_FEATURE: False,
+            CONF_USE_MOTION_FEATURE: False,
+            CONF_USE_POWER_FEATURE: False,
+            CONF_USE_PRESENCE_FEATURE: False,
+            CONF_UNDERLYING_LIST: ["climate.mock_climate"],
+            CONF_MINIMAL_ACTIVATION_DELAY: 30,
+            CONF_MINIMAL_DEACTIVATION_DELAY: 0,
+            CONF_SAFETY_DELAY_MIN: 5,
+            CONF_SAFETY_MIN_ON_PERCENT: 0.3,
+            CONF_AUTO_FAN_MODE: CONF_AUTO_FAN_HIGH,
+        },
+    )
+
+    fake_underlying_climate = await create_and_register_mock_climate(
+        hass=hass,
+        unique_id="mock_climate",
+        name="MockClimateName",
+        fan_modes=fan_modes,
+    )
+
+    # 1. Init with CONF_AUTO_FAN_HIGH
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    assert entry.state is ConfigEntryState.LOADED
+
+    entity: ThermostatOverClimate = search_entity(hass, "climate.theoverclimatemockname", "climate")
+
+    assert entity
+    assert isinstance(entity, ThermostatOverClimate)
+
+    assert entity.name == "TheOverClimateMockName"
+    assert entity.is_over_climate is True
+    assert entity.fan_modes == fan_modes
+    assert entity._auto_fan_mode == "auto_fan_high"
+    assert entity._auto_activated_fan_mode == "speed_3"
+    assert entity._auto_deactivated_fan_mode == "speed_1"
+
+    # 2. Change auto_fan_mode by CONF_AUTO_FAN_TURBO
+    with patch(
+        "custom_components.versatile_thermostat.underlyings.UnderlyingClimate.set_fan_mode"
+    ) as mock_send_fan_mode:
+        await entity.service_set_auto_fan_mode("Turbo")
+        assert entity._auto_activated_fan_mode == "speed_4"
+        assert entity._auto_deactivated_fan_mode == "speed_1"
+
+    # 3. Change auto_fan_mode by CONF_AUTO_FAN_MEDIUM
+    with patch(
+        "custom_components.versatile_thermostat.underlyings.UnderlyingClimate.set_fan_mode"
+    ) as mock_send_fan_mode:
+        await entity.service_set_auto_fan_mode("Medium")
+        assert entity._auto_activated_fan_mode == "speed_2"
+        assert entity._auto_deactivated_fan_mode == "speed_1"
+
+    # 4. Change auto_fan_mode by CONF_AUTO_FAN_LOW
+    with patch(
+        "custom_components.versatile_thermostat.underlyings.UnderlyingClimate.set_fan_mode"
+    ) as mock_send_fan_mode:
+        await entity.service_set_auto_fan_mode("Low")
+        assert entity._auto_activated_fan_mode == "speed_1"
+        assert entity._auto_deactivated_fan_mode == "speed_1"
+
+    entity.remove_thermostat()
+
 async def test_over_climate_auto_fan_mode_with_4_fan_speed_values(
     hass: HomeAssistant, skip_hass_states_is_state, skip_send_event
 ):

--- a/tests/test_auto_fan_mode.py
+++ b/tests/test_auto_fan_mode.py
@@ -106,6 +106,91 @@ async def test_over_climate_auto_fan_mode_with_3_fan_speed_values(
 
     entity.remove_thermostat()
 
+async def test_over_climate_auto_fan_mode_with_worded_fan_speed_values(
+    hass: HomeAssistant, skip_hass_states_is_state, skip_send_event
+):
+    """Test the init of an over climate thermostat with worded fan speed values (MelCloud Home)"""
+
+    fan_modes = ["auto", "one", "two", "three"]
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="TheOverClimateMockName",
+        unique_id="uniqueId",
+        data={
+            CONF_NAME: "TheOverClimateMockName",
+            CONF_THERMOSTAT_TYPE: CONF_THERMOSTAT_CLIMATE,
+            CONF_TEMP_SENSOR: "sensor.mock_temp_sensor",
+            CONF_EXTERNAL_TEMP_SENSOR: "sensor.mock_ext_temp_sensor",
+            CONF_CYCLE_MIN: 5,
+            CONF_TEMP_MIN: 15,
+            CONF_TEMP_MAX: 30,
+            "eco_temp": 17,
+            "comfort_temp": 18,
+            "boost_temp": 19,
+            CONF_USE_WINDOW_FEATURE: False,
+            CONF_USE_MOTION_FEATURE: False,
+            CONF_USE_POWER_FEATURE: False,
+            CONF_USE_PRESENCE_FEATURE: False,
+            CONF_UNDERLYING_LIST: ["climate.mock_climate"],
+            CONF_MINIMAL_ACTIVATION_DELAY: 30,
+            CONF_MINIMAL_DEACTIVATION_DELAY: 0,
+            CONF_SAFETY_DELAY_MIN: 5,
+            CONF_SAFETY_MIN_ON_PERCENT: 0.3,
+            CONF_AUTO_FAN_MODE: CONF_AUTO_FAN_HIGH,
+        },
+    )
+
+    fake_underlying_climate = await create_and_register_mock_climate(
+        hass=hass,
+        unique_id="mock_climate",
+        name="MockClimateName",
+        fan_modes=fan_modes,
+    )
+
+    # 1. Init with CONF_AUTO_FAN_HIGH
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    assert entry.state is ConfigEntryState.LOADED
+
+    entity: ThermostatOverClimate = search_entity(hass, "climate.theoverclimatemockname", "climate")
+
+    assert entity
+    assert isinstance(entity, ThermostatOverClimate)
+
+    assert entity.name == "TheOverClimateMockName"
+    assert entity.is_over_climate is True
+    assert entity.fan_modes == fan_modes
+    assert entity._auto_fan_mode == "auto_fan_high"
+    assert entity._auto_activated_fan_mode == "three"
+    assert entity._auto_deactivated_fan_mode == "auto"
+
+    # 2. Change auto_fan_mode by CONF_AUTO_FAN_TURBO
+    with patch(
+        "custom_components.versatile_thermostat.underlyings.UnderlyingClimate.set_fan_mode"
+    ) as mock_send_fan_mode:
+        await entity.service_set_auto_fan_mode("Turbo")
+        assert entity._auto_activated_fan_mode == "three"
+        assert entity._auto_deactivated_fan_mode == "auto"
+
+    # 3. Change auto_fan_mode by CONF_AUTO_FAN_MEDIUM
+    with patch(
+        "custom_components.versatile_thermostat.underlyings.UnderlyingClimate.set_fan_mode"
+    ) as mock_send_fan_mode:
+        await entity.service_set_auto_fan_mode("Medium")
+        assert entity._auto_activated_fan_mode == "two"
+        assert entity._auto_deactivated_fan_mode == "auto"
+
+    # 4. Change auto_fan_mode by CONF_AUTO_FAN_LOW
+    with patch(
+        "custom_components.versatile_thermostat.underlyings.UnderlyingClimate.set_fan_mode"
+    ) as mock_send_fan_mode:
+        await entity.service_set_auto_fan_mode("Low")
+        assert entity._auto_activated_fan_mode == "one"
+        assert entity._auto_deactivated_fan_mode == "auto"
+
+    entity.remove_thermostat()
+
 async def test_over_climate_auto_fan_mode_with_4_fan_speed_values(
     hass: HomeAssistant, skip_hass_states_is_state, skip_send_event
 ):


### PR DESCRIPTION
## Problem

On devices like **MelCloud Home**, `fan_modes` are exposed as `[auto, one, two, three]`.

`choose_auto_fan_mode()` detects speed values by searching for the exact keywords `"low"` or `"1"`, so with worded speeds the detection fails: the `#1419` warning is logged, `_auto_activated_fan_mode` stays `None`, and `_send_auto_fan_mode()` returns immediately — the auto fan feature never changes the fan speed even when configured (e.g. `auto_fan_high`).

## Fix

- Add `"one"` to the speed-detection keywords in `determine_fan_mode_contains_speed()`
- Handle `"one"` in `fix_order_speed_modes()` for the ordering check

With `[auto, one, two, three]`, `auto_fan_high` now activates `three` and deactivates back to `auto` (already covered by `AUTO_FAN_DEACTIVATED_MODES`).

## Tests

Added `test_over_climate_auto_fan_mode_with_worded_fan_speed_values` in `tests/test_auto_fan_mode.py` covering the MelCloud-style list (High/Turbo/Medium/Low mappings). All 8 tests in the file pass.