### PR TITLE
fix(over_climate): repair hvac_mode drift and space out mode/temperature commands

### DIFF
--- a/custom_components/versatile_thermostat/thermostat_climate.py
+++ b/custom_components/versatile_thermostat/thermostat_climate.py
@@ -275,6 +275,25 @@ class ThermostatOverClimate(BaseThermostat[UnderlyingClimate]):
                 )
                 continue
 
+            # Some climate integrations (e.g. Midea cloud) mishandle a set_temperature
+            # call fired right on the heels of set_hvac_mode: the device bounces back
+            # to its previous mode shortly after, even though the mode change alone
+            # (without a following command) is handled fine. If a hvac_mode command was
+            # just sent to this underlying earlier in this same control cycle (turn-on
+            # cascade or drift-repair resync), skip the immediate send here and let the
+            # delayed resend already scheduled by set_hvac_mode (see resend_delay_sec)
+            # carry it once the underlying has settled. consume_mode_just_sent() resets
+            # itself, so a later, genuinely separate temperature change is unaffected.
+            if under.consume_mode_just_sent():
+                _LOGGER.debug(
+                    "%s - hvac_mode was just sent to %s (startup/resync) -> skip sending the regulated temperature %.1f for now, the delayed resend will send the target temperature in %s sec",
+                    self,
+                    under.entity_id,
+                    target_temp,
+                    resend_delay_sec,
+                )
+                continue
+
             _LOGGER.debug(
                 "%s - The device offset temp for regulation is %.2f - internal temp is %.2f. New target is %.2f",
                 self,

--- a/custom_components/versatile_thermostat/thermostat_climate.py
+++ b/custom_components/versatile_thermostat/thermostat_climate.py
@@ -277,7 +277,7 @@ class ThermostatOverClimate(BaseThermostat[UnderlyingClimate]):
             # later, genuinely separate temperature change is unaffected.
             if under.consume_mode_just_sent():
                 _LOGGER.debug(
-                    "%s - hvac_mode was just sent to %s (startup/resync) -> delay sending the regulated temperature %.1f by %s sec",
+                    "%s - hvac_mode was just sent to %s (startup/resync) -> delay sending the regulated temperature %.2f by %s sec",
                     self,
                     under.entity_id,
                     target_temp,

--- a/custom_components/versatile_thermostat/thermostat_climate.py
+++ b/custom_components/versatile_thermostat/thermostat_climate.py
@@ -184,6 +184,21 @@ class ThermostatOverClimate(BaseThermostat[UnderlyingClimate]):
             self.do_send_regulated_temp_later()
             return
 
+        # Some climate integrations can silently drift away from the hvac_mode VTherm
+        # asked for (device bounces back to a previous mode on its own, a command is
+        # lost, a compressor minimum-off-time protection silently ignores the command,
+        # ...) since VTherm otherwise only resends hvac_mode when its own internal
+        # state changes. Realign them here: the auto-regulation period gate above
+        # already ensures we don't get here more often than that period allows (or
+        # that force=True was explicitly requested), so retrying the repair can't
+        # re-trigger a device-side protection before it has had a chance to let the
+        # device actually start. Still skip it for the few seconds right after
+        # VTherm itself just sent a hvac_mode command, since the underlying's cached
+        # state may not have caught up yet in that case.
+        if not self._last_change_time_from_vtherm or (self.now - self._last_change_time_from_vtherm).total_seconds() >= resend_delay_sec:
+            for under in self._underlyings:
+                await under.resync_hvac_mode()
+
         self._regulation_algo.set_target_temp(self.target_temperature)
 
         if not self._regulated_target_temp:
@@ -836,20 +851,9 @@ class ThermostatOverClimate(BaseThermostat[UnderlyingClimate]):
 
         # Continue the normal async_control_heating
 
-        # Some climate integrations can silently drift away from the hvac_mode VTherm
-        # asked for (device bounces back to a previous mode on its own, a command is
-        # lost, a compressor minimum-off-time protection silently ignores the command,
-        # ...) since VTherm otherwise only resends hvac_mode when its own internal
-        # state changes. Realign them, but only once the auto-regulation period has
-        # elapsed (same gate as _send_regulated_temperature), not on every control
-        # cycle: retrying more often than that risks re-triggering a device-side
-        # protection before it has had a chance to let the device actually start.
-        if not self._last_change_time_from_vtherm or (self.now - self._last_change_time_from_vtherm).total_seconds() >= resend_delay_sec:
-            if self.check_auto_regulation_period_min(self.now):
-                for under in self._underlyings:
-                    await under.resync_hvac_mode()
-
-        # Send the regulated temperature to the underlyings
+        # Send the regulated temperature to the underlyings. The hvac_mode drift
+        # repair (see resync_hvac_mode) is also triggered from within this call,
+        # gated by the same auto-regulation period check.
         await self._send_regulated_temperature(force=force)
 
         if self._auto_fan_mode and self._auto_fan_mode != CONF_AUTO_FAN_NONE:

--- a/custom_components/versatile_thermostat/thermostat_climate.py
+++ b/custom_components/versatile_thermostat/thermostat_climate.py
@@ -265,6 +265,31 @@ class ThermostatOverClimate(BaseThermostat[UnderlyingClimate]):
             # will not have any effect on the device. This avoid to send too many temperature changes to the underlying.
             dtemp = target_temp - (under.last_sent_temperature if under.last_sent_temperature else 0)
 
+            # Some climate integrations (e.g. Midea cloud) mishandle a set_temperature
+            # call fired right on the heels of set_hvac_mode: the device bounces back
+            # to its previous mode shortly after, even though the mode change alone
+            # (without a following command) is handled fine. If a hvac_mode command was
+            # just sent to this underlying earlier in this same control cycle (turn-on
+            # cascade or drift-repair resync), don't send the regulated temperature
+            # immediately: re-schedule it resend_delay_sec later (replacing the
+            # raw-target resend set_hvac_mode scheduled), once the underlying has
+            # settled on the new mode. consume_mode_just_sent() resets itself, so a
+            # later, genuinely separate temperature change is unaffected.
+            if under.consume_mode_just_sent():
+                _LOGGER.debug(
+                    "%s - hvac_mode was just sent to %s (startup/resync) -> delay sending the regulated temperature %.1f by %s sec",
+                    self,
+                    under.entity_id,
+                    target_temp,
+                    resend_delay_sec,
+                )
+                under.set_temperature_later(
+                    target_temp,
+                    self._attr_max_temp,
+                    self._attr_min_temp,
+                )
+                continue
+
             if not force and abs(dtemp) < (self._auto_regulation_dtemp or 0):
                 _LOGGER.info(
                     "%s - dtemp (%.1f) is < %.1f -> forget the regulation send for %s",
@@ -272,25 +297,6 @@ class ThermostatOverClimate(BaseThermostat[UnderlyingClimate]):
                     dtemp,
                     self._auto_regulation_dtemp,
                     under.entity_id,
-                )
-                continue
-
-            # Some climate integrations (e.g. Midea cloud) mishandle a set_temperature
-            # call fired right on the heels of set_hvac_mode: the device bounces back
-            # to its previous mode shortly after, even though the mode change alone
-            # (without a following command) is handled fine. If a hvac_mode command was
-            # just sent to this underlying earlier in this same control cycle (turn-on
-            # cascade or drift-repair resync), skip the immediate send here and let the
-            # delayed resend already scheduled by set_hvac_mode (see resend_delay_sec)
-            # carry it once the underlying has settled. consume_mode_just_sent() resets
-            # itself, so a later, genuinely separate temperature change is unaffected.
-            if under.consume_mode_just_sent():
-                _LOGGER.debug(
-                    "%s - hvac_mode was just sent to %s (startup/resync) -> skip sending the regulated temperature %.1f for now, the delayed resend will send the target temperature in %s sec",
-                    self,
-                    under.entity_id,
-                    target_temp,
-                    resend_delay_sec,
                 )
                 continue
 

--- a/custom_components/versatile_thermostat/thermostat_climate.py
+++ b/custom_components/versatile_thermostat/thermostat_climate.py
@@ -21,7 +21,7 @@ from .pi_algorithm import PITemperatureRegulator
 from .const import *  # pylint: disable=wildcard-import, unused-wildcard-import
 
 from .vtherm_central_api import VersatileThermostatAPI
-from .underlyings import UnderlyingClimate
+from .underlyings import UnderlyingClimate, resend_delay_sec
 from .feature_auto_start_stop_manager import FeatureAutoStartStopManager
 from .vtherm_hvac_mode import VThermHvacMode
 
@@ -838,12 +838,14 @@ class ThermostatOverClimate(BaseThermostat[UnderlyingClimate]):
 
         # Some climate integrations can silently drift away from the hvac_mode VTherm
         # asked for (device bounces back to a previous mode on its own, a command is
-        # lost, ...). Realign them on every periodical cycle since VTherm otherwise only
-        # resends hvac_mode when its own internal state changes. This is only done on
-        # genuine periodical ticks (timestamp is set) and not on the internal calls
-        # chained from update_states() right after a hvac_mode command was just sent,
-        # since the underlying's cached state may not have caught up yet in that case.
-        if timestamp:
+        # lost, ...). Realign them on every control cycle (periodical tick, but also
+        # temperature-sensor-triggered cycles so the repair doesn't have to wait for a
+        # long cycle_min) since VTherm otherwise only resends hvac_mode when its own
+        # internal state changes. Skip it only for the few seconds right after VTherm
+        # itself just sent a hvac_mode command (this call is then chained straight from
+        # update_states()), since the underlying's cached state may not have caught up
+        # yet in that case.
+        if not self._last_change_time_from_vtherm or (self.now - self._last_change_time_from_vtherm).total_seconds() >= resend_delay_sec:
             for under in self._underlyings:
                 await under.resync_hvac_mode()
 

--- a/custom_components/versatile_thermostat/thermostat_climate.py
+++ b/custom_components/versatile_thermostat/thermostat_climate.py
@@ -836,6 +836,17 @@ class ThermostatOverClimate(BaseThermostat[UnderlyingClimate]):
 
         # Continue the normal async_control_heating
 
+        # Some climate integrations can silently drift away from the hvac_mode VTherm
+        # asked for (device bounces back to a previous mode on its own, a command is
+        # lost, ...). Realign them on every periodical cycle since VTherm otherwise only
+        # resends hvac_mode when its own internal state changes. This is only done on
+        # genuine periodical ticks (timestamp is set) and not on the internal calls
+        # chained from update_states() right after a hvac_mode command was just sent,
+        # since the underlying's cached state may not have caught up yet in that case.
+        if timestamp:
+            for under in self._underlyings:
+                await under.resync_hvac_mode()
+
         # Send the regulated temperature to the underlyings
         await self._send_regulated_temperature(force=force)
 

--- a/custom_components/versatile_thermostat/thermostat_climate.py
+++ b/custom_components/versatile_thermostat/thermostat_climate.py
@@ -162,6 +162,17 @@ class ThermostatOverClimate(BaseThermostat[UnderlyingClimate]):
             _LOGGER.debug(
                 "%s - don't send regulated temperature cause VTherm is off ", self
             )
+            # Realign the underlying if it silently drifted back on while VTherm
+            # wants it off (the reverse-direction case of the resync done below
+            # for the "on" path). Gated the same way: the auto-regulation period
+            # (or force) throttles retries, and the grace period after VTherm's
+            # own last command avoids reading a stale/echoed cache as a false
+            # positive.
+            if (force or self.check_auto_regulation_period_min(self.now)) and (
+                not self._last_change_time_from_vtherm or (self.now - self._last_change_time_from_vtherm).total_seconds() >= resend_delay_sec
+            ):
+                for under in self._underlyings:
+                    await under.resync_hvac_mode()
             # In this case, reset the timer of last regulation change to avoid time delta too high
             self._last_regulation_change = self.now
             return

--- a/custom_components/versatile_thermostat/thermostat_climate.py
+++ b/custom_components/versatile_thermostat/thermostat_climate.py
@@ -838,16 +838,16 @@ class ThermostatOverClimate(BaseThermostat[UnderlyingClimate]):
 
         # Some climate integrations can silently drift away from the hvac_mode VTherm
         # asked for (device bounces back to a previous mode on its own, a command is
-        # lost, ...). Realign them on every control cycle (periodical tick, but also
-        # temperature-sensor-triggered cycles so the repair doesn't have to wait for a
-        # long cycle_min) since VTherm otherwise only resends hvac_mode when its own
-        # internal state changes. Skip it only for the few seconds right after VTherm
-        # itself just sent a hvac_mode command (this call is then chained straight from
-        # update_states()), since the underlying's cached state may not have caught up
-        # yet in that case.
+        # lost, a compressor minimum-off-time protection silently ignores the command,
+        # ...) since VTherm otherwise only resends hvac_mode when its own internal
+        # state changes. Realign them, but only once the auto-regulation period has
+        # elapsed (same gate as _send_regulated_temperature), not on every control
+        # cycle: retrying more often than that risks re-triggering a device-side
+        # protection before it has had a chance to let the device actually start.
         if not self._last_change_time_from_vtherm or (self.now - self._last_change_time_from_vtherm).total_seconds() >= resend_delay_sec:
-            for under in self._underlyings:
-                await under.resync_hvac_mode()
+            if self.check_auto_regulation_period_min(self.now):
+                for under in self._underlyings:
+                    await under.resync_hvac_mode()
 
         # Send the regulated temperature to the underlyings
         await self._send_regulated_temperature(force=force)

--- a/custom_components/versatile_thermostat/underlyings.py
+++ b/custom_components/versatile_thermostat/underlyings.py
@@ -934,7 +934,9 @@ class UnderlyingClimate(UnderlyingEntity):
             self._cancel_set_temperature_later = None
 
         # Issue 508 we have to take care of service set_temperature or set_range
-        target_temp = self.clamp_sent_value(temperature)
+        # Round to absorb float noise from the regulation calculation
+        # (e.g. 23.099999999999998 -> 23.1)
+        target_temp = round(self.clamp_sent_value(temperature), 2)
         data = {
             ATTR_ENTITY_ID: self._entity_id,
         }

--- a/custom_components/versatile_thermostat/underlyings.py
+++ b/custom_components/versatile_thermostat/underlyings.py
@@ -590,6 +590,17 @@ class UnderlyingClimate(UnderlyingEntity):
         self._min_sync_entity: float = None
         self._max_sync_entity: float = None
         self._step_sync_entity: float = None
+        self._mode_just_sent: bool = False
+
+    def consume_mode_just_sent(self) -> bool:
+        """Whether a set_hvac_mode command was just sent to this underlying (turn-on
+        cascade or drift-repair resync) earlier in the current control cycle, not yet
+        consumed by a follow-up command check. Consuming it resets it, so a later,
+        genuinely separate call (e.g. an explicit user temperature change) is unaffected.
+        """
+        just_sent = self._mode_just_sent
+        self._mode_just_sent = False
+        return just_sent
 
     async def set_hvac_mode(self, hvac_mode: VThermHvacMode) -> bool:
         """Set the HVACmode of the underlying climate. Returns true if something have change"""
@@ -617,6 +628,7 @@ class UnderlyingClimate(UnderlyingEntity):
             SERVICE_SET_HVAC_MODE,
             data,
         )
+        self._mode_just_sent = True
 
         # if restart the climate, then resend the target temperature 2 sec later for lazy SonoffTRVZB
         if hvac_mode in (VThermHvacMode_HEAT, VThermHvacMode_COOL):
@@ -673,7 +685,7 @@ class UnderlyingClimate(UnderlyingEntity):
         """Prevent the underlying to be on but thermostat is off"""
         await self.resync_hvac_mode()
 
-    async def resync_hvac_mode(self):
+    async def resync_hvac_mode(self) -> bool:
         """Realign the underlying climate hvac_mode on the one requested by VTherm.
 
         Some climate integrations (e.g. cloud-polled devices) can silently drift away
@@ -682,10 +694,12 @@ class UnderlyingClimate(UnderlyingEntity):
         command when its own internal state changes, so without this periodic
         re-check such a drift is never corrected. This is called once at startup
         (via check_initial_state) and then on every control cycle.
+
+        Returns True if a set_hvac_mode command was actually (re)sent to repair a drift.
         """
         underlying_state = self._state_manager.get_state(self._entity_id)
         if underlying_state is None or underlying_state.state in [STATE_UNAVAILABLE, STATE_UNKNOWN]:
-            return
+            return False
 
         underlying_hvac_mode = from_ha_hvac_mode(underlying_state.state)
         self._hvac_mode = underlying_hvac_mode
@@ -703,7 +717,7 @@ class UnderlyingClimate(UnderlyingEntity):
                 underlying_state.state,
                 hvac_mode,
             )
-            await self.set_hvac_mode(hvac_mode)
+            return await self.set_hvac_mode(hvac_mode)
         elif hvac_mode != VThermHvacMode_OFF and not is_device_active:
             _LOGGER.warning(
                 "%s - Drift detected on %s: VTherm wants hvac_mode=%s but the underlying is currently in state=%s (not active). "
@@ -714,7 +728,9 @@ class UnderlyingClimate(UnderlyingEntity):
                 underlying_state.state,
                 hvac_mode,
             )
-            await self.set_hvac_mode(hvac_mode)
+            return await self.set_hvac_mode(hvac_mode)
+
+        return False
 
     async def _underlying_changed(self, entity_id: str, new_state: Optional[State], old_state: Optional[State] = None):
         """Handle underlying state change notified by UnderlyingStateManager.

--- a/custom_components/versatile_thermostat/underlyings.py
+++ b/custom_components/versatile_thermostat/underlyings.py
@@ -694,18 +694,25 @@ class UnderlyingClimate(UnderlyingEntity):
         hvac_mode = self._thermostat.vtherm_hvac_mode
 
         if hvac_mode == VThermHvacMode_OFF and is_device_active:
-            _LOGGER.info(
-                "%s - The hvac mode is OFF, but the underlying device is ON. Turning off device %s",
+            _LOGGER.warning(
+                "%s - Drift detected on %s: VTherm wants hvac_mode=%s but the underlying is currently in state=%s. "
+                "Sending set_hvac_mode(%s) to realign it",
                 self,
                 self._entity_id,
+                hvac_mode,
+                underlying_state.state,
+                hvac_mode,
             )
             await self.set_hvac_mode(hvac_mode)
         elif hvac_mode != VThermHvacMode_OFF and not is_device_active:
-            _LOGGER.info(
-                "%s - The hvac mode is %s, but the underlying device is not ON. Turning on device %s if needed",
+            _LOGGER.warning(
+                "%s - Drift detected on %s: VTherm wants hvac_mode=%s but the underlying is currently in state=%s (not active). "
+                "Sending set_hvac_mode(%s) to realign it",
                 self,
-                hvac_mode,
                 self._entity_id,
+                hvac_mode,
+                underlying_state.state,
+                hvac_mode,
             )
             await self.set_hvac_mode(hvac_mode)
 

--- a/custom_components/versatile_thermostat/underlyings.py
+++ b/custom_components/versatile_thermostat/underlyings.py
@@ -650,14 +650,27 @@ class UnderlyingClimate(UnderlyingEntity):
 
         async def callback_resend_temp(_):
             self._cancel_set_temperature_later = None
-            await self.set_temperature(
-                temperature if temperature is not None else self._thermostat.target_temperature,
-                max_temp,
-                min_temp,
+            temp_to_send = temperature if temperature is not None else self._thermostat.target_temperature
+            _LOGGER.debug(
+                "%s - delayed set_temperature fires now: sending %s (%s)",
+                self,
+                temp_to_send,
+                "value captured at scheduling" if temperature is not None else "thermostat target read at fire time",
             )
+            await self.set_temperature(temp_to_send, max_temp, min_temp)
 
         if self._cancel_set_temperature_later:
+            _LOGGER.debug(
+                "%s - a delayed set_temperature was already pending -> replacing it",
+                self,
+            )
             self._cancel_set_temperature_later()
+        _LOGGER.debug(
+            "%s - scheduling a delayed set_temperature in %s sec with %s",
+            self,
+            resend_delay_sec,
+            f"temperature {temperature}" if temperature is not None else "the thermostat target temperature (read at fire time)",
+        )
         self._cancel_set_temperature_later = async_call_later(self._hass, resend_delay_sec, callback_resend_temp)
 
     @overrides
@@ -912,6 +925,11 @@ class UnderlyingClimate(UnderlyingEntity):
         # set_temperature_later): cancel it so a stale value cannot
         # overwrite this newer one afterwards.
         if self._cancel_set_temperature_later:
+            _LOGGER.debug(
+                "%s - a direct set_temperature (%s) supersedes the pending delayed send -> cancelling the delayed send",
+                self,
+                temperature,
+            )
             self._cancel_set_temperature_later()
             self._cancel_set_temperature_later = None
 

--- a/custom_components/versatile_thermostat/underlyings.py
+++ b/custom_components/versatile_thermostat/underlyings.py
@@ -630,17 +630,35 @@ class UnderlyingClimate(UnderlyingEntity):
         )
         self._mode_just_sent = True
 
-        # if restart the climate, then resend the target temperature 2 sec later for lazy SonoffTRVZB
+        # if restart the climate, then resend the target temperature 2 sec later.
+        # Originally added for lazy SonoffTRVZB; also gives cloud-polled devices
+        # (e.g. Midea) time to settle on the new mode before receiving a temperature.
+        # When the thermostat is regulated, _send_regulated_temperature replaces this
+        # raw-target send with the regulated temperature via set_temperature_later.
         if hvac_mode in (VThermHvacMode_HEAT, VThermHvacMode_COOL):
-
-            async def callback_resend_temp(_):
-                await self.set_temperature(self._thermostat.target_temperature, None, None)
-
-            if self._cancel_set_temperature_later:
-                self._cancel_set_temperature_later()
-            self._cancel_set_temperature_later = async_call_later(self._hass, resend_delay_sec, callback_resend_temp)
+            self.set_temperature_later(None, None, None)
 
         return True
+
+    def set_temperature_later(self, temperature, max_temp, min_temp):
+        """Schedule a set_temperature to this underlying after resend_delay_sec,
+        replacing any already pending delayed send. Used to space out a temperature
+        command from a set_hvac_mode command just sent to the same underlying, since
+        some integrations (e.g. Midea cloud) bounce back to their previous mode when
+        both commands arrive back-to-back.
+        A None temperature means: use the thermostat's target temperature at fire time."""
+
+        async def callback_resend_temp(_):
+            self._cancel_set_temperature_later = None
+            await self.set_temperature(
+                temperature if temperature is not None else self._thermostat.target_temperature,
+                max_temp,
+                min_temp,
+            )
+
+        if self._cancel_set_temperature_later:
+            self._cancel_set_temperature_later()
+        self._cancel_set_temperature_later = async_call_later(self._hass, resend_delay_sec, callback_resend_temp)
 
     @overrides
     def remove_entity(self):
@@ -889,6 +907,13 @@ class UnderlyingClimate(UnderlyingEntity):
         """Set the target temperature"""
         if not self.is_initialized:
             return
+
+        # A direct send supersedes any pending delayed resend (see
+        # set_temperature_later): cancel it so a stale value cannot
+        # overwrite this newer one afterwards.
+        if self._cancel_set_temperature_later:
+            self._cancel_set_temperature_later()
+            self._cancel_set_temperature_later = None
 
         # Issue 508 we have to take care of service set_temperature or set_range
         target_temp = self.clamp_sent_value(temperature)

--- a/custom_components/versatile_thermostat/underlyings.py
+++ b/custom_components/versatile_thermostat/underlyings.py
@@ -652,7 +652,7 @@ class UnderlyingClimate(UnderlyingEntity):
             self._cancel_set_temperature_later = None
             temp_to_send = temperature if temperature is not None else self._thermostat.target_temperature
             _LOGGER.debug(
-                "%s - delayed set_temperature fires now: sending %s (%s)",
+                "%s - delayed set_temperature fires now: sending %.2f (%s)",
                 self,
                 temp_to_send,
                 "value captured at scheduling" if temperature is not None else "thermostat target read at fire time",
@@ -669,7 +669,7 @@ class UnderlyingClimate(UnderlyingEntity):
             "%s - scheduling a delayed set_temperature in %s sec with %s",
             self,
             resend_delay_sec,
-            f"temperature {temperature}" if temperature is not None else "the thermostat target temperature (read at fire time)",
+            f"temperature {temperature:.2f}" if temperature is not None else "the thermostat target temperature (read at fire time)",
         )
         self._cancel_set_temperature_later = async_call_later(self._hass, resend_delay_sec, callback_resend_temp)
 
@@ -926,7 +926,7 @@ class UnderlyingClimate(UnderlyingEntity):
         # overwrite this newer one afterwards.
         if self._cancel_set_temperature_later:
             _LOGGER.debug(
-                "%s - a direct set_temperature (%s) supersedes the pending delayed send -> cancelling the delayed send",
+                "%s - a direct set_temperature (%.2f) supersedes the pending delayed send -> cancelling the delayed send",
                 self,
                 temperature,
             )
@@ -941,7 +941,7 @@ class UnderlyingClimate(UnderlyingEntity):
             ATTR_ENTITY_ID: self._entity_id,
         }
 
-        _LOGGER.info("%s - Set setpoint temperature to: %s", self, target_temp)
+        _LOGGER.info("%s - Set setpoint temperature to: %.2f", self, target_temp)
 
         # Issue 807 add TARGET_TEMPERATURE only if in the features
         if ClimateEntityFeature.TARGET_TEMPERATURE_RANGE in self.supported_features:

--- a/custom_components/versatile_thermostat/underlyings.py
+++ b/custom_components/versatile_thermostat/underlyings.py
@@ -671,8 +671,23 @@ class UnderlyingClimate(UnderlyingEntity):
 
     async def check_initial_state(self):
         """Prevent the underlying to be on but thermostat is off"""
+        await self.resync_hvac_mode()
+
+    async def resync_hvac_mode(self):
+        """Realign the underlying climate hvac_mode on the one requested by VTherm.
+
+        Some climate integrations (e.g. cloud-polled devices) can silently drift away
+        from the hvac_mode VTherm asked for (the device bounces back to a previous
+        mode on its own, a command is lost, etc). VTherm only (re)sends a hvac_mode
+        command when its own internal state changes, so without this periodic
+        re-check such a drift is never corrected. This is called once at startup
+        (via check_initial_state) and then on every control cycle.
+        """
         underlying_state = self._state_manager.get_state(self._entity_id)
-        underlying_hvac_mode = from_ha_hvac_mode(underlying_state.state) if underlying_state else None
+        if underlying_state is None or underlying_state.state in [STATE_UNAVAILABLE, STATE_UNKNOWN]:
+            return
+
+        underlying_hvac_mode = from_ha_hvac_mode(underlying_state.state)
         self._hvac_mode = underlying_hvac_mode
 
         is_device_active = underlying_state.state not in [HVACMode.OFF, STATE_UNAVAILABLE, STATE_UNKNOWN]

--- a/tests/test_auto_regulation.py
+++ b/tests/test_auto_regulation.py
@@ -165,19 +165,37 @@ async def test_over_climate_regulation_ac_mode(hass: HomeAssistant, skip_send_ev
 
     # Activate the heating by changing VThermHvacMode and temperature
     # Select a hvacmode, presence and preset
-    await entity.async_set_hvac_mode(VThermHvacMode_COOL)
+    # The immediate regulated-temperature push right after set_hvac_mode is skipped
+    # (see resend_delay_sec) and would otherwise be carried by a delayed resend of the
+    # raw (unregulated) target_temperature, scheduled via async_call_later -- a coarse
+    # fallback meant for lazy TRV devices, not a substitute for the regulation
+    # calculation this test exercises below. Stub it out so it doesn't race the
+    # explicit temperature/sensor changes that drive the regulation cycles here.
+    with patch("custom_components.versatile_thermostat.underlyings.async_call_later", return_value=lambda: None):
+        await entity.async_set_hvac_mode(VThermHvacMode_COOL)
+        await hass.async_block_till_done()
     assert entity.vtherm_hvac_mode is VThermHvacMode_COOL
-    assert entity.hvac_action == HVACAction.OFF
+    assert entity.hvac_action == HVACAction.IDLE
 
     # change temperature so that the heating will start
+    # Advance past auto_regulation_period_min first so this sensor update takes
+    # immediate effect on the room_temperature used for regulation, instead of being
+    # throttled by the period gate (which would otherwise only apply it on some later,
+    # separately-triggered cycle).
+    now = now + timedelta(minutes=3)
     entity._set_now(now)
     fake_temp_sensor.set_native_value(30)
     fake_ext_temp_sensor.set_native_value(35)
     fake_underlying_climate.set_current_temperature(30)
     await hass.async_block_till_done()
+    # Force a regulation cycle so the fresh room/outdoor temperatures are picked up now
+    # (previously this happened incidentally via the underlying's echo of the
+    # back-to-back mode+temperature commands, which the fix above eliminates).
+    await entity.async_control_heating(force=True)
+    await hass.async_block_till_done()
 
     # set manual target temp
-    now = now + timedelta(minutes=7)
+    now = now + timedelta(minutes=4)
     entity._set_now(now)
 
     await entity.async_set_temperature(temperature=25)
@@ -187,7 +205,7 @@ async def test_over_climate_regulation_ac_mode(hass: HomeAssistant, skip_send_ev
 
     # the regulated temperature should be lower
     assert entity.regulated_target_temp < entity.target_temperature
-    assert entity.regulated_target_temp == 25 - 2.5  # In medium we could go up to -3 degre
+    assert entity.regulated_target_temp == 25 - 2.0  # In medium we could go up to -3 degre
     assert entity.hvac_action == HVACAction.COOLING
 
     # change temperature so that the regulated temperature should slow down
@@ -201,7 +219,7 @@ async def test_over_climate_regulation_ac_mode(hass: HomeAssistant, skip_send_ev
 
     # the regulated temperature should be under
     assert entity.regulated_target_temp < entity.target_temperature
-    assert entity.regulated_target_temp == 25 - 1  # +2.3 without round_to_nearest
+    assert entity.regulated_target_temp == 25 - 0.5  # +2.3 without round_to_nearest
 
     # change temperature so that the regulated temperature should slow down
     now = now + timedelta(minutes=3)
@@ -214,7 +232,7 @@ async def test_over_climate_regulation_ac_mode(hass: HomeAssistant, skip_send_ev
 
     # the regulated temperature should be greater
     assert entity.regulated_target_temp > entity.target_temperature
-    assert entity.regulated_target_temp == 25 + 3
+    assert entity.regulated_target_temp == 25 + 3.5
 
     entity.remove_thermostat()
 
@@ -387,10 +405,15 @@ async def test_over_climate_regulation_use_device_temp(hass: HomeAssistant, skip
 
     await entity.async_set_temperature(temperature=16)
 
-    await wait_for_local_condition(lambda: fake_underlying_climate.target_temperature == 12)  # 15 (regulated) - 3 (device offset 18-15)
+    await wait_for_local_condition(lambda: fake_underlying_climate.target_temperature == 12, hass=hass)  # 15 (regulated) - 3 (device offset 18-15)
     assert fake_underlying_climate.hvac_action == HVACAction.IDLE  # current is 15 and target is 12
 
-    # entity.calculate_hvac_action()
+    # wait_for_local_condition returns as soon as the mock's raw python attribute
+    # (checked above) flips, which can be a beat before the corresponding state_changed
+    # event is actually dispatched and processed by VTherm's underlying state manager.
+    # Flush once more so entity.hvac_action reflects the settled state.
+    await hass.async_block_till_done()
+    entity.calculate_hvac_action()
     assert entity.hvac_action == HVACAction.IDLE
     assert entity.preset_mode == VThermPreset.NONE  # Manual mode
 

--- a/tests/test_auto_regulation.py
+++ b/tests/test_auto_regulation.py
@@ -165,12 +165,10 @@ async def test_over_climate_regulation_ac_mode(hass: HomeAssistant, skip_send_ev
 
     # Activate the heating by changing VThermHvacMode and temperature
     # Select a hvacmode, presence and preset
-    # The immediate regulated-temperature push right after set_hvac_mode is skipped
-    # (see resend_delay_sec) and would otherwise be carried by a delayed resend of the
-    # raw (unregulated) target_temperature, scheduled via async_call_later -- a coarse
-    # fallback meant for lazy TRV devices, not a substitute for the regulation
-    # calculation this test exercises below. Stub it out so it doesn't race the
-    # explicit temperature/sensor changes that drive the regulation cycles here.
+    # The immediate regulated-temperature push right after set_hvac_mode is delayed
+    # by resend_delay_sec (via async_call_later) to let the underlying settle on the
+    # new mode. Stub that scheduling out so the delayed send doesn't race the explicit
+    # temperature/sensor changes that drive the regulation cycles this test exercises.
     with patch("custom_components.versatile_thermostat.underlyings.async_call_later", return_value=lambda: None):
         await entity.async_set_hvac_mode(VThermHvacMode_COOL)
         await hass.async_block_till_done()

--- a/tests/test_check_initial_state.py
+++ b/tests/test_check_initial_state.py
@@ -243,17 +243,15 @@ async def test_check_initial_state_underlying_climate(hass, hvac_mode, last_stat
 async def test_resync_hvac_mode_repairs_drift_outside_of_startup(hass, vtherm_hvac_mode, underlying_state, expect_hvac_call):
     """resync_hvac_mode must be able to detect and repair a hvac_mode mismatch at any
     time, not only during the initial check done at startup. This is what
-    ThermostatOverClimate._send_regulated_temperature now calls (once the
-    auto-regulation period has elapsed, or forced) to fix a underlying climate
-    that silently drifted away from what VTherm asked for (see the Qlima/Midea bug
-    report: the device flaps to a different mode on its own and VTherm never
-    noticed because it only resends hvac_mode when its own internal state
-    changes).
-
-    Note: when vtherm_hvac_mode is OFF, _send_regulated_temperature returns before
-    reaching resync_hvac_mode, so the OFF-direction case exercised here (VTherm
-    off, underlying stuck on) is currently only repaired by resync_hvac_mode being
-    called directly (as this test does), not by a live control cycle."""
+    ThermostatOverClimate._send_regulated_temperature now calls, in both
+    directions (whether vtherm_hvac_mode is OFF or not), once the auto-regulation
+    period has elapsed or forced, to fix a underlying climate that silently
+    drifted away from what VTherm asked for (see the Qlima/Midea bug report: the
+    device flaps to a different mode on its own and VTherm never noticed because
+    it only resends hvac_mode when its own internal state changes). See
+    test_overclimate.py::test_under_climate_resync_hvac_mode_drift and
+    ::test_under_climate_resync_hvac_mode_drift_off_direction for the end-to-end,
+    live-control-cycle versions of both directions of this test."""
 
     hass.services = MagicMock()
     hass.services.async_call = AsyncMock()

--- a/tests/test_check_initial_state.py
+++ b/tests/test_check_initial_state.py
@@ -226,6 +226,92 @@ async def test_check_initial_state_underlying_climate(hass, hvac_mode, last_stat
             assert u.set_hvac_mode.await_count == 1
             u.set_hvac_mode.assert_awaited_once_with(thermostat.vtherm_hvac_mode)
 
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "vtherm_hvac_mode, underlying_state, expect_hvac_call",
+    [
+        # VTherm believes it is heating but the underlying silently drifted back to off
+        (VThermHvacMode_HEAT, VThermHvacMode_OFF, True),
+        # VTherm believes it is off but the underlying is stuck on (drift the other way)
+        (VThermHvacMode_OFF, VThermHvacMode_HEAT, True),
+        # No drift: nothing to repair
+        (VThermHvacMode_HEAT, VThermHvacMode_HEAT, False),
+        (VThermHvacMode_OFF, VThermHvacMode_OFF, False),
+    ],
+)
+async def test_resync_hvac_mode_repairs_drift_outside_of_startup(hass, vtherm_hvac_mode, underlying_state, expect_hvac_call):
+    """resync_hvac_mode must be able to detect and repair a hvac_mode mismatch at any
+    time, not only during the initial check done at startup. This is what
+    ThermostatOverClimate.async_control_heating now calls on every control cycle to
+    fix a underlying climate that silently drifted away from what VTherm asked for
+    (see the Qlima/Midea bug report: the device flaps to a different mode on its
+    own and VTherm never noticed because it only resends hvac_mode when its own
+    internal state changes)."""
+
+    hass.services = MagicMock()
+    hass.services.async_call = AsyncMock()
+
+    thermostat = MagicMock()
+    thermostat.vtherm_hvac_mode = vtherm_hvac_mode
+    thermostat.now = None
+    power_manager = MagicMock()
+    power_manager.check_power_available = AsyncMock(return_value=(True, None))
+    thermostat.power_manager = power_manager
+    thermostat.init_underlyings_completed = AsyncMock()
+    thermostat.underlying_changed = AsyncMock()
+
+    u = UnderlyingClimate(hass=hass, thermostat=thermostat, climate_entity_id="climate.test")
+    u.set_hvac_mode = AsyncMock()
+
+    u.startup()
+    # Simulate that the underlying was already fully initialized (drift happening
+    # well after startup, not during the initial check) so the state update below
+    # does not go through the startup check_initial_state path.
+    u._is_initialized = True
+    hass.states.async_set("climate.test", underlying_state)
+    await hass.async_block_till_done()
+
+    # Call resync_hvac_mode directly, as async_control_heating now does every cycle
+    await u.resync_hvac_mode()
+
+    if expect_hvac_call:
+        u.set_hvac_mode.assert_awaited_once_with(vtherm_hvac_mode)
+    else:
+        u.set_hvac_mode.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("underlying_state", [STATE_UNAVAILABLE, STATE_UNKNOWN])
+async def test_resync_hvac_mode_ignores_unavailable_underlying(hass, underlying_state):
+    """resync_hvac_mode must not try to repair a device that is currently
+    unavailable/unknown: there is nothing useful to send to it."""
+
+    hass.services = MagicMock()
+    hass.services.async_call = AsyncMock()
+
+    thermostat = MagicMock()
+    thermostat.vtherm_hvac_mode = VThermHvacMode_HEAT
+    thermostat.now = None
+    power_manager = MagicMock()
+    power_manager.check_power_available = AsyncMock(return_value=(True, None))
+    thermostat.power_manager = power_manager
+    thermostat.init_underlyings_completed = AsyncMock()
+    thermostat.underlying_changed = AsyncMock()
+
+    u = UnderlyingClimate(hass=hass, thermostat=thermostat, climate_entity_id="climate.test")
+    u.set_hvac_mode = AsyncMock()
+
+    u.startup()
+    hass.states.async_set("climate.test", underlying_state)
+    await hass.async_block_till_done()
+    u._is_initialized = True
+
+    await u.resync_hvac_mode()
+
+    u.set_hvac_mode.assert_not_awaited()
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "hvac_mode, is_sleeping, last_state, open_percent, current_valve_opening, expect_percent_open_call",

--- a/tests/test_check_initial_state.py
+++ b/tests/test_check_initial_state.py
@@ -243,11 +243,17 @@ async def test_check_initial_state_underlying_climate(hass, hvac_mode, last_stat
 async def test_resync_hvac_mode_repairs_drift_outside_of_startup(hass, vtherm_hvac_mode, underlying_state, expect_hvac_call):
     """resync_hvac_mode must be able to detect and repair a hvac_mode mismatch at any
     time, not only during the initial check done at startup. This is what
-    ThermostatOverClimate.async_control_heating now calls on every control cycle to
-    fix a underlying climate that silently drifted away from what VTherm asked for
-    (see the Qlima/Midea bug report: the device flaps to a different mode on its
-    own and VTherm never noticed because it only resends hvac_mode when its own
-    internal state changes)."""
+    ThermostatOverClimate._send_regulated_temperature now calls (once the
+    auto-regulation period has elapsed, or forced) to fix a underlying climate
+    that silently drifted away from what VTherm asked for (see the Qlima/Midea bug
+    report: the device flaps to a different mode on its own and VTherm never
+    noticed because it only resends hvac_mode when its own internal state
+    changes).
+
+    Note: when vtherm_hvac_mode is OFF, _send_regulated_temperature returns before
+    reaching resync_hvac_mode, so the OFF-direction case exercised here (VTherm
+    off, underlying stuck on) is currently only repaired by resync_hvac_mode being
+    called directly (as this test does), not by a live control cycle."""
 
     hass.services = MagicMock()
     hass.services.async_call = AsyncMock()
@@ -272,7 +278,8 @@ async def test_resync_hvac_mode_repairs_drift_outside_of_startup(hass, vtherm_hv
     hass.states.async_set("climate.test", underlying_state)
     await hass.async_block_till_done()
 
-    # Call resync_hvac_mode directly, as async_control_heating now does every cycle
+    # Call resync_hvac_mode directly, as _send_regulated_temperature now does
+    # (once the auto-regulation period has elapsed, or forced)
     await u.resync_hvac_mode()
 
     if expect_hvac_call:

--- a/tests/test_overclimate.py
+++ b/tests/test_overclimate.py
@@ -1398,6 +1398,73 @@ async def test_under_climate_resync_hvac_mode_drift(
     vtherm.remove_thermostat()
 
 
+async def test_under_climate_resync_hvac_mode_drift_off_direction(
+    hass: HomeAssistant,
+    skip_hass_states_is_state,
+    skip_turn_on_off_heater,
+    skip_send_event,
+):
+    """Mirror of test_under_climate_resync_hvac_mode_drift for the reverse
+    direction: VTherm wants the underlying off, but it silently drifted back on
+    on its own. _send_regulated_temperature returns early when vtherm_hvac_mode
+    is OFF (there is nothing to regulate), so the drift repair for this
+    direction is done right there, before that early return, gated the same way
+    (auto-regulation period or force, plus the grace period after VTherm's own
+    last command)."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="TheOverClimateMockName",
+        unique_id="uniqueId",
+        data=PARTIAL_CLIMATE_NOT_REGULATED_CONFIG,
+    )
+
+    fake_underlying_climate = await create_and_register_mock_climate(
+        hass,
+        "mock_climate",
+        "MockClimateName",
+        {},
+        hvac_modes=[VThermHvacMode_OFF, VThermHvacMode_HEAT],
+        hvac_mode=VThermHvacMode_HEAT,
+        hvac_action=HVACAction.HEATING,
+    )
+
+    vtherm = await create_thermostat(hass, entry, "climate.theoverclimatemockname")
+    assert vtherm
+
+    # 1. Turn the VTherm off: this really sends hvac_mode=off to the underlying
+    await vtherm.async_set_hvac_mode(VThermHvacMode_OFF)
+    await hass.async_block_till_done()
+
+    assert vtherm.vtherm_hvac_mode == VThermHvacMode_OFF
+    assert hass.states.get("climate.mock_climate").state == VThermHvacMode_OFF
+
+    # 2. Simulate the underlying device drifting back on on its own, independent
+    # of VTherm.
+    fake_underlying_climate.set_hvac_mode(VThermHvacMode_HEAT)
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+    assert hass.states.get("climate.mock_climate").state == VThermHvacMode_HEAT
+
+    # VTherm itself is unaware of the drift: it still believes it is off
+    assert vtherm.vtherm_hvac_mode == VThermHvacMode_OFF
+
+    under = vtherm.underlyings[0]
+    assert under.state_manager.get_state("climate.mock_climate").state == VThermHvacMode_HEAT
+
+    # Move past both the grace period and the auto-regulation period
+    vtherm._set_now(vtherm.now + timedelta(minutes=vtherm._auto_regulation_period_min + 1))
+
+    # 3. Run a control cycle exactly as a room temperature sensor update would
+    await vtherm.async_control_heating(force=False)
+    await hass.async_block_till_done()
+
+    # 4. The underlying should have been realigned on OFF
+    assert hass.states.get("climate.mock_climate").state == VThermHvacMode_OFF
+
+    vtherm.remove_thermostat()
+
+
 async def test_under_climate_resync_hvac_mode_skipped_right_after_own_command(
     hass: HomeAssistant,
     skip_hass_states_is_state,
@@ -1458,12 +1525,9 @@ async def test_under_climate_resync_hvac_mode_no_drift_no_action(
     """When the underlying climate already matches what VTherm asked for,
     resync_hvac_mode (called from _send_regulated_temperature, once the
     auto-regulation period has elapsed or forced) must not send any spurious
-    command.
-
-    vtherm_hvac_mode is HEAT here (not OFF): _send_regulated_temperature returns
-    before ever reaching resync_hvac_mode when VTherm itself is off, so a
-    meaningful no-drift check needs VTherm on and the underlying already matching
-    that state. force=True is used to reach the resync call without waiting out
+    command. This covers the "on" direction (vtherm_hvac_mode is HEAT); see
+    test_under_climate_resync_hvac_mode_drift_off_direction for the "off"
+    direction. force=True is used to reach the resync call without waiting out
     the auto-regulation period."""
 
     entry = MockConfigEntry(

--- a/tests/test_overclimate.py
+++ b/tests/test_overclimate.py
@@ -9,6 +9,7 @@ import pytest
 
 from homeassistant.core import HomeAssistant
 from homeassistant.components.climate import SERVICE_SET_TEMPERATURE, HVACMode, HVACAction
+from homeassistant.util import dt as dt_util
 
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 
@@ -1304,3 +1305,116 @@ async def test_under_climate_is_device_active(
         f"hvac_mode={hvac_mode}, hvac_action={hvac_action}, "
         f"state={under_state}, target_temp={target_temp}, current_temp={current_temp}"
     )
+
+
+async def test_under_climate_resync_hvac_mode_drift(
+    hass: HomeAssistant,
+    skip_hass_states_is_state,
+    skip_turn_on_off_heater,
+    skip_send_event,
+):
+    """Reproduces the Qlima/Midea bug report: the underlying climate silently drifts
+    back to a hvac_mode VTherm didn't ask for (device flapping, cloud lag, lost
+    command, ...). Since VTherm only (re)sends hvac_mode when its own internal
+    state changes, without a periodic re-check the underlying stays stuck out of
+    sync forever, even though VTherm itself thinks it is on.
+
+    This checks that UnderlyingClimate.resync_hvac_mode(), called on every
+    async_control_heating cycle, detects and repairs such a drift."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="TheOverClimateMockName",
+        unique_id="uniqueId",
+        data=PARTIAL_CLIMATE_NOT_REGULATED_CONFIG,
+    )
+
+    fake_underlying_climate = await create_and_register_mock_climate(
+        hass,
+        "mock_climate",
+        "MockClimateName",
+        {},
+        hvac_modes=[VThermHvacMode_OFF, VThermHvacMode_HEAT],
+        hvac_mode=VThermHvacMode_OFF,
+        hvac_action=HVACAction.OFF,
+    )
+
+    vtherm = await create_thermostat(hass, entry, "climate.theoverclimatemockname")
+    assert vtherm
+    assert vtherm.is_over_climate is True
+
+    # 1. Turn the VTherm on: this really sends hvac_mode=heat to the underlying
+    # (no mock/patch here, this goes through the real climate.set_hvac_mode service)
+    await vtherm.async_set_hvac_mode(VThermHvacMode_HEAT)
+    await hass.async_block_till_done()
+
+    assert vtherm.vtherm_hvac_mode == VThermHvacMode_HEAT
+    assert hass.states.get("climate.mock_climate").state == VThermHvacMode_HEAT
+
+    # 2. Simulate the underlying device drifting back to OFF on its own (bug on the
+    # device/integration side), completely independent of VTherm.
+    fake_underlying_climate.set_hvac_mode(VThermHvacMode_OFF)
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+    assert hass.states.get("climate.mock_climate").state == VThermHvacMode_OFF
+
+    # VTherm itself is unaware of the drift: it still believes it is heating
+    assert vtherm.vtherm_hvac_mode == VThermHvacMode_HEAT
+
+    # sanity check: VTherm's own cached view of the underlying's state must have
+    # caught up with the drift too, otherwise the assertions below would be
+    # meaningless (resync_hvac_mode reads from this cache, not from hass.states
+    # directly)
+    under = vtherm.underlyings[0]
+    assert under.state_manager.get_state("climate.mock_climate").state == VThermHvacMode_OFF
+
+    # 3. Run a control cycle (this is what the periodic timer does every cycle_min,
+    # passing a timestamp). Without the fix, this only resends the regulated
+    # temperature and never touches hvac_mode, so the underlying stays stuck OFF
+    # forever.
+    await vtherm.async_control_heating(timestamp=dt_util.utcnow(), force=True)
+    await hass.async_block_till_done()
+
+    # 4. The underlying should have been realigned on HEAT
+    assert hass.states.get("climate.mock_climate").state == VThermHvacMode_HEAT
+
+    vtherm.remove_thermostat()
+
+
+async def test_under_climate_resync_hvac_mode_no_drift_no_action(
+    hass: HomeAssistant,
+    skip_hass_states_is_state,
+    skip_turn_on_off_heater,
+    skip_send_event,
+):
+    """When the underlying climate already matches what VTherm asked for,
+    resync_hvac_mode (called every control cycle) must not send any spurious
+    command."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="TheOverClimateMockName",
+        unique_id="uniqueId",
+        data=PARTIAL_CLIMATE_NOT_REGULATED_CONFIG,
+    )
+
+    await create_and_register_mock_climate(
+        hass,
+        "mock_climate",
+        "MockClimateName",
+        {},
+        hvac_modes=[VThermHvacMode_OFF, VThermHvacMode_HEAT],
+        hvac_mode=VThermHvacMode_OFF,
+        hvac_action=HVACAction.OFF,
+    )
+
+    vtherm = await create_thermostat(hass, entry, "climate.theoverclimatemockname")
+    assert vtherm.vtherm_hvac_mode == VThermHvacMode_OFF
+
+    with patch("custom_components.versatile_thermostat.underlyings.UnderlyingClimate.set_hvac_mode") as mock_set_hvac_mode:
+        await vtherm.async_control_heating(timestamp=dt_util.utcnow(), force=True)
+        await hass.async_block_till_done()
+
+        mock_set_hvac_mode.assert_not_called()
+
+    vtherm.remove_thermostat()

--- a/tests/test_overclimate.py
+++ b/tests/test_overclimate.py
@@ -1318,12 +1318,18 @@ async def test_under_climate_resync_hvac_mode_drift(
     state changes, without a periodic re-check the underlying stays stuck out of
     sync forever, even though VTherm itself thinks it is on.
 
-    This checks that UnderlyingClimate.resync_hvac_mode(), called on every
-    async_control_heating cycle (periodical tick or temperature-sensor-triggered,
-    not just the long cycle_min timer), detects and repairs such a drift. Here the
-    cycle is triggered the same way a room temperature sensor update would
-    (no timestamp, force=False), on purpose: the reporter needed the repair to not
-    have to wait for a 40 minutes cycle_min."""
+    This checks that UnderlyingClimate.resync_hvac_mode(), called from within
+    ThermostatOverClimate._send_regulated_temperature (itself invoked by
+    async_control_heating on every cycle -- periodical tick or
+    temperature-sensor-triggered, not just the long cycle_min timer) once the
+    auto-regulation period has elapsed (or force=True), detects and repairs such
+    a drift. Here the cycle is triggered the same way a room temperature sensor
+    update would (no timestamp, force=False), on purpose: the reporter needed the
+    repair to not have to wait for a 40 minutes cycle_min. The repair itself is
+    still spaced out by the same auto-regulation period gate that already guards
+    _send_regulated_temperature (not fired on every cycle) so it doesn't keep
+    re-triggering a device-side protection (e.g. a compressor minimum-off-time)
+    before the device gets a chance to actually start."""
 
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -1371,16 +1377,18 @@ async def test_under_climate_resync_hvac_mode_drift(
     under = vtherm.underlyings[0]
     assert under.state_manager.get_state("climate.mock_climate").state == VThermHvacMode_OFF
 
-    # Move past the short grace period after VTherm's own last command (this is not
-    # a wait for the long cycle_min timer, just the couple of seconds VTherm gives
-    # the underlying's state cache to catch up with a command it just sent)
-    vtherm._set_now(vtherm.now + timedelta(seconds=5))
+    # Move past both the short grace period after VTherm's own last command (the
+    # couple of seconds VTherm gives the underlying's state cache to catch up with
+    # a command it just sent) and the auto-regulation period (the repair is spaced
+    # out by this, same gate as _send_regulated_temperature, so it doesn't keep
+    # re-triggering a device-side protection before the device can actually start)
+    vtherm._set_now(vtherm.now + timedelta(minutes=vtherm._auto_regulation_period_min + 1))
 
     # 3. Run a control cycle exactly as a room temperature sensor update would
-    # (no timestamp, force=False) -- this must NOT require waiting for the
-    # periodic cycle_min timer. Without the fix, this only resends the regulated
-    # temperature and never touches hvac_mode, so the underlying stays stuck OFF
-    # forever.
+    # (no timestamp, force=False) -- this must NOT require waiting for the long
+    # cycle_min timer (only the much shorter auto-regulation period). Without the
+    # fix, this only resends the regulated temperature and never touches
+    # hvac_mode, so the underlying stays stuck OFF forever.
     await vtherm.async_control_heating(force=False)
     await hass.async_block_till_done()
 
@@ -1399,7 +1407,13 @@ async def test_under_climate_resync_hvac_mode_skipped_right_after_own_command(
     """resync_hvac_mode must NOT run in the couple of seconds right after VTherm
     itself just sent a hvac_mode command: the underlying's cached state may not
     have caught up yet, so reading it now would be a false positive and cause a
-    spurious duplicate command."""
+    spurious duplicate command.
+
+    resync_hvac_mode is called from _send_regulated_temperature, guarded first by
+    the auto-regulation period check and then by this grace-period check. Since
+    the auto-regulation period (minutes) is always much longer than the grace
+    period (a couple of seconds), force=True is used here to bypass the former so
+    the latter can be exercised on its own."""
 
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -1425,9 +1439,9 @@ async def test_under_climate_resync_hvac_mode_skipped_right_after_own_command(
     assert vtherm.vtherm_hvac_mode == VThermHvacMode_HEAT
 
     with patch("custom_components.versatile_thermostat.underlyings.UnderlyingClimate.resync_hvac_mode") as mock_resync:
-        # Immediately after (no time advance): this is the internal call chained
-        # from update_states() right after the hvac_mode command was sent.
-        await vtherm.async_control_heating(force=False)
+        # Immediately after (no time advance) and forced, so only the grace-period
+        # check (not the auto-regulation period check) is at play.
+        await vtherm.async_control_heating(force=True)
         await hass.async_block_till_done()
 
         mock_resync.assert_not_called()
@@ -1442,8 +1456,15 @@ async def test_under_climate_resync_hvac_mode_no_drift_no_action(
     skip_send_event,
 ):
     """When the underlying climate already matches what VTherm asked for,
-    resync_hvac_mode (called every control cycle) must not send any spurious
-    command."""
+    resync_hvac_mode (called from _send_regulated_temperature, once the
+    auto-regulation period has elapsed or forced) must not send any spurious
+    command.
+
+    vtherm_hvac_mode is HEAT here (not OFF): _send_regulated_temperature returns
+    before ever reaching resync_hvac_mode when VTherm itself is off, so a
+    meaningful no-drift check needs VTherm on and the underlying already matching
+    that state. force=True is used to reach the resync call without waiting out
+    the auto-regulation period."""
 
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -1463,12 +1484,18 @@ async def test_under_climate_resync_hvac_mode_no_drift_no_action(
     )
 
     vtherm = await create_thermostat(hass, entry, "climate.theoverclimatemockname")
-    assert vtherm.vtherm_hvac_mode == VThermHvacMode_OFF
 
+    await vtherm.async_set_hvac_mode(VThermHvacMode_HEAT)
+    await hass.async_block_till_done()
+    assert vtherm.vtherm_hvac_mode == VThermHvacMode_HEAT
+    assert hass.states.get("climate.mock_climate").state == VThermHvacMode_HEAT
+
+    # Move past the grace period so resync_hvac_mode actually reads the (matching)
+    # underlying state instead of being skipped as a possible echo.
     vtherm._set_now(vtherm.now + timedelta(seconds=5))
 
     with patch("custom_components.versatile_thermostat.underlyings.UnderlyingClimate.set_hvac_mode") as mock_set_hvac_mode:
-        await vtherm.async_control_heating(force=False)
+        await vtherm.async_control_heating(force=True)
         await hass.async_block_till_done()
 
         mock_set_hvac_mode.assert_not_called()

--- a/tests/test_overclimate.py
+++ b/tests/test_overclimate.py
@@ -9,7 +9,6 @@ import pytest
 
 from homeassistant.core import HomeAssistant
 from homeassistant.components.climate import SERVICE_SET_TEMPERATURE, HVACMode, HVACAction
-from homeassistant.util import dt as dt_util
 
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 
@@ -1320,7 +1319,11 @@ async def test_under_climate_resync_hvac_mode_drift(
     sync forever, even though VTherm itself thinks it is on.
 
     This checks that UnderlyingClimate.resync_hvac_mode(), called on every
-    async_control_heating cycle, detects and repairs such a drift."""
+    async_control_heating cycle (periodical tick or temperature-sensor-triggered,
+    not just the long cycle_min timer), detects and repairs such a drift. Here the
+    cycle is triggered the same way a room temperature sensor update would
+    (no timestamp, force=False), on purpose: the reporter needed the repair to not
+    have to wait for a 40 minutes cycle_min."""
 
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -1368,15 +1371,66 @@ async def test_under_climate_resync_hvac_mode_drift(
     under = vtherm.underlyings[0]
     assert under.state_manager.get_state("climate.mock_climate").state == VThermHvacMode_OFF
 
-    # 3. Run a control cycle (this is what the periodic timer does every cycle_min,
-    # passing a timestamp). Without the fix, this only resends the regulated
+    # Move past the short grace period after VTherm's own last command (this is not
+    # a wait for the long cycle_min timer, just the couple of seconds VTherm gives
+    # the underlying's state cache to catch up with a command it just sent)
+    vtherm._set_now(vtherm.now + timedelta(seconds=5))
+
+    # 3. Run a control cycle exactly as a room temperature sensor update would
+    # (no timestamp, force=False) -- this must NOT require waiting for the
+    # periodic cycle_min timer. Without the fix, this only resends the regulated
     # temperature and never touches hvac_mode, so the underlying stays stuck OFF
     # forever.
-    await vtherm.async_control_heating(timestamp=dt_util.utcnow(), force=True)
+    await vtherm.async_control_heating(force=False)
     await hass.async_block_till_done()
 
     # 4. The underlying should have been realigned on HEAT
     assert hass.states.get("climate.mock_climate").state == VThermHvacMode_HEAT
+
+    vtherm.remove_thermostat()
+
+
+async def test_under_climate_resync_hvac_mode_skipped_right_after_own_command(
+    hass: HomeAssistant,
+    skip_hass_states_is_state,
+    skip_turn_on_off_heater,
+    skip_send_event,
+):
+    """resync_hvac_mode must NOT run in the couple of seconds right after VTherm
+    itself just sent a hvac_mode command: the underlying's cached state may not
+    have caught up yet, so reading it now would be a false positive and cause a
+    spurious duplicate command."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="TheOverClimateMockName",
+        unique_id="uniqueId",
+        data=PARTIAL_CLIMATE_NOT_REGULATED_CONFIG,
+    )
+
+    await create_and_register_mock_climate(
+        hass,
+        "mock_climate",
+        "MockClimateName",
+        {},
+        hvac_modes=[VThermHvacMode_OFF, VThermHvacMode_HEAT],
+        hvac_mode=VThermHvacMode_OFF,
+        hvac_action=HVACAction.OFF,
+    )
+
+    vtherm = await create_thermostat(hass, entry, "climate.theoverclimatemockname")
+
+    await vtherm.async_set_hvac_mode(VThermHvacMode_HEAT)
+    await hass.async_block_till_done()
+    assert vtherm.vtherm_hvac_mode == VThermHvacMode_HEAT
+
+    with patch("custom_components.versatile_thermostat.underlyings.UnderlyingClimate.resync_hvac_mode") as mock_resync:
+        # Immediately after (no time advance): this is the internal call chained
+        # from update_states() right after the hvac_mode command was sent.
+        await vtherm.async_control_heating(force=False)
+        await hass.async_block_till_done()
+
+        mock_resync.assert_not_called()
 
     vtherm.remove_thermostat()
 
@@ -1411,8 +1465,10 @@ async def test_under_climate_resync_hvac_mode_no_drift_no_action(
     vtherm = await create_thermostat(hass, entry, "climate.theoverclimatemockname")
     assert vtherm.vtherm_hvac_mode == VThermHvacMode_OFF
 
+    vtherm._set_now(vtherm.now + timedelta(seconds=5))
+
     with patch("custom_components.versatile_thermostat.underlyings.UnderlyingClimate.set_hvac_mode") as mock_set_hvac_mode:
-        await vtherm.async_control_heating(timestamp=dt_util.utcnow(), force=True)
+        await vtherm.async_control_heating(force=False)
         await hass.async_block_till_done()
 
         mock_set_hvac_mode.assert_not_called()


### PR DESCRIPTION
Fixes #2020

## Problem

Some climate integrations (cloud-polled devices like **Midea Auto Cloud**) silently drift away from the hvac_mode VTherm asked for. Investigating on real hardware revealed two distinct issues:

1. **Silent drift is never repaired**: VTherm only resends hvac_mode when its own internal state changes, so an underlying that bounces back to a previous mode (or is changed externally by remote/app) stays out of sync indefinitely.
2. **Back-to-back commands cause the bounce-back in the first place**: sending `set_temperature` immediately after `set_hvac_mode` makes the Midea device accept the mode change, then revert to its previous mode ~15 seconds later — even though the mode change alone (or the same two commands manually spaced by a few seconds) is handled fine. This defeated the drift repair itself: the repair command was sent and accepted, then undone by its own temperature follow-up.

## History of the changes and why they were done like that

The fix evolved through real-device testing; each step is a separate commit:

1. **Periodic drift resync** (`6225278` → `ad8d5a2`): extract the startup sync logic (`check_initial_state`) into a reusable `resync_hvac_mode()` and call it on every control cycle, in both directions (underlying off while VTherm wants heat/cool, and underlying on while VTherm is off). It is deliberately gated by `auto_regulation_period_min` — so retries cannot hammer a device-side compressor protection — and by a grace period after VTherm's own commands, so a stale/echoed state cache is not misread as a drift.

2. **Command spacing** (`1f12f52`): live testing showed the repair command was accepted but the device bounced back to `off` 15s later. The cause was the immediate regulated-temperature push following the mode command. When a `set_hvac_mode` was just sent to an underlying (tracked by a consume-once flag, covering both the fresh turn-on cascade and the drift-repair resync), the immediate regulated-temperature send is skipped and the delayed resend already scheduled by `set_hvac_mode` (`resend_delay_sec` = 2s, originally added for lazy SonoffTRVZB devices) carries the temperature once the device has settled.

   Two other approaches were tried and rejected:
   - a blocking `asyncio.sleep(2)` inside `set_hvac_mode`: opens a reentrancy window in the control cycle (other events can trigger nested cycles during the sleep) and broke 7 tests by mixing real wall-clock sleep with the fake test clock;
   - a timestamp-based check inside `set_hvac_mode` itself: also suppressed legitimate immediate sends on the normal turn-on path.

3. **Delayed send carries the regulated temperature** (`85059d6`): the raw-target fallback meant the device got the plain setpoint at +2s and the properly regulated value only at the next regulation period (minutes later). Now the already-computed regulated temperature (including device-temp offset) replaces the raw-target resend, so the device ends up with the right setpoint right away. Also in this commit:
   - the mode-just-sent check was moved above the dtemp gate so the consume-once flag cannot go stale (a stale flag would have spuriously skipped one send on a later cycle);
   - a direct `set_temperature` now cancels any pending delayed resend, so a stale delayed value can never overwrite a newer command;
   - the raw-target fallback (used when the thermostat is not regulated) reads the target at fire time, preserving the original SonoffTRVZB freshness semantics.

4. **Observability** (`fbdc8dc`, `7748452`): debug logs for the whole lifecycle (scheduling a delayed send, replacing a pending one, firing it, cancelling it on a direct send), plus rounding of the sent value (`a4957e6`, absorbs float noise like `23.099999999999998`) and two-decimal formatting in the logs.

## Why some unrelated-looking unit tests changed

- **`test_over_climate_regulation_ac_mode`**: this test implicitly depended on the buggy behavior. The old expected PI values (`25 - 2.5`, `25 - 1`, `25 + 3`) were the output of a regulation-cycle history that included an *extra* cycle incidentally triggered by the mock underlying echoing the (now eliminated) back-to-back mode+temperature commands. Since the PI output is stateful (`accumulated_error`, `time_delta`), removing that accidental cycle changes the exact offsets. The test now drives that cycle explicitly (`async_control_heating(force=True)` after the sensor updates), stubs the delayed resend so it doesn't race the test's fake clock, and asserts the values that match the PI math for the real cycle sequence (`25 - 2.0`, `25 - 0.5`, `25 + 3.5`). The direction of every assertion is unchanged (regulated below target when too warm, above when too cold). Also, `hvac_action` right after turn-on is now deterministically `IDLE` instead of a stale `OFF` read.

- **`test_over_climate_regulation_use_device_temp`**: pre-existing flaky test, already documented in the file ("Disable this test which is not working when run in // of others. I couldn't find out why") with a disabled `@pytest.mark.skip`. The failure reproduces on the unmodified base branch at the same rate (~1 in 8 full-suite runs). Root cause: `wait_for_local_condition` was called without `hass`, so it never flushed pending HA tasks while polling, and it returns as soon as the mock's raw python attribute flips — a beat before the corresponding `state_changed` event is processed by VTherm. Deflaked by passing `hass=hass`, flushing once more after the condition holds, and enabling the already-written-but-commented-out `calculate_hvac_action()` call.

## Validated on real hardware (Midea AC via Midea Auto Cloud)

- Fresh turn-on: mode sent → 2s pause → regulated setpoint delivered → device settles into `cool`, no bounce-back
- Drift repair, ON direction (AC turned off manually while VTherm cooling): detected and re-aligned at the next regulation window, temperature delivered 2s after the mode command
- Drift repair, OFF direction (AC turned on manually while VTherm off): detected and turned off, correctly with no temperature follow-up

## Note for future work

The periodic drift resync could be relocated into `FeatureRepairIncorrectStateManager` (active only when `is_repair_incorrect_state_configured` is true) so users can opt in/out of the repair behavior explicitly. However, the **mode/temperature command spacing must stay unconditional**: it fixes the root cause (devices reverting on back-to-back commands) by itself — including for the repair manager's own re-emitted commands, which previously could spam a device without success for this very reason.

## Tests

615 passed, 2 skipped; suite runtime unchanged (~57s). Verified stable across 18+ consecutive full-suite runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)