### PR TITLE
fix #2026 - restore window bypass from nested state attributes

### DIFF
--- a/custom_components/versatile_thermostat/feature_window_manager.py
+++ b/custom_components/versatile_thermostat/feature_window_manager.py
@@ -134,7 +134,8 @@ class FeatureWindowManager(BaseFeatureManager):
 
         # Try to get last window bypass state
         old_state = await self._vtherm.async_get_last_state()
-        self._is_window_bypass = old_state is not None and hasattr(old_state, "attributes") and old_state.attributes.get("is_window_bypass") is True
+        old_attributes = getattr(old_state, "attributes", None) or {}
+        self._is_window_bypass = (old_attributes.get("window_manager") or {}).get("is_window_bypass") is True
 
         if self._is_configured:
             self.stop_listening()

--- a/tests/test_window_feature_manager.py
+++ b/tests/test_window_feature_manager.py
@@ -1,5 +1,6 @@
 # pylint: disable=unused-argument, line-too-long, protected-access, too-many-lines
-""" Test the Window management """
+"""Test the Window management"""
+
 import logging
 from datetime import datetime, timedelta
 from unittest.mock import patch, call, PropertyMock, AsyncMock, MagicMock
@@ -613,9 +614,7 @@ async def test_window_feature_manager_window_auto(
 
     # Add a fake temp point for the window_auto_algo. We need at least 4 points
     for i in range(0, 4):
-        window_manager._window_auto_algo.add_temp_measurement(
-            17 + (i * (new_temp - 17) / 4), now, True
-        )
+        window_manager._window_auto_algo.add_temp_measurement(17 + (i * (new_temp - 17) / 4), now, True)
         now = now + timedelta(minutes=5)
 
     # fmt:off
@@ -649,3 +648,92 @@ async def test_window_feature_manager_window_auto(
 
     window_manager.stop_listening()
     await hass.async_block_till_done()
+
+
+async def test_window_feature_manager_restore_bypass_from_saved_state(
+    hass: HomeAssistant,
+):
+    """Test that the window bypass is restored from the saved state.
+
+    The bypass is exposed under the "window_manager" sub-dict by
+    add_custom_attributes, so start_listening must read it from there.
+    """
+
+    fake_vtherm = MagicMock(spec=BaseThermostat)
+    type(fake_vtherm).name = PropertyMock(return_value="the name")
+    type(fake_vtherm).preset_mode = PropertyMock(return_value=VThermPreset.COMFORT)
+    type(fake_vtherm).auto_start_stop_manager = PropertyMock(return_value=None)
+
+    # 1. a manager which saved a bypass set to True
+    saving_manager = FeatureWindowManager(fake_vtherm, hass)
+    saving_manager.post_init(
+        {
+            CONF_WINDOW_SENSOR: "sensor.the_window_sensor",
+            CONF_USE_WINDOW_FEATURE: True,
+            CONF_WINDOW_DELAY: 10,
+            CONF_WINDOW_OFF_DELAY: 10,
+            CONF_WINDOW_ACTION: CONF_WINDOW_TURN_OFF,
+        }
+    )
+    await saving_manager.set_window_bypass(True)
+
+    saved_attributes = {}
+    saving_manager.add_custom_attributes(saved_attributes)
+    assert saved_attributes["window_manager"]["is_window_bypass"] is True
+
+    # 2. a new manager restoring that state
+    type(fake_vtherm).async_get_last_state = AsyncMock(return_value=State("climate.the_vtherm", HVACMode.HEAT, attributes=saved_attributes))
+
+    restoring_manager = FeatureWindowManager(fake_vtherm, hass)
+    restoring_manager.post_init(
+        {
+            CONF_WINDOW_SENSOR: "sensor.the_window_sensor",
+            CONF_USE_WINDOW_FEATURE: True,
+            CONF_WINDOW_DELAY: 10,
+            CONF_WINDOW_OFF_DELAY: 10,
+            CONF_WINDOW_ACTION: CONF_WINDOW_TURN_OFF,
+        }
+    )
+    await restoring_manager.start_listening()
+
+    assert restoring_manager.is_window_bypass is True
+
+    restored_attributes = {}
+    restoring_manager.add_custom_attributes(restored_attributes)
+    assert restored_attributes["window_manager"]["is_window_bypass"] is True
+
+    restoring_manager.stop_listening()
+
+
+async def test_window_feature_manager_restore_bypass_off_stays_off(
+    hass: HomeAssistant,
+):
+    """Test that a saved bypass set to False is not restored as True."""
+
+    fake_vtherm = MagicMock(spec=BaseThermostat)
+    type(fake_vtherm).name = PropertyMock(return_value="the name")
+    type(fake_vtherm).preset_mode = PropertyMock(return_value=VThermPreset.COMFORT)
+    type(fake_vtherm).auto_start_stop_manager = PropertyMock(return_value=None)
+    type(fake_vtherm).async_get_last_state = AsyncMock(
+        return_value=State(
+            "climate.the_vtherm",
+            HVACMode.HEAT,
+            attributes={"window_manager": {"is_window_bypass": False}},
+        )
+    )
+
+    window_manager = FeatureWindowManager(fake_vtherm, hass)
+    window_manager.post_init(
+        {
+            CONF_WINDOW_SENSOR: "sensor.the_window_sensor",
+            CONF_USE_WINDOW_FEATURE: True,
+            CONF_WINDOW_DELAY: 10,
+            CONF_WINDOW_OFF_DELAY: 10,
+            CONF_WINDOW_ACTION: CONF_WINDOW_TURN_OFF,
+        }
+    )
+    await window_manager.start_listening()
+
+    assert window_manager.is_window_bypass is False
+
+    window_manager.stop_listening()


### PR DESCRIPTION
Fixes #2026

## Problem

`FeatureWindowManager.add_custom_attributes()` writes the bypass flag nested:

```python
"window_manager": {
    ...
    "is_window_bypass": self._is_window_bypass,
```

`start_listening()` read it from the top level of the restored state:

```python
self._is_window_bypass = old_state is not None and hasattr(old_state, "attributes") and old_state.attributes.get("is_window_bypass") is True
```

The key does not exist there, so `.get()` returned `None`, `is True` evaluated to
`False`, and the bypass was dropped on every restart and every
`versatile_thermostat.reload` — silently, with no log line. Confirmed on a live
instance with the bypass enabled: `attributes['is_window_bypass']` is absent
while `attributes['window_manager']['is_window_bypass']` is `True`.

## Fix

Read the flag from the `window_manager` sub-dict, where `add_custom_attributes`
writes it. `getattr(old_state, "attributes", None) or {}` keeps the existing
`None`/missing-attributes tolerance, so the `async_get_last_state() -> None`
and `-> {}` fixtures used throughout the test suite still work.

## Tests

Two tests in `tests/test_window_feature_manager.py`:

- `test_window_feature_manager_restore_bypass_from_saved_state` — sets the
  bypass, serializes it through `add_custom_attributes`, feeds that dict back as
  the saved state, and asserts `start_listening()` restores it. This goes
  through the same path Home Assistant uses, not the helper in isolation.
- `test_window_feature_manager_restore_bypass_off_stays_off` — guards against
  over-correction, a saved `False` must not become `True`.

Verified the first test fails without the fix and passes with it:

```
$ pytest tests/test_window_feature_manager.py -k restore_bypass   # fix reverted
>       assert restoring_manager.is_window_bypass is True
E       assert False is True
1 failed, 1 passed

$ pytest tests/test_window_feature_manager.py -k restore_bypass   # fix applied
2 passed
```

Existing tests could not catch this: every fixture stubs `async_get_last_state`
to return `None` or `{}`, so the restore path never saw real attributes.

Full suite: `607 passed, 2 skipped`.

`black` reports both touched files as needing reformatting, but they already did
so before this change (verified by running `black --check` on the unmodified
files) — the offending lines are pre-existing and untouched here, so the diff is
kept minimal rather than mixing in a reformat.
