### PR TITLE
fix #2018: exclude nested custom attribute sections from recorder history

### DIFF
--- a/custom_components/versatile_thermostat/base_manager.py
+++ b/custom_components/versatile_thermostat/base_manager.py
@@ -17,6 +17,12 @@ _LOGGER = get_vtherm_logger(__name__)
 class BaseFeatureManager:
     """A base class for all feature"""
 
+    # Attributes that should be excluded from the recorder history. Each manager
+    # exposes its custom attributes under a dedicated top-level section key; that
+    # section name is declared here so the recorder skips the whole section
+    # (the recorder can only filter top-level keys, not nested ones).
+    unrecorded_attributes = frozenset()
+
     def __init__(self, vtherm: Any, hass: HomeAssistant, name: str = None):
         """Init of a featureManager"""
         self._vtherm = vtherm

--- a/custom_components/versatile_thermostat/base_thermostat.py
+++ b/custom_components/versatile_thermostat/base_thermostat.py
@@ -85,11 +85,16 @@ class BaseThermostat(ClimateEntity, RestoreEntity, Generic[T]):
     _attr_swing_horizontal_mode = ""
 
     _entity_component_unrecorded_attributes = (
-        ClimateEntity._entity_component_unrecorded_attributes.union(frozenset({"configuration", "preset_temperatures"}))
+        ClimateEntity._entity_component_unrecorded_attributes.union(frozenset({"configuration", "preset_temperatures", "specific_states"}))
         .union(FeaturePresenceManager.unrecorded_attributes)
         .union(FeaturePowerManager.unrecorded_attributes)
         .union(FeatureMotionManager.unrecorded_attributes)
         .union(FeatureWindowManager.unrecorded_attributes)
+        .union(FeatureSafetyManager.unrecorded_attributes)
+        .union(FeatureLockManager.unrecorded_attributes)
+        .union(FeatureTimedPresetManager.unrecorded_attributes)
+        .union(FeatureHeatingFailureDetectionManager.unrecorded_attributes)
+        .union(FeatureRepairIncorrectStateManager.unrecorded_attributes)
     )
 
     ##

--- a/custom_components/versatile_thermostat/feature_auto_start_stop_manager.py
+++ b/custom_components/versatile_thermostat/feature_auto_start_stop_manager.py
@@ -32,12 +32,8 @@ class FeatureAutoStartStopManager(BaseFeatureManager):
 
     unrecorded_attributes = frozenset(
         {
-            "auto_start_stop_level",
-            "auto_start_stop_dtmin",
-            "auto_start_stop_enable",
-            "auto_start_stop_accumulated_error",
-            "auto_start_stop_accumulated_error_threshold",
-            "auto_start_stop_last_switch_date",
+            "is_auto_start_stop_configured",
+            "auto_start_stop_manager",
         }
     )
 

--- a/custom_components/versatile_thermostat/feature_heating_failure_detection_manager.py
+++ b/custom_components/versatile_thermostat/feature_heating_failure_detection_manager.py
@@ -54,12 +54,8 @@ class FeatureHeatingFailureDetectionManager(BaseFeatureManager):
 
     unrecorded_attributes = frozenset(
         {
-            "heating_failure_threshold",
-            "cooling_failure_threshold",
-            "heating_failure_detection_delay",
-            "temperature_change_tolerance",
             "is_heating_failure_detection_configured",
-            "failure_detection_enable_template",
+            "heating_failure_detection_manager",
         }
     )
 

--- a/custom_components/versatile_thermostat/feature_lock_manager.py
+++ b/custom_components/versatile_thermostat/feature_lock_manager.py
@@ -21,6 +21,14 @@ _LOGGER = get_vtherm_logger(__name__)
 
 class FeatureLockManager(BaseFeatureManager):
     """ The implementation of the Lock Feature Manager for Versatile Thermostat """
+
+    unrecorded_attributes = frozenset(
+        {
+            "is_lock_configured",
+            "lock_manager",
+        }
+    )
+
     def __init__(self, vtherm: Any, hass: HomeAssistant):
         """Initialize the FeatureLockManager."""
         super().__init__(vtherm, hass)

--- a/custom_components/versatile_thermostat/feature_motion_manager.py
+++ b/custom_components/versatile_thermostat/feature_motion_manager.py
@@ -42,12 +42,8 @@ class FeatureMotionManager(BaseFeatureManager):
 
     unrecorded_attributes = frozenset(
         {
-            "motion_sensor_entity_id",
             "is_motion_configured",
-            "motion_delay_sec",
-            "motion_off_delay_sec",
-            "motion_preset",
-            "no_motion_preset",
+            "motion_manager",
         }
     )
 

--- a/custom_components/versatile_thermostat/feature_power_manager.py
+++ b/custom_components/versatile_thermostat/feature_power_manager.py
@@ -31,13 +31,8 @@ class FeaturePowerManager(BaseFeatureManager):
 
     unrecorded_attributes = frozenset(
         {
-            "power_sensor_entity_id",
-            "max_power_sensor_entity_id",
             "is_power_configured",
-            "device_power",
-            "power_temp",
-            "current_power",
-            "current_max_power",
+            "power_manager",
         }
     )
 

--- a/custom_components/versatile_thermostat/feature_presence_manager.py
+++ b/custom_components/versatile_thermostat/feature_presence_manager.py
@@ -38,8 +38,8 @@ class FeaturePresenceManager(BaseFeatureManager):
 
     unrecorded_attributes = frozenset(
         {
-            "presence_sensor_entity_id",
             "is_presence_configured",
+            "presence_manager",
         }
     )
 

--- a/custom_components/versatile_thermostat/feature_repair_incorrect_state_manager.py
+++ b/custom_components/versatile_thermostat/feature_repair_incorrect_state_manager.py
@@ -38,6 +38,7 @@ class FeatureRepairIncorrectStateManager(BaseFeatureManager):
     unrecorded_attributes = frozenset(
         {
             "is_repair_incorrect_state_configured",
+            "repair_incorrect_state_manager",
         }
     )
 

--- a/custom_components/versatile_thermostat/feature_safety_manager.py
+++ b/custom_components/versatile_thermostat/feature_safety_manager.py
@@ -32,10 +32,8 @@ class FeatureSafetyManager(BaseFeatureManager):
 
     unrecorded_attributes = frozenset(
         {
-            "safety_delay_min",
-            "safety_min_on_percent",
-            "safety_default_on_percent",
             "is_safety_configured",
+            "safety_manager",
         }
     )
 

--- a/custom_components/versatile_thermostat/feature_window_manager.py
+++ b/custom_components/versatile_thermostat/feature_window_manager.py
@@ -43,15 +43,8 @@ class FeatureWindowManager(BaseFeatureManager):
 
     unrecorded_attributes = frozenset(
         {
-            "window_sensor_entity_id",
             "is_window_configured",
-            "window_delay_sec",
-            "window_off_delay_sec",
-            "window_auto_configured",
-            "window_auto_open_threshold",
-            "window_auto_close_threshold",
-            "window_auto_max_duration",
-            "window_action",
+            "window_manager",
         }
     )
 

--- a/custom_components/versatile_thermostat/manifest.json
+++ b/custom_components/versatile_thermostat/manifest.json
@@ -22,6 +22,6 @@
     "vtherm_api>=0.3.0"
   ],
   "ssdp": [],
-  "version": "10.0.2",
+  "version": "10.1.0",
   "zeroconf": []
 }

--- a/tests/test_unrecorded_attributes.py
+++ b/tests/test_unrecorded_attributes.py
@@ -1,0 +1,44 @@
+# pylint: disable=wildcard-import, unused-wildcard-import, protected-access, unused-argument, line-too-long
+
+"""Test that the volatile custom attribute sections are excluded from the recorder history."""
+
+from custom_components.versatile_thermostat.base_thermostat import BaseThermostat
+from custom_components.versatile_thermostat.thermostat_climate import ThermostatOverClimate
+
+
+# Section top-level keys shared by all VTherm types
+COMMON_EXCLUDED_SECTIONS = {
+    "configuration",
+    "preset_temperatures",
+    "specific_states",
+    "presence_manager",
+    "power_manager",
+    "motion_manager",
+    "window_manager",
+    "safety_manager",
+    "lock_manager",
+    "timed_preset_manager",
+    "heating_failure_detection_manager",
+    "repair_incorrect_state_manager",
+}
+
+
+def test_base_thermostat_excludes_attribute_sections():
+    """The recorder must skip every volatile custom attribute section on the base thermostat."""
+    excluded = BaseThermostat._entity_component_unrecorded_attributes
+    for section in COMMON_EXCLUDED_SECTIONS:
+        assert section in excluded, f"Section '{section}' should be excluded from the recorder"
+
+
+def test_over_climate_excludes_specific_sections():
+    """The over_climate thermostat must also exclude its own sections."""
+    excluded = ThermostatOverClimate._entity_component_unrecorded_attributes
+    for section in COMMON_EXCLUDED_SECTIONS | {"vtherm_over_climate", "auto_start_stop_manager"}:
+        assert section in excluded, f"Section '{section}' should be excluded from the recorder"
+
+
+def test_recorded_semantic_sections_are_kept():
+    """current_state / requested_state must stay recorded for history."""
+    excluded = BaseThermostat._entity_component_unrecorded_attributes
+    assert "current_state" not in excluded
+    assert "requested_state" not in excluded


### PR DESCRIPTION
The recorder only filters top-level attribute keys. Since the v8 attribute reorganization into sections, the managers' flat exclusion names no longer matched, and the volatile "specific_states" section (per-update timestamps, fast-changing floats) defeated recorder deduplication, causing large database and backup growth.

Each feature manager now declares its own top-level section name in its unrecorded_attributes set, all managers are unioned in the base thermostat, and "specific_states" is excluded. Dead flat names are removed, keeping only the still-valid is_*_configured flags. "current_state" and "requested_state" remain recorded to preserve setpoint history.

Unrecorded attributes stay live on the entity (Dev Tools, cards, automations) and restore-on-restart is unaffected (RestoreEntity persists the full state independently of the recorder).