### PR TITLE
fix(pi): prevent accumulated_error explosion on fractional cycle

### DIFF
--- a/custom_components/versatile_thermostat/pi_algorithm.py
+++ b/custom_components/versatile_thermostat/pi_algorithm.py
@@ -86,8 +86,11 @@ class PITemperatureRegulator:
         # Calculate the sum of error (I)
         # Discussion #384. Finally don't reset the accumulated error but smoothly reset it if the sign is inversed
         # If the error have change its sign, reset smoothly the accumulated error
+        # The divisor is clamped so that a fractional cycle (time_delta < 0.5), which happens when
+        # the regulation is triggered twice in quick succession (e.g. repeated target changes),
+        # can never amplify the accumulated error instead of decaying it.
         if self.overheat_protection and error * self.accumulated_error < 0:
-            self.accumulated_error = self.accumulated_error / (2.0 * time_delta)
+            self.accumulated_error = self.accumulated_error / (2.0 * max(time_delta, 0.5))
 
         self.accumulated_error += error * time_delta
 

--- a/tests/test_pi.py
+++ b/tests/test_pi.py
@@ -274,3 +274,33 @@ def test_pi_algorithm_time_delta():
     assert the_algo.calculate_regulated_temperature(25, 15, 1.0) == 25.8
     assert the_algo.calculate_regulated_temperature(25, 15, 1.0) == 25.4
     assert the_algo.calculate_regulated_temperature(25, 15, 10.0) == 25.2  # miss 9 cycles, capped
+
+
+def test_pi_algorithm_small_time_delta_sign_change():
+    """A fractional cycle (time_delta < 0.5) on a sign change must never amplify the
+    accumulated error (issue #2024). The divisor is clamped so the integral keeps decaying."""
+
+    the_algo = PITemperatureRegulator(
+        target_temp=20,
+        kp=0.6,
+        ki=0.2,
+        k_ext=0.2,
+        offset_max=4,
+        accumulated_error_threshold=40,
+        overheat_protection=True,
+    )
+
+    assert the_algo
+
+    # Build up a positive accumulated error
+    the_algo.set_target_temp(20)
+    the_algo.reset_accumulated_error()
+    the_algo.calculate_regulated_temperature(18, 18, 1.0)
+    the_algo.calculate_regulated_temperature(18, 18, 1.0)
+    positive_accumulated_error = the_algo.accumulated_error
+    assert positive_accumulated_error > 0
+
+    # A sign change with a near-zero time_delta must decay (or keep) the accumulated error,
+    # never amplify it. Before the fix, dividing by (2.0 * 0.001) multiplied it by ~500.
+    the_algo.calculate_regulated_temperature(22, 18, 0.001)
+    assert abs(the_algo.accumulated_error) <= positive_accumulated_error


### PR DESCRIPTION
The smooth reset of the integral on a sign change divided the accumulated error by (2.0 * time_delta). When regulation ran twice within one cycle (e.g. repeated target changes), time_delta could be near zero, multiplying the error by hundreds instead of halving it. This pegged the integral to its threshold and slammed the offset to its maximum, sending the underlying the opposite of the requested setpoint.

Clamp the divisor with max(time_delta, 0.5) so a fractional cycle can never amplify the accumulated error. Add a regression test.

Fixes #2024