### PR TITLE
fix(auto-tpi): align base service signature with schema

### DIFF
--- a/custom_components/versatile_thermostat/base_thermostat.py
+++ b/custom_components/versatile_thermostat/base_thermostat.py
@@ -2157,7 +2157,13 @@ class BaseThermostat(ClimateEntity, RestoreEntity, Generic[T]):
             "This thermostat does not use TPI algorithm."
         )
 
-    async def service_set_auto_tpi_mode(self, auto_tpi_mode: bool):
+    async def service_set_auto_tpi_mode(
+        self,
+        auto_tpi_mode: bool,
+        reinitialise: bool = True,
+        allow_kint_boost_on_stagnation: bool = False,
+        allow_kext_compensation_on_overshoot: bool = False,
+    ):
         """Stub method for Auto TPI mode service on non-TPI thermostats.
 
         This service is only available for switch/valve type thermostats that use TPI algorithm.

--- a/tests/test_tpi.py
+++ b/tests/test_tpi.py
@@ -511,9 +511,8 @@ async def test_service_set_tpi_parameters(hass: HomeAssistant, skip_hass_states_
 
 @pytest.mark.parametrize("expected_lingering_tasks", [True])
 @pytest.mark.parametrize("expected_lingering_timers", [True])
-async def test_service_set_tpi_parameters_not_allowed_on_over_climate(hass: HomeAssistant, skip_hass_states_is_state, skip_turn_on_off_heater):
-    """Test that the set_tpi_parameters service cannot be called on a VTherm over_climate.
-    This service is only available for VTherms using TPI algorithm (over_switch, over_valve)."""
+async def test_tpi_services_not_allowed_on_over_climate(hass: HomeAssistant, skip_hass_states_is_state, skip_turn_on_off_heater):
+    """Test that TPI services cannot be called on a VTherm over_climate."""
 
     # Create a mock climate entity
     climate_entity = MockClimate(
@@ -561,6 +560,14 @@ async def test_service_set_tpi_parameters_not_allowed_on_over_climate(hass: Home
 
     # Verify that the entity doesn't have a prop_algorithm (TPI is not used for over_climate)
     assert getattr(entity, "proportional_algorithm", None) is None
+
+    with pytest.raises(ServiceValidationError):
+        await entity.service_set_auto_tpi_mode(
+            auto_tpi_mode=True,
+            reinitialise=True,
+            allow_kint_boost_on_stagnation=False,
+            allow_kext_compensation_on_overshoot=False,
+        )
 
     # Try to call the service - it should raise an error or do nothing
     # since over_climate doesn't use TPI algorithm


### PR DESCRIPTION
This fix missing attributes in basethermostat signature for set_autotpi_mode service.

fix #2038 

