### PR TITLE
fix: restore broken star history chart

### DIFF
--- a/README-cs.md
+++ b/README-cs.md
@@ -141,7 +141,7 @@ Užijte si to!
 
 # ⭐ Historie hvězdiček
 
-[![Star History Chart](https://api.star-history.com/svg?repos=jmcollin78/versatile_thermostat&type=Date)](https://star-history.com/#jmcollin78/versatile_thermostat&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=jmcollin78/versatile_thermostat&type=Date)](https://star-history.dera.page/#jmcollin78/versatile_thermostat&Date)
 
 # Příspěvky jsou vítány!
 

--- a/README-de.md
+++ b/README-de.md
@@ -141,7 +141,7 @@ Die Dokumentation ist jetzt auf mehrere Seiten aufgeteilt, um das Lesen und Such
 
 # ⭐ Star history
 
-[![Star History Chart](https://api.star-history.com/svg?repos=jmcollin78/versatile_thermostat&type=Date)](https://star-history.com/#jmcollin78/versatile_thermostat&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=jmcollin78/versatile_thermostat&type=Date)](https://star-history.dera.page/#jmcollin78/versatile_thermostat&Date)
 
 Viel Spaß!
 

--- a/README-fr.md
+++ b/README-fr.md
@@ -148,7 +148,7 @@ Enjoy !
 
 # ⭐ Star history
 
-[![Star History Chart](https://api.star-history.com/svg?repos=jmcollin78/versatile_thermostat&type=Date)](https://star-history.com/#jmcollin78/versatile_thermostat&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=jmcollin78/versatile_thermostat&type=Date)](https://star-history.dera.page/#jmcollin78/versatile_thermostat&Date)
 
 # Les contributions sont les bienvenues !
 

--- a/README-pl.md
+++ b/README-pl.md
@@ -153,7 +153,7 @@ Dla wygody Użytkownika, a także w celu dostępu do pomocy kontekstowej podczas
 
 # ⭐ Historia gwiazdek
 
-[![Star History Chart](https://api.star-history.com/svg?repos=jmcollin78/versatile_thermostat&type=Date)](https://star-history.com/#jmcollin78/versatile_thermostat&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=jmcollin78/versatile_thermostat&type=Date)](https://star-history.dera.page/#jmcollin78/versatile_thermostat&Date)
 
 ## Współpraca mile widziana!
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ The documentation is now divided into several pages for easier reading and searc
 
 # ⭐ Star history
 
-[![Star History Chart](https://api.star-history.com/svg?repos=jmcollin78/versatile_thermostat&type=Date)](https://star-history.com/#jmcollin78/versatile_thermostat&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=jmcollin78/versatile_thermostat&type=Date)](https://star-history.dera.page/#jmcollin78/versatile_thermostat&Date)
 
 Enjoy!
 


### PR DESCRIPTION
The star history chart in the README is currently broken because of GitHub stargazer API restrictions. This PR updates the chart links to a working alternative so the chart renders again for all users.

Updated README.md, README-cs.md, README-de.md, README-fr.md, and README-pl.md.