### PR TITLE
Fix delayed valve updates with proportional algorithm plugins

### DIFF
--- a/custom_components/versatile_thermostat/cycle_scheduler.py
+++ b/custom_components/versatile_thermostat/cycle_scheduler.py
@@ -260,7 +260,15 @@ class CycleScheduler:
             self.min_activation_delay,
             self.min_deactivation_delay,
         )
-        realized_on_percent = on_time_sec / self._cycle_duration_sec if self._cycle_duration_sec > 0 else 0.0
+        # A valve applies the retained position directly. Converting it back
+        # from integer cycle seconds would quantize it a second time and feed a
+        # different command into the next automatic cycle restart.
+        if self._is_valve_mode:
+            realized_on_percent = on_percent
+        elif self._cycle_duration_sec > 0:
+            realized_on_percent = on_time_sec / self._cycle_duration_sec
+        else:
+            realized_on_percent = 0.0
 
         # Always update thermostat timing attributes immediately so sensors
         # reflect the latest computed value, even when the cycle returns early.
@@ -365,7 +373,9 @@ class CycleScheduler:
             self.min_activation_delay,
             self.min_deactivation_delay,
         )
-        realized_on_percent = on_time_sec / self._cycle_duration_sec if self._cycle_duration_sec > 0 else 0.0
+        # Valve mode is direct-position control: cycle seconds are diagnostic
+        # timing data, not the source of the applied valve percentage.
+        realized_on_percent = on_percent
 
         self._thermostat._on_time_sec = on_time_sec
         self._thermostat._off_time_sec = off_time_sec

--- a/custom_components/versatile_thermostat/cycle_scheduler.py
+++ b/custom_components/versatile_thermostat/cycle_scheduler.py
@@ -158,6 +158,24 @@ class CycleScheduler:
             UnderlyingEntityType.VALVE_REGULATION,
         )
 
+    def _resolve_valve_on_percent(
+        self,
+        on_percent: float,
+        force: bool = False,
+    ) -> float:
+        """Return the valve command retained by the thermostat."""
+        requested = max(0.0, min(1.0, float(on_percent)))
+        resolver = getattr(
+            type(self._thermostat),
+            "apply_valve_command_percent",
+            None,
+        )
+        if resolver is None:
+            return requested
+
+        retained = resolver(self._thermostat, requested, force=force)
+        return max(0.0, min(1.0, float(retained)))
+
     def register_cycle_start_callback(self, callback: Callable):
         """Register a callback to be called at the start of each master cycle.
 
@@ -232,6 +250,9 @@ class CycleScheduler:
             force: If True, cancel any running cycle and restart immediately.
             _from_cycle_end: Internal flag — True when called from _on_master_cycle_end.
         """
+        if self._is_valve_mode:
+            on_percent = self._resolve_valve_on_percent(on_percent, force=force)
+
         cycle_min = self._cycle_duration_sec / 60
         on_time_sec, off_time_sec, _ = calculate_cycle_times(
             on_percent,
@@ -336,6 +357,7 @@ class CycleScheduler:
         if not self._is_valve_mode:
             return
 
+        on_percent = self._resolve_valve_on_percent(on_percent)
         cycle_min = self._cycle_duration_sec / 60
         on_time_sec, off_time_sec, _ = calculate_cycle_times(
             on_percent,

--- a/custom_components/versatile_thermostat/thermostat_valve.py
+++ b/custom_components/versatile_thermostat/thermostat_valve.py
@@ -212,8 +212,29 @@ class ThermostatOverValve(ThermostatProp[UnderlyingValve]):  # pylint: disable=a
             # Temperature not yet available; preserve the current valve position.
             return
 
+        self.apply_valve_command_percent(current_on_percent, force=True)
+
+    def apply_valve_command_percent(
+        self,
+        on_percent: float,
+        force: bool = False,
+    ) -> float:
+        """Accept a requested valve command and return the retained ratio.
+
+        This is the single conversion point between a proportional algorithm's
+        continuous output and the integer command exposed by the thermostat.
+        """
+        self.stop_recalculate_later()
+
+        if self._auto_regulation_period_min is None or self._auto_regulation_dpercent is None:
+            _LOGGER.warning(
+                "%s - auto_regulation_period_min or auto_regulation_dpercent is not set. Keeping current valve command.",
+                self,
+            )
+            return self.valve_open_percent / 100.0
+
         new_valve_percent = round(
-            max(0, min(current_on_percent, 1)) * 100
+            max(0, min(on_percent, 1)) * 100
         )
 
         # Issue 533 - don't filter with dtemp if valve should be close. Else it will never close
@@ -233,11 +254,23 @@ class ThermostatOverValve(ThermostatProp[UnderlyingValve]):  # pylint: disable=a
                 dpercent,
             )
 
-            return
+            return self.valve_open_percent / 100.0
 
         if self._valve_open_percent == new_valve_percent:
             _LOGGER.debug("%s - no change in valve_open_percent.", self)
-            return
+            return self.valve_open_percent / 100.0
+
+        now = self.now
+        if self._last_calculation_timestamp is not None:
+            period = (now - self._last_calculation_timestamp).total_seconds() / 60
+            if not force and period < self._auto_regulation_period_min:
+                _LOGGER.info(
+                    "%s - do not apply valve command because regulation_period (%d) is not exceeded",
+                    self,
+                    period,
+                )
+                self.do_recalculate_later()
+                return self.valve_open_percent / 100.0
 
         self._valve_open_percent = new_valve_percent
 
@@ -249,6 +282,7 @@ class ThermostatOverValve(ThermostatProp[UnderlyingValve]):  # pylint: disable=a
         # self.calculate_hvac_action()
         self.update_custom_attributes()
         self.async_write_ha_state()
+        return self.valve_open_percent / 100.0
 
     def do_recalculate_later(self):
         """A utility function to set the valve open percent later on all underlyings"""

--- a/tests/test_cycle_scheduler.py
+++ b/tests/test_cycle_scheduler.py
@@ -389,6 +389,52 @@ class TestCycleSchedulerCallbacks:
         assert scheduler._valve_cycle_trace[1][1] == pytest.approx(0.6)
 
     @pytest.mark.asyncio
+    @patch("custom_components.versatile_thermostat.cycle_scheduler.async_call_later")
+    async def test_valve_cycle_uses_command_retained_by_thermostat(
+        self,
+        mock_call_later,
+    ):
+        """Valve updates must send and trace the thermostat-retained command."""
+        mock_call_later.return_value = MagicMock()
+
+        class ValveThermostat:
+            """Minimal thermostat exposing the over-valve command contract."""
+
+            def __init__(self):
+                self.valve_open_percent = 0
+                self.calls = []
+                self._on_time_sec = 0
+                self._off_time_sec = 0
+
+            def apply_valve_command_percent(self, on_percent, force=False):
+                self.calls.append((on_percent, force))
+                self.valve_open_percent = round(on_percent * 100)
+                return self.valve_open_percent / 100.0
+
+            def __str__(self):
+                return "ValveThermostat"
+
+        hass = make_hass()
+        thermostat = ValveThermostat()
+        valve = make_underlying("V1", active=False, entity_type=UnderlyingEntityType.VALVE)
+        scheduler = CycleScheduler(hass, thermostat, [valve], 600)
+
+        await scheduler.start_cycle(VThermHvacMode_HEAT, 0.234, force=True)
+
+        assert thermostat.valve_open_percent == 23
+        assert thermostat.calls == [(0.234, True)]
+        assert scheduler._active_on_percent == pytest.approx(0.23)
+        assert scheduler._valve_cycle_trace == [(0.0, 0.23)]
+
+        await scheduler.start_cycle(VThermHvacMode_HEAT, 0.678, force=False)
+
+        assert thermostat.valve_open_percent == 68
+        assert thermostat.calls == [(0.234, True), (0.678, False)]
+        assert scheduler._active_on_percent == pytest.approx(0.68)
+        assert scheduler._valve_cycle_trace[-1][1] == pytest.approx(0.68)
+        assert valve.set_valve_open_percent.await_count == 2
+
+    @pytest.mark.asyncio
     @patch("custom_components.versatile_thermostat.cycle_scheduler.time.time")
     @patch("custom_components.versatile_thermostat.cycle_scheduler.async_call_later")
     async def test_valve_mid_cycle_update_contributes_to_realized_power(


### PR DESCRIPTION
## Summary

1) Valve schedulers received updated commands from proportional algorithm plugins, but the underlying valve reread the thermostat's stale `valve_open_percent` value. As a result, commands could remain unapplied until the next temperature update.

This change centralizes valve command validation in the over-valve thermostat and makes the scheduler use the retained value for both the physical command and the realized-power trace.

Existing regulation period, percentage threshold, rounding, and clamping protections remain unchanged.

2) This PR also prevents valve commands from being quantized a second time at automatic cycle restarts. Valve mode now keeps the integer percentage retained by the thermostat instead of recalculating it from cycle seconds, avoiding transient changes such as 3 → 2 → 3 and unnecessary TRV writes. PWM behavior for switches remains unchanged.



12:10 PM

## Tests

Added regression coverage for initial and mid-cycle valve command updates.